### PR TITLE
Make it possible to build against GLib 2.58 and newer

### DIFF
--- a/core/cog-utils.h
+++ b/core/cog-utils.h
@@ -17,7 +17,9 @@ G_BEGIN_DECLS
 
 typedef struct _GObjectClass GObjectClass;
 
+#if !GLIB_CHECK_VERSION(2, 58, 0)
 G_DEFINE_AUTOPTR_CLEANUP_FUNC (GEnumClass, g_type_class_unref)
+#endif // !GLIB_CHECK_VERSION
 
 
 char* cog_appid_to_dbus_object_path (const char *appid)


### PR DESCRIPTION
Starting from 2.58.0 GLib already includes the definition needed to use `g_autoptr(GEnumClass)`.