### PR TITLE
cogctl: Do not segfault on unrecognized command names

### DIFF
--- a/cogctl.c
+++ b/cogctl.c
@@ -312,7 +312,7 @@ cmd_find_by_name (const char *name)
         },
     };
 
-    for (unsigned i = 0; i < G_N_ELEMENTS (cmdlist); i++)
+    for (unsigned i = 0; cmdlist[i].name; i++)
         if (strcmp (cmdlist[i].name, name) == 0)
             return &cmdlist[i];
 


### PR DESCRIPTION
When a non-existent command name was passed to `cmd_find_by_name()` the program would crash due to attempting to compare the command name with the `NULL` string from the terminating entry of the commands table.

This fixes the issue by making the loop do a `NULL`-check for termination instead of iterating over the number of entries in the table (which included the terminating entry).