### PR TITLE
Support building cog on older versions of wayland

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,7 +35,6 @@ endif()
 add_definitions(-DCOG_INSIDE_COG__=1)
 add_definitions(-DG_LOG_DOMAIN=\"Cog\")
 
-configure_file(core/cog-config.h.in cog-config.h @ONLY)
 include_directories(${CMAKE_CURRENT_BINARY_DIR})
 
 find_package(PkgConfig)
@@ -137,11 +136,17 @@ set(COGPLATFORM_FDO_SOURCES
     wayland/fullscreen-shell-unstable-v1-protocol.c
 )
 
+set(WAYLAND_1_10_OR_GREATER OFF)
+pkg_check_modules(WAYLAND REQUIRED wayland-client)
+if (NOT (WAYLAND_VERSION VERSION_LESS 1.10))
+    set(WAYLAND_1_10_OR_GREATER ON)
+endif ()
+
 pkg_check_modules(COGPLATFORM_FDO_DEPS REQUIRED wpe-webkit-0.1 wpe-0.1 wpebackend-fdo-0.1 egl wayland-egl xkbcommon)
 
-set(COGPLATFORM_FDO_INCLUDE_DIRS ${COGPLATFORM_FDO_DEPS_INCLUDE_DIRS})
-set(COGPLATFORM_FDO_CFLAGS ${COGPLATFORM_FDO_DEPS_CFLAGS_OTHER})
-set(COGPLATFORM_FDO_LDFLAGS ${COGPLATFORM_FDO_DEPS_LDFLAGS})
+set(COGPLATFORM_FDO_INCLUDE_DIRS ${COGPLATFORM_FDO_DEPS_INCLUDE_DIRS} ${WAYLAND_INCLUDE_DIRS})
+set(COGPLATFORM_FDO_CFLAGS ${COGPLATFORM_FDO_DEPS_CFLAGS_OTHER} ${WAYLAND_CFLAGS_OTHER})
+set(COGPLATFORM_FDO_LDFLAGS ${COGPLATFORM_FDO_DEPS_LDFLAGS} ${WAYLAND_LDFLAGS})
 
 add_library(cogplatform-fdo MODULE ${COGPLATFORM_FDO_SOURCES})
 
@@ -156,3 +161,5 @@ install(TARGETS cogplatform-fdo
 )
 
 endif ()  # !COG_USE_WEBKITGTK
+
+configure_file(core/cog-config.h.in cog-config.h @ONLY)

--- a/core/cog-config.h.in
+++ b/core/cog-config.h.in
@@ -15,6 +15,7 @@
 #cmakedefine COG_DEFAULT_APPID "@COG_DEFAULT_APPID@"
 #cmakedefine COG_DEFAULT_HOME_URI "@COG_DEFAULT_HOME_URI@"
 #cmakedefine01 COG_USE_WEBKITGTK
+#cmakedefine01 WAYLAND_1_10_OR_GREATER
 
 /* FIXME: Perhaps make this a cmake define instead. */
 #define COG_DEFAULT_APPNAME "Cog"

--- a/platform/cog-platform-fdo.c
+++ b/platform/cog-platform-fdo.c
@@ -464,6 +464,8 @@ pointer_on_axis (void* data,
     wpe_view_backend_dispatch_axis_event (wpe_view_data.backend, &event);
 }
 
+#if WAYLAND_1_10_OR_GREATER
+
 static void
 pointer_on_frame (void* data,
                   struct wl_pointer *pointer)
@@ -496,6 +498,8 @@ pointer_on_axis_discrete (void *data,
 {
 }
 
+#endif /* WAYLAND_1_10_OR_GREATER */
+
 static const struct wl_pointer_listener pointer_listener = {
     .enter = pointer_on_enter,
     .leave = pointer_on_leave,
@@ -503,10 +507,12 @@ static const struct wl_pointer_listener pointer_listener = {
     .button = pointer_on_button,
     .axis = pointer_on_axis,
 
+#if WAYLAND_1_10_OR_GREATER
     .frame = pointer_on_frame,
     .axis_source = pointer_on_axis_source,
     .axis_stop = pointer_on_axis_stop,
     .axis_discrete = pointer_on_axis_discrete,
+#endif /* WAYLAND_1_10_OR_GREATER */
 };
 
 static void


### PR DESCRIPTION
Specifically, cog needs these patches to build on a Yocto Krogoth system for i.MX6 with an slightly old version of the NXP BSP.