### PR TITLE
Provide command line options for WebKitSettings properties

### DIFF
--- a/cog.c
+++ b/cog.c
@@ -29,9 +29,6 @@ static struct {
     gboolean version;
     gboolean print_appid;
     gboolean doc_viewer;
-    gboolean dev_tools;
-    gboolean webgl;
-    gboolean log_console;
     gdouble  scale_factor;
     GStrv    dir_handlers;
     GStrv    arguments;
@@ -57,15 +54,6 @@ static GOptionEntry s_cli_options[] =
         NULL },
     { "print-appid", '\0', 0, G_OPTION_ARG_NONE, &s_options.print_appid,
         "Print application ID and exit",
-        NULL },
-    { "dev-tools", 'D', 0, G_OPTION_ARG_NONE, &s_options.dev_tools,
-        "Enable usage of the inspector and JavaScript console",
-        NULL },
-    { "log-console", 'v', 0, G_OPTION_ARG_NONE, &s_options.log_console,
-        "Log JavaScript console messages to standard output",
-        NULL },
-    { "webgl", '\0', 0, G_OPTION_ARG_NONE, &s_options.webgl,
-        "Allow web content to use the WebGL API",
         NULL },
     { "scale", '\0', 0, G_OPTION_ARG_DOUBLE, &s_options.scale_factor,
         "Zoom/Scaling factor (default: 1.0, no scaling)",
@@ -284,13 +272,6 @@ on_create_web_view (CogLauncher *launcher,
                                             WEBKIT_CACHE_MODEL_DOCUMENT_VIEWER);
     }
 
-    g_autoptr(WebKitSettings) settings =
-        webkit_settings_new_with_settings ("enable-developer-extras", s_options.dev_tools,
-                                           "enable-page-cache", !s_options.doc_viewer,
-                                           "enable-webgl", s_options.webgl,
-                                           "enable-write-console-messages-to-stdout", s_options.log_console,
-                                           NULL);
-
 #if !COG_USE_WEBKITGTK
     WebKitWebViewBackend *view_backend = NULL;
 
@@ -318,7 +299,7 @@ on_create_web_view (CogLauncher *launcher,
 #endif
 
     g_autoptr(WebKitWebView) web_view = g_object_new (WEBKIT_TYPE_WEB_VIEW,
-                                                      "settings", settings,
+                                                      "settings", cog_launcher_get_web_settings (launcher),
                                                       "web-context", web_context,
                                                       "zoom-level", s_options.scale_factor,
 #if !COG_USE_WEBKITGTK
@@ -362,6 +343,7 @@ main (int argc, char *argv[])
 {
     g_autoptr(GApplication) app = G_APPLICATION (cog_launcher_get_default ());
     g_application_add_main_option_entries (app, s_cli_options);
+    cog_launcher_add_web_settings_option_entries (COG_LAUNCHER (app));
 
 #if !COG_USE_WEBKITGTK
     g_signal_connect (app, "shutdown", G_CALLBACK (on_shutdown), NULL);

--- a/core/cog-launcher.c
+++ b/core/cog-launcher.c
@@ -17,6 +17,7 @@
 
 struct _CogLauncher {
     CogLauncherBase   parent;
+    WebKitSettings   *web_settings;
     WebKitWebContext *web_context;
     WebKitWebView    *web_view;
     char             *home_uri;
@@ -36,6 +37,7 @@ static int s_signals[LAST_SIGNAL] = { 0, };
 
 enum {
     PROP_0,
+    PROP_WEB_SETTINGS,
     PROP_WEB_CONTEXT,
     PROP_WEB_VIEW,
     PROP_HOME_URI,
@@ -167,17 +169,17 @@ cog_launcher_startup (GApplication *application)
      * Create the web view ourselves if the signal handler did not.
      */
     if (!launcher->web_view) {
-        g_autoptr(WebKitSettings) settings =
-            webkit_settings_new_with_settings ("enable-developer-extras", TRUE, NULL);
         launcher->web_view = WEBKIT_WEB_VIEW (g_object_new (WEBKIT_TYPE_WEB_VIEW,
-                                                            "settings", settings,
+                                                            "settings", cog_launcher_get_web_settings (launcher),
                                                             "web-context", cog_launcher_get_web_context (launcher),
                                                             NULL));
     }
 
     /*
-     * The web context being used must be the same created by CogLauncher.
+     * The web context and settings being used by the web view must be
+     * the same that were pre-created by CogLauncher.
      */
+    g_assert (webkit_web_view_get_settings (launcher->web_view) == cog_launcher_get_web_settings (launcher));
     g_assert (webkit_web_view_get_context (launcher->web_view) == cog_launcher_get_web_context (launcher));
 
     /*
@@ -226,6 +228,9 @@ cog_launcher_get_property (GObject    *object,
 {
     CogLauncher *launcher = COG_LAUNCHER (object);
     switch (prop_id) {
+        case PROP_WEB_SETTINGS:
+            g_value_set_object (value, cog_launcher_get_web_settings (launcher));
+            break;
         case PROP_WEB_CONTEXT:
             g_value_set_object (value, cog_launcher_get_web_context (launcher));
             break;
@@ -265,6 +270,7 @@ cog_launcher_dispose (GObject *object)
 
     g_clear_object (&launcher->web_view);
     g_clear_object (&launcher->web_context);
+    g_clear_object (&launcher->web_settings);
 
     g_clear_pointer (&launcher->request_handlers, g_hash_table_unref);
 
@@ -327,6 +333,8 @@ cog_launcher_constructed (GObject *object)
 
     CogLauncher *launcher = COG_LAUNCHER (object);
 
+    launcher->web_settings = g_object_ref_sink (webkit_settings_new ());
+
     cog_launcher_add_action (launcher, "quit", on_action_quit, NULL);
     cog_launcher_add_action (launcher, "previous", on_action_prev, NULL);
     cog_launcher_add_action (launcher, "next", on_action_next, NULL);
@@ -359,6 +367,14 @@ cog_launcher_class_init (CogLauncherClass *klass)
     application_class->open = cog_launcher_open;
     application_class->startup = cog_launcher_startup;
     application_class->activate = cog_launcher_activate;
+
+    s_properties[PROP_WEB_SETTINGS] =
+        g_param_spec_object ("web-settings",
+                             "Web Settings",
+                             "The WebKitSettings for the launcher",
+                             WEBKIT_TYPE_SETTINGS,
+                             G_PARAM_READABLE |
+                             G_PARAM_STATIC_STRINGS);
 
     s_properties[PROP_WEB_CONTEXT] =
         g_param_spec_object ("web-context",
@@ -445,6 +461,14 @@ cog_launcher_get_web_context (CogLauncher *launcher)
 {
     g_return_val_if_fail (COG_IS_LAUNCHER (launcher), NULL);
     return launcher->web_context;
+}
+
+
+WebKitSettings*
+cog_launcher_get_web_settings (CogLauncher *launcher)
+{
+    g_return_val_if_fail (COG_IS_LAUNCHER (launcher), NULL);
+    return launcher->web_settings;
 }
 
 
@@ -564,4 +588,29 @@ cog_launcher_set_request_handler (CogLauncher       *launcher,
     }
 
     request_handler_map_entry_register (scheme, entry, launcher->web_context);
+}
+
+
+void
+cog_launcher_add_web_settings_option_entries (CogLauncher *launcher)
+{
+    g_return_if_fail (COG_IS_LAUNCHER (launcher));
+
+    g_autofree GOptionEntry *option_entries =
+        cog_option_entries_from_class (G_OBJECT_GET_CLASS (launcher->web_settings));
+    if (!option_entries) {
+        g_critical ("Could not deduce option entries for WebKitSettings."
+                    " This should not happen, continuing but YMMV.");
+        return;
+    }
+
+    g_autoptr(GOptionGroup) option_group =
+        g_option_group_new ("websettings",
+                            "WebKit settings",
+                            "WebKit settings",
+                            launcher->web_settings,
+                            NULL);
+    g_option_group_add_entries (option_group, option_entries);
+    g_application_add_option_group (G_APPLICATION (launcher),
+                                    g_steal_pointer (&option_group));
 }

--- a/core/cog-launcher.c
+++ b/core/cog-launcher.c
@@ -606,8 +606,14 @@ cog_launcher_add_web_settings_option_entries (CogLauncher *launcher)
 
     g_autoptr(GOptionGroup) option_group =
         g_option_group_new ("websettings",
-                            "WebKit settings",
-                            "WebKit settings",
+                            "WebKitSettings options can be used to configure features exposed to the loaded Web content.\n"
+                            "\n"
+                            "  BOOL values are either 'true', '1', 'false', or '0'. Ommitting the value implies '1'.\n"
+                            "  INTEGER values can be decimal, octal (prefix '0'), or hexadecimal (prefix '0x').\n"
+                            "  UNSIGNED values behave like INTEGER, but negative values are not accepted.\n"
+                            "  FLOAT values may optionally use decimal separators and scientific notation.\n"
+                            "  STRING values may need quoting when passed from the shell.\n",
+                            "Show WebKitSettings options",
                             launcher->web_settings,
                             NULL);
     g_option_group_add_entries (option_group, option_entries);

--- a/core/cog-launcher.h
+++ b/core/cog-launcher.h
@@ -44,6 +44,7 @@ struct _CogLauncherClass
 CogLauncher      *cog_launcher_get_default         (void);
 WebKitWebView    *cog_launcher_get_web_view        (CogLauncher       *launcher);
 WebKitWebContext *cog_launcher_get_web_context     (CogLauncher       *launcher);
+WebKitSettings   *cog_launcher_get_web_settings    (CogLauncher       *launcher);
 const char       *cog_launcher_get_home_uri        (CogLauncher       *launcher);
 void              cog_launcher_set_home_uri        (CogLauncher       *launcher,
                                                     const char        *home_uri);
@@ -51,6 +52,8 @@ void              cog_launcher_set_home_uri        (CogLauncher       *launcher,
 void              cog_launcher_set_request_handler (CogLauncher       *launcher,
                                                     const char        *scheme,
                                                     CogRequestHandler *handler);
+
+void  cog_launcher_add_web_settings_option_entries (CogLauncher       *launcher);
 
 G_END_DECLS
 

--- a/core/cog-utils.c
+++ b/core/cog-utils.c
@@ -259,18 +259,18 @@ cog_option_entries_from_class (GObjectClass *klass)
 
         // Pick only properties of basic types we know how to convert.
         const GType prop_type = G_PARAM_SPEC_VALUE_TYPE (prop);
+        const char *type_name = NULL;
         switch (prop_type) {
-            case G_TYPE_BOOLEAN:
+            case G_TYPE_BOOLEAN: type_name = "BOOL"; break;
             case G_TYPE_DOUBLE:
-            case G_TYPE_FLOAT:
+            case G_TYPE_FLOAT: type_name = "FLOAT"; break;
             case G_TYPE_INT64:
             case G_TYPE_INT:
-            case G_TYPE_LONG:
-            case G_TYPE_STRING:
+            case G_TYPE_LONG: type_name = "INTEGER"; break;
+            case G_TYPE_STRING: type_name = "STRING"; break;
             case G_TYPE_UINT:
             case G_TYPE_UINT64:
-            case G_TYPE_ULONG:
-                break;
+            case G_TYPE_ULONG: type_name = "UNSIGNED"; break;
             default:
                 continue;
         }
@@ -281,7 +281,7 @@ cog_option_entries_from_class (GObjectClass *klass)
         entry->arg = G_OPTION_ARG_CALLBACK;
         entry->arg_data = option_entry_parse_to_property;
         entry->description = g_param_spec_get_blurb (prop);
-        entry->arg_description = g_type_name (prop_type);
+        entry->arg_description = type_name;
         if (prop_type == G_TYPE_BOOLEAN && g_str_has_prefix (entry->long_name, "enable-"))
             entry->flags |= G_OPTION_FLAG_OPTIONAL_ARG;
     }

--- a/core/cog-utils.h
+++ b/core/cog-utils.h
@@ -15,11 +15,16 @@
 
 G_BEGIN_DECLS
 
+typedef struct _GObjectClass GObjectClass;
+
+
 char* cog_appid_to_dbus_object_path (const char *appid)
     G_GNUC_WARN_UNUSED_RESULT;
 
 char* cog_uri_guess_from_user_input (const char *uri_like,
                                      gboolean    is_cli_arg,
                                      GError    **error);
+
+GOptionEntry* cog_option_entries_from_class (GObjectClass *klass);
 
 G_END_DECLS


### PR DESCRIPTION
This adds code to introspect properties of a given `GObjectClass` and obtain a set of `GOptionEntry` instances which, when added to a `GOptionGroup`, will set the values of the properties from the parsed command line options.

Then, the above utility code is used to expose the properties from `WebKitSettings` in a generic way, instead of having to manually add a `GOptionEntry` and handling for each settings.

The following CLI options are replaced by the new functionality, which covers the corresponding settings:

| Old | New |
|-----|-----|
| `--webgl` | `--enable-webgl=1` |
| `-D` <br> `--dev-tools` | `--enable-developer-extras=1` |
| `-v` <br> `--log-console` | `--enable-write-console-messages-to-stdout=1` |

Closes #27