### PR TITLE
Do not use the WebKitWebView::web-process-crashed signal

### DIFF
--- a/cog.c
+++ b/cog.c
@@ -333,16 +333,16 @@ on_create_web_view (CogLauncher *launcher,
             break;
 
         case WEBPROCESS_FAIL_EXIT:
-            cog_web_view_connect_web_process_crashed_exit_handler (web_view, EXIT_FAILURE);
+            cog_web_view_connect_web_process_terminated_exit_handler (web_view, EXIT_FAILURE);
             break;
 
         case WEBPROCESS_FAIL_EXIT_OK:
-            cog_web_view_connect_web_process_crashed_exit_handler (web_view, EXIT_SUCCESS);
+            cog_web_view_connect_web_process_terminated_exit_handler (web_view, EXIT_SUCCESS);
             break;
 
         case WEBPROCESS_FAIL_RESTART:
             // TODO: Un-hardcode the 5 retries per second.
-            cog_web_view_connect_web_process_crashed_restart_handler (web_view, 5, 1000);
+            cog_web_view_connect_web_process_terminated_restart_handler (web_view, 5, 1000);
             break;
 
         default:

--- a/core/cog-webkit-utils.h
+++ b/core/cog-webkit-utils.h
@@ -44,25 +44,27 @@ gboolean cog_handle_web_view_load_failed_with_tls_errors (WebKitWebView       *w
                                                           GTlsCertificateFlags errors,
                                                           void                *user_data);
 
-gboolean cog_handle_web_view_web_process_crashed (WebKitWebView *web_view,
-                                                  void          *userdata);
-gboolean cog_handle_web_view_web_process_crashed_exit (WebKitWebView *web_view,
-                                                       void          *userdata);
+gboolean cog_handle_web_view_web_process_terminated (WebKitWebView                     *web_view,
+                                                     WebKitWebProcessTerminationReason  reason,
+                                                     void                              *userdata);
+gboolean cog_handle_web_view_web_process_terminated_exit (WebKitWebView                     *web_view,
+                                                          WebKitWebProcessTerminationReason  reason,
+                                                          void                              *userdata);
 
 static inline gulong
-cog_web_view_connect_web_process_crashed_exit_handler (WebKitWebView* web_view,
-                                                       int exit_code)
+cog_web_view_connect_web_process_terminated_exit_handler (WebKitWebView* web_view,
+                                                          int            exit_code)
 {
     g_return_val_if_fail (WEBKIT_IS_WEB_VIEW (web_view), 0);
     return g_signal_connect (web_view,
-                             "web-process-crashed",
-                             G_CALLBACK (cog_handle_web_view_web_process_crashed_exit),
+                             "web-process-terminated",
+                             G_CALLBACK (cog_handle_web_view_web_process_terminated_exit),
                              GINT_TO_POINTER (exit_code));
 }
 
-gulong cog_web_view_connect_web_process_crashed_restart_handler (WebKitWebView *web_view,
-                                                                 unsigned       max_tries,
-                                                                 unsigned       try_window_ms);
+gulong cog_web_view_connect_web_process_terminated_restart_handler (WebKitWebView *web_view,
+                                                                    unsigned       max_tries,
+                                                                    unsigned       try_window_ms);
 
 void cog_web_view_connect_default_error_handlers (WebKitWebView *web_view);
 


### PR DESCRIPTION
Instead use `WebKitWebView::web-process-terminated`, which provides additional information about the reason of the process termination. The termination reason is used to format the messages and error pages, but other than that the behaviour of the updated code remains the same.

Fixes #3