### PR TITLE
Skip error page when WebKit hands load to plug-in or media engine

### DIFF
--- a/core/cog-webkit-utils.c
+++ b/core/cog-webkit-utils.c
@@ -53,6 +53,13 @@ cog_handle_web_view_load_failed (WebKitWebView  *web_view,
                                  GError         *error,
                                  void           *userdata)
 {
+    // If the resource is going to be shown by a plug-in (or a
+    // media engine) just return FALSE and let WebKit handle it.
+    if (g_error_matches (error,
+                         WEBKIT_PLUGIN_ERROR,
+                         WEBKIT_PLUGIN_ERROR_WILL_HANDLE_LOAD))
+        return FALSE;
+
     return load_error_page (web_view,
                             failing_uri,
                             "Page load error",


### PR DESCRIPTION
This situation is easily triggered by loading an URL pointing directly to a video, due to WebKit passing the responsibility of fetching data to GStreamer. In that case, do not show an error page and return `FALSE` in order to let WebKit continue with its fall-back handling, which will let the plug-in or media engine do the loading.

Fixes #2