### PR TITLE
Add missing __func__ parameter to g_debug() call

### DIFF
--- a/cog.c
+++ b/cog.c
@@ -235,7 +235,7 @@ platform_setup (CogLauncher *launcher)
             g_strdup_printf ("libcogplatform-%s.so", s_options.platform_name);
         g_clear_pointer (&s_options.platform_name, g_free);
 
-        g_debug ("%s: Platform plugin: %s", platform_soname);
+        g_debug ("%s: Platform plugin: %s", __func__, platform_soname);
 
         g_autoptr(CogPlatform) platform = cog_platform_new ();
         if (!cog_platform_try_load (platform, platform_soname)) {


### PR DESCRIPTION
This fixes the following warning:

```
In file included from /usr/include/glib-2.0/glib.h:62,
                 from ../core/cog-webkit-utils.h:19,
                 from ../core/cog.h:15,
                 from ../cog.c:12:
../cog.c: In function ‘platform_setup’:
../cog.c:238:18: warning: format ‘%s’ expects a matching ‘char *’ argument [-Wformat=]
         g_debug ("%s: Platform plugin: %s", platform_soname);
                  ^~~~~~~~~~~~~~~~~~~~~~~~~
/usr/include/glib-2.0/glib/gmessages.h:345:32: note: in definition of macro ‘g_debug’
                                __VA_ARGS__)
                                ^~~~~~~~~~~
```

-----

We really ought to build with `-Wall` as per #7... This slipped from PR #5 as there were two instances of this issue, but I fixed only one before merging it. If our build would be using `-Wall` by default I would have caught this one as well.