### PR TITLE
Add CLI flags for setting cookie handling options

### DIFF
--- a/cog.c
+++ b/cog.c
@@ -341,9 +341,19 @@ on_create_web_view (CogLauncher *launcher,
 int
 main (int argc, char *argv[])
 {
+    // We need to set the program name early because constructing the
+    // CogLauncher instance will use g_get_prgname() to determine where
+    // to store the caches for Web content.
+    {
+        const char *dir_separator = strrchr (argv[0], G_DIR_SEPARATOR);
+        g_set_prgname (dir_separator ? dir_separator + 1 : argv[0]);
+        g_set_application_name ("Cog");
+    }
+
     g_autoptr(GApplication) app = G_APPLICATION (cog_launcher_get_default ());
     g_application_add_main_option_entries (app, s_cli_options);
     cog_launcher_add_web_settings_option_entries (COG_LAUNCHER (app));
+    cog_launcher_add_web_cookies_option_entries (COG_LAUNCHER (app));
 
 #if !COG_USE_WEBKITGTK
     g_signal_connect (app, "shutdown", G_CALLBACK (on_shutdown), NULL);

--- a/core/cog-launcher.c
+++ b/core/cog-launcher.c
@@ -789,6 +789,15 @@ option_entry_parse_cookie_jar (const char          *option G_GNUC_UNUSED,
                                WebKitCookieManager *cookie_manager,
                                GError             **error)
 {
+    if (strcmp (value, "help") == 0) {
+        g_autoptr(GEnumClass) enum_class =
+            g_type_class_ref (WEBKIT_TYPE_COOKIE_PERSISTENT_STORAGE);
+        for (unsigned i = 0; i < enum_class->n_values; i++)
+            g_print ("%s\n", enum_class->values[i].value_nick);
+        exit (EXIT_SUCCESS);
+        g_assert_not_reached ();
+    }
+
     g_autofree char *cookie_jar_path = NULL;
     g_autofree char *format_name = g_strdup (value);
     char *path = strchr (format_name, ':');
@@ -874,7 +883,7 @@ static GOptionEntry s_cookies_options[] =
         .long_name = "cookie-jar",
         .arg = G_OPTION_ARG_CALLBACK,
         .arg_data = option_entry_parse_cookie_jar,
-        .description = "Enable persisting cookies to disk in a given format (text, sqlite).",
+        .description = "Enable persisting cookies to disk. Pass 'help' for a list of formats.",
         .arg_description = "FORMAT[:PATH]",
     },
     { NULL }

--- a/core/cog-launcher.c
+++ b/core/cog-launcher.c
@@ -651,6 +651,138 @@ option_entry_parse_cookie_store (const char          *option G_GNUC_UNUSED,
 }
 
 
+static void
+cookie_set_session (SoupCookie *cookie, gboolean session)
+{
+    if (session)
+        soup_cookie_set_expires (cookie, NULL);
+}
+
+
+typedef void (*CookieFlagCallback) (SoupCookie*, gboolean);
+
+
+static inline CookieFlagCallback
+option_entry_parse_cookie_add_get_flag_callback (const char *name)
+{
+    static const struct {
+        const char *name;
+        CookieFlagCallback callback;
+    } flag_map[] = {
+        { "httponly", soup_cookie_set_http_only },
+        { "secure",   soup_cookie_set_secure    },
+        { "session",  cookie_set_session        },
+    };
+
+    for (unsigned i = 0; i < G_N_ELEMENTS (flag_map); i++)
+        if (strcmp (name, flag_map[i].name) == 0)
+            return flag_map[i].callback;
+
+    return NULL;
+}
+
+
+static void
+on_cookie_added (WebKitCookieManager *cookie_manager,
+                 GAsyncResult        *result,
+                 GMainLoop           *loop)
+{
+    g_autoptr(GError) error = NULL;
+    if (!webkit_cookie_manager_add_cookie_finish (cookie_manager, result, &error)) {
+        g_warning ("Error setting cookie: %s", error->message);
+    }
+    g_main_loop_quit (loop);
+}
+
+
+static gboolean
+option_entry_parse_cookie_add (const char          *option G_GNUC_UNUSED,
+                               const char          *value,
+                               WebKitCookieManager *cookie_manager,
+                               GError             **error G_GNUC_UNUSED)
+{
+    g_autofree char *domain = g_strdup (value);
+
+    char *flagstr = strchr (domain, ':');
+    if (!flagstr)
+        goto bad_format;
+    *flagstr++ = '\0';
+
+    char *contents = strchr (flagstr, ':');
+    if (!contents)
+        goto bad_format;
+
+    // The domain might include a port in the domain, in that
+    // case skip forward to the next colon after the port number.
+    if (g_ascii_isdigit (contents[1])) {
+        if (!(contents = strchr (contents + 1, ':')))
+            goto bad_format;
+    }
+    *contents++ = '\0';
+
+    // The contents of the cookie cannot be empty.
+    if (!contents[0])
+        goto bad_format;
+
+    g_autoptr(SoupCookie) cookie = soup_cookie_parse (contents, NULL);
+    if (!cookie)
+        goto bad_format;
+
+    soup_cookie_set_domain (cookie, domain);
+
+    // Go through the flags.
+    if (flagstr && flagstr[0]) {
+        g_auto(GStrv) flags = g_strsplit (flagstr, ",", -1);
+
+        for (unsigned i = 0; flags[i] != NULL; i++) {
+            // Skip the optional leading +/- signs.
+            const char *flag = flags[i];
+            gboolean flag_value = flag[0] != '-';
+            if (flag[0] == '+' || flag[0] == '-')
+                flag++;
+
+            const CookieFlagCallback flag_callback =
+                option_entry_parse_cookie_add_get_flag_callback (flag);
+            if (!flag_callback) {
+                g_set_error (error,
+                             G_OPTION_ERROR,
+                             G_OPTION_ERROR_BAD_VALUE,
+                             "Invalid cookie flag '%s'",
+                             flag);
+                return FALSE;
+            }
+            (*flag_callback) (cookie, flag_value);
+        }
+    }
+
+    // XXX: If the cookie has no path defined, conversion to WebKit's
+    //      internal format will fail and the WebProcess will spit ouy
+    //      a critical error -- and the cookie won't be set. Workaround
+    //      the issue while this is not fixed inside WebKit.
+    if (!soup_cookie_get_path (cookie))
+        soup_cookie_set_path (cookie, "/");
+
+    // Adding a cookie is an asynchronous operation, so spin up an
+    // event loop until to block until the operation completes.
+    g_autoptr(GMainLoop) loop = g_main_loop_new (NULL, FALSE);
+    webkit_cookie_manager_add_cookie (cookie_manager,
+                                      cookie,
+                                      NULL,  // GCancellable
+                                      (GAsyncReadyCallback) on_cookie_added,
+                                      loop);
+    g_main_loop_run (loop);
+    return TRUE;
+
+bad_format:
+    g_set_error (error,
+                 G_OPTION_ERROR,
+                 G_OPTION_ERROR_BAD_VALUE,
+                 "Invalid cookie specification '%s'",
+                 value);
+    return FALSE;
+}
+
+
 static GOptionEntry s_cookies_options[] =
 {
     {
@@ -659,6 +791,13 @@ static GOptionEntry s_cookies_options[] =
         .arg_data = option_entry_parse_cookie_store,
         .description = "When to store cookies: always (default), never, nothirdparty.",
         .arg_description = "MODE",
+    },
+    {
+        .long_name = "cookie-add",
+        .arg = G_OPTION_ARG_CALLBACK,
+        .arg_data = option_entry_parse_cookie_add,
+        .description = "Pre-set a cookie, available flags: httponly, secure, session.",
+        .arg_description = "DOMAIN:[FLAG,-FLAG,..]:CONTENTS",
     },
     { NULL }
 };

--- a/core/cog-launcher.h
+++ b/core/cog-launcher.h
@@ -54,6 +54,7 @@ void              cog_launcher_set_request_handler (CogLauncher       *launcher,
                                                     CogRequestHandler *handler);
 
 void  cog_launcher_add_web_settings_option_entries (CogLauncher       *launcher);
+void  cog_launcher_add_web_cookies_option_entries  (CogLauncher       *launcher);
 
 G_END_DECLS
 

--- a/core/cog-utils.h
+++ b/core/cog-utils.h
@@ -11,11 +11,13 @@
 # error "Do not include this header directly, use <cog.h> instead"
 #endif
 
-#include <glib.h>
+#include <glib-object.h>
 
 G_BEGIN_DECLS
 
 typedef struct _GObjectClass GObjectClass;
+
+G_DEFINE_AUTOPTR_CLEANUP_FUNC (GEnumClass, g_type_class_unref)
 
 
 char* cog_appid_to_dbus_object_path (const char *appid)
@@ -26,5 +28,23 @@ char* cog_uri_guess_from_user_input (const char *uri_like,
                                      GError    **error);
 
 GOptionEntry* cog_option_entries_from_class (GObjectClass *klass);
+
+
+static inline const char*
+cog_g_enum_get_nick (GType enum_type, int value)
+{
+    g_autoptr(GEnumClass) enum_class = g_type_class_ref (enum_type);
+    const GEnumValue *enum_value = g_enum_get_value (enum_class, value);
+    return enum_value ? enum_value->value_nick : NULL;
+}
+
+
+static inline const GEnumValue*
+cog_g_enum_get_value (GType enum_type, const char *nick)
+{
+    g_autoptr(GEnumClass) enum_class = g_type_class_ref (enum_type);
+    return g_enum_get_value_by_nick (enum_class, nick);
+}
+
 
 G_END_DECLS


### PR DESCRIPTION
This adds a new `GOptionGroup` which will contain all the cookies-related command line flags.

Some reorganization was needed to allow early creation of the `WebKitWebContext` instance, which we need at the time when the option group is added to the `GApplication` in order to pass the context's `WebKitCookieManager` to the callback used to parse the command line.

Closes #31 