### PR TITLE
Cog fixes for iMX8M-evk

### DIFF
--- a/platform/cog-platform-fdo.c
+++ b/platform/cog-platform-fdo.c
@@ -257,10 +257,11 @@ configure_surface_geometry (int32_t width, int32_t height)
 static void
 resize_window (void)
 {
-    wl_egl_window_resize (win_data.egl_window,
-                          win_data.width,
-                          win_data.height,
-                          0, 0);
+    if (win_data.egl_window)
+        wl_egl_window_resize (win_data.egl_window,
+			      win_data.width,
+			      win_data.height,
+			      0, 0);
 
     wpe_view_backend_dispatch_set_size (wpe_view_data.backend,
                                         win_data.width,

--- a/platform/cog-platform-fdo.c
+++ b/platform/cog-platform-fdo.c
@@ -1234,6 +1234,7 @@ create_window (GError **error)
             app_id = COG_DEFAULT_APPID;
         }
         zxdg_toplevel_v6_set_app_id (win_data.xdg_toplevel, app_id);
+        wl_surface_commit(win_data.wl_surface);
     } else if (wl_data.fshell != NULL) {
         zwp_fullscreen_shell_v1_present_surface (wl_data.fshell,
                                                  win_data.wl_surface,


### PR DESCRIPTION
With these two patches Cog launcher starts OK using wpewebkit 2.22.2 and backend-fdo on iMX8M-evk v4.9 based BSP release. I notice weston-simple-egl has a similar guard on egl_window resize and also calls wl_surface_commit when using zxdg_surface_v6.