### PR TITLE
Include stdlib.h for EXIT_SUCCESS

### DIFF
--- a/core/cog-launcher.c
+++ b/core/cog-launcher.c
@@ -14,6 +14,7 @@
 # include "cog-gtk-utils.h"
 #endif
 
+#include <stdlib.h>
 #include <string.h>
 
 


### PR DESCRIPTION
Without this patch, compilation fails with glibc 2.23 and gcc 5.3.
Apparently older versions of glibc need stdlib.h to define EXIT_SUCCESS.