### PR TITLE
fdo: Introduce error handling, cleanups, and GLib assertions

### DIFF
--- a/core/cog-platform.c
+++ b/core/cog-platform.c
@@ -9,6 +9,10 @@
 #include <dlfcn.h>
 #include "cog-platform.h"
 
+
+G_DEFINE_QUARK (COG_PLATFORM_EGL_ERROR, cog_platform_egl_error)
+
+
 /* @FIXME: Move this implementation to use a GIO extension point. */
 
 struct _CogPlatform {

--- a/core/cog-platform.h
+++ b/core/cog-platform.h
@@ -18,6 +18,10 @@
 
 G_BEGIN_DECLS
 
+#define COG_PLATFORM_EGL_ERROR  (cog_platform_egl_error_quark ())
+GQuark cog_platform_egl_error_quark (void);
+
+
 /* @FIXME: Eventually move this interface to GObject. */
 typedef struct _CogPlatform CogPlatform;
 


### PR DESCRIPTION
This improves the FDO platform plug-in by:

- Making the `init_*` functions return errors, which get bubbled up from `cog_platform_setup()`. This includes more informative error strings, plus fetching and reporting EGL errors as well.

- The added error handling alone removes many assertions, which is quite a good improvement when it comes to knowing what went South during initialization. Also this means that other fallbacks can be used on failure (e.g. a Wayland compositor is not available), instead of  aborting the process miserably with an assertion message.

- The `clear_egl()`, `destroy_window()`, and `clear_input()` functions are made idempotent, and safe to use on partially initialized data. This allows using them to free resources at different stages of initialization in the event of a failure.

- Wherever possible, `g_clear_pointer()` is used for brevity and clarity.

While there are still many assertions remaining, most of them are quite unlikely of being ever hit, so this is a good stab at mostly fixing issue #1 — reviewing the remaining assertions later on would not hurt, though.