### PR TITLE
Wrap and submit the exported buffer forward instead of blitting

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -137,7 +137,7 @@ set(COGPLATFORM_FDO_SOURCES
     wayland/fullscreen-shell-unstable-v1-protocol.c
 )
 
-pkg_check_modules(COGPLATFORM_FDO_DEPS REQUIRED wpe-webkit-0.1 wpe-0.1 wpebackend-fdo-0.1 egl glesv2 wayland-egl xkbcommon)
+pkg_check_modules(COGPLATFORM_FDO_DEPS REQUIRED wpe-webkit-0.1 wpe-0.1 wpebackend-fdo-0.1 egl wayland-egl xkbcommon)
 
 set(COGPLATFORM_FDO_INCLUDE_DIRS ${COGPLATFORM_FDO_DEPS_INCLUDE_DIRS})
 set(COGPLATFORM_FDO_CFLAGS ${COGPLATFORM_FDO_DEPS_CFLAGS_OTHER})


### PR DESCRIPTION
Since we render the exported buffer to the full size of the surface, we don't need to blit it.

This patch creates a wl_buffer that wraps the buffer resource and attach it to the wayland compositor surface for rendering, thus avoiding texture mapping and GLES altogether.

Tested in Intel/i965 and i.MX6 platforms, in both cases with a noticeable increase in performance. 