### PR TITLE
Release the wrapped EGLImage upon wl_buffer release

### DIFF
--- a/platform/cog-platform-fdo.c
+++ b/platform/cog-platform-fdo.c
@@ -992,14 +992,6 @@ on_surface_frame (void *data, struct wl_callback *callback, uint32_t time)
 
     wpe_view_backend_exportable_fdo_dispatch_frame_complete
         (wpe_host_data.exportable);
-
-    if (wpe_view_data.image != NULL) {
-        wpe_view_backend_exportable_fdo_egl_dispatch_release_image (wpe_host_data.exportable,
-                                                                    wpe_view_data.image);
-        wpe_view_data.image = NULL;
-    }
-
-    g_clear_pointer (&wpe_view_data.buffer, wl_buffer_destroy);
 }
 
 static const struct wl_callback_listener frame_listener = {
@@ -1018,6 +1010,18 @@ request_frame (void)
                               NULL);
 }
 
+static void
+on_buffer_release (void* data, struct wl_buffer* buffer)
+{
+    EGLImageKHR image = data;
+    wpe_view_backend_exportable_fdo_egl_dispatch_release_image (wpe_host_data.exportable,
+                                                                image);
+    g_clear_pointer (&buffer, wl_buffer_destroy);
+}
+
+static const struct wl_buffer_listener buffer_listener = {
+    .release = on_buffer_release,
+};
 
 static void
 on_export_egl_image(void *data, EGLImageKHR image)
@@ -1035,6 +1039,7 @@ on_export_egl_image(void *data, EGLImageKHR image)
     wpe_view_data.buffer = eglCreateWaylandBufferFromImageWL (egl_data.display,
                                                               wpe_view_data.image);
     g_assert_nonnull (wpe_view_data.buffer);
+    wl_buffer_add_listener(wpe_view_data.buffer, &buffer_listener, image);
 
     wl_surface_attach (win_data.wl_surface, wpe_view_data.buffer, 0, 0);
     wl_surface_damage (win_data.wl_surface,


### PR DESCRIPTION
Hold off instructing the exportable object to release the exported EGLImage
until the wl_buffer wrapping that EGLImage is released by the Wayland
compositor.