### PR TITLE
core: Use "about:blank" instead of NULL as default URL

### DIFF
--- a/core/cog-shell.c
+++ b/core/cog-shell.c
@@ -7,6 +7,10 @@
 
 #include "cog-shell.h"
 
+#ifndef COG_SHELL_DEFAULT_HOME_URI
+#define COG_SHELL_DEFAULT_HOME_URI "about:blank"
+#endif // !COG_SHELL_DEFAULT_HOME_URI
+
 
 typedef struct {
     char             *name;
@@ -268,7 +272,7 @@ cog_shell_class_init (CogShellClass *klass)
         g_param_spec_string ("home-uri",
                              "Home URI",
                              "URI initially loaded by the Web view",
-                             NULL,
+                             COG_SHELL_DEFAULT_HOME_URI,
                              G_PARAM_READWRITE |
                              G_PARAM_STATIC_STRINGS);
 
@@ -363,10 +367,14 @@ cog_shell_set_home_uri (CogShell   *shell,
 
     CogShellPrivate *priv = PRIV (shell);
 
+    if (!uri)
+        uri = COG_SHELL_DEFAULT_HOME_URI;
+
     if (g_strcmp0 (priv->home_uri, uri) == 0)
         return;
 
-    priv->home_uri = uri ? g_strdup (uri) : NULL;
+    g_assert_nonnull (priv->home_uri);
+    priv->home_uri = g_strdup (uri);
     g_object_notify_by_pspec (G_OBJECT (shell),
                               s_properties[PROP_HOME_URI]);
 }


### PR DESCRIPTION
Using `NULL` as default home URL was causing a critical warning to be logged right after creating the Web view if no valid URL is set with `cog_shell_set_home_uri()` beforehand, when requesting the URL to be loaded.

Also, when passing a `NULL` URL to `cog_shell_set_home_uri()` convert it into `"about:blank"` internally, guaranteeing that `cog_shell_get_home_uri()` always returns a valid pointer.
