### PR TITLE
core: Support replacing the Web view with a new one

### DIFF
--- a/cog.c
+++ b/cog.c
@@ -291,11 +291,13 @@ platform_setup (CogShell *shell)
     g_debug ("%s: Platform = %p", __func__, s_options.platform);
     return TRUE;
 }
+#endif // !COG_USE_WEBKITGTK
 
 
 static void
 on_shutdown (CogLauncher *launcher G_GNUC_UNUSED, void *user_data G_GNUC_UNUSED)
 {
+#if !COG_USE_WEBKITGTK
     g_debug ("%s: Platform = %p", __func__, s_options.platform);
 
     if (s_options.platform) {
@@ -303,8 +305,10 @@ on_shutdown (CogLauncher *launcher G_GNUC_UNUSED, void *user_data G_GNUC_UNUSED)
         g_clear_pointer (&s_options.platform, cog_platform_free);
         g_debug ("%s: Platform teardown completed.", __func__);
     }
-}
 #endif // !COG_USE_WEBKITGTK
+
+    g_clear_pointer (&s_options.home_uri, g_free);
+}
 
 
 static WebKitWebView*
@@ -380,7 +384,6 @@ on_create_view (CogShell *shell, void *user_data G_GNUC_UNUSED)
     cog_web_view_connect_default_error_handlers (web_view);
 
     webkit_web_view_load_uri (web_view, s_options.home_uri);
-    g_clear_pointer (&s_options.home_uri, g_free);
 
     return g_steal_pointer (&web_view);
 }

--- a/cogctl.c
+++ b/cogctl.c
@@ -308,6 +308,11 @@ cmd_find_by_name (const char *name)
             .handler = cmd_generic_no_args,
         },
         {
+            .name = "reset",
+            .desc = "Reset the web view",
+            .handler = cmd_generic_no_args,
+        },
+        {
             .name = NULL,
         },
     };

--- a/core/cog-gtk-utils.c
+++ b/core/cog-gtk-utils.c
@@ -10,6 +10,24 @@
 #include <gtk/gtk.h>
 
 
+static void
+on_shell_web_view_notify (CogShell    *shell,
+                          GParamSpec  *pspec G_GNUC_UNUSED,
+                          GtkWindow   *window)
+{
+    GtkWidget *new_web_view = GTK_WIDGET (cog_shell_get_web_view (shell));
+    GtkWidget *old_web_view = gtk_bin_get_child (GTK_BIN (window));
+
+    if (old_web_view == new_web_view)
+        return;
+
+    gtk_widget_hide (old_web_view);
+    gtk_container_remove (GTK_CONTAINER (window), old_web_view);
+    gtk_container_add (GTK_CONTAINER (window), new_web_view);
+    gtk_widget_show (new_web_view);
+}
+
+
 GtkWidget*
 cog_gtk_create_window (CogLauncher *launcher)
 {
@@ -60,6 +78,15 @@ cog_gtk_create_window (CogLauncher *launcher)
     gtk_window_set_default_size (GTK_WINDOW (window), 800, 700);
     gtk_widget_set_size_request (window, 300, 200);
     gtk_container_add (GTK_CONTAINER (window), web_view);
+
+    /*
+     * Get notified when the Web view changes, in order to replace
+     * the widget being shown inside the GTK+ top level window.
+     */
+    g_signal_connect (cog_launcher_get_shell (launcher),
+                      "notify::web-view",
+                      G_CALLBACK (on_shell_web_view_notify),
+                      window);
 
     gtk_widget_show_all (window);
     return window;

--- a/core/cog-launcher.c
+++ b/core/cog-launcher.c
@@ -60,6 +60,14 @@ on_action_reload (G_GNUC_UNUSED GAction  *action,
 }
 
 static void
+on_action_reset (G_GNUC_UNUSED GAction  *action,
+                 G_GNUC_UNUSED GVariant *param,
+                 CogLauncher            *launcher)
+{
+    cog_shell_recreate_web_view (launcher->shell);
+}
+
+static void
 on_action_open (G_GNUC_UNUSED GAction *action,
                 GVariant              *param,
                 CogLauncher           *launcher)
@@ -215,6 +223,7 @@ cog_launcher_constructed (GObject *object)
     cog_launcher_add_action (launcher, "previous", on_action_prev, NULL);
     cog_launcher_add_action (launcher, "next", on_action_next, NULL);
     cog_launcher_add_action (launcher, "reload", on_action_reload, NULL);
+    cog_launcher_add_action (launcher, "reset", on_action_reset, NULL);
     cog_launcher_add_action (launcher, "open", on_action_open, G_VARIANT_TYPE_STRING);
 
 #if COG_DBUS_SYSTEM_BUS

--- a/core/cog-shell.h
+++ b/core/cog-shell.h
@@ -31,6 +31,7 @@ struct _CogShellClass {
 
 
 CogShell         *cog_shell_new                 (const char        *name);
+void              cog_shell_recreate_web_view   (CogShell          *shell);
 const char       *cog_shell_get_name            (CogShell          *shell);
 WebKitWebContext *cog_shell_get_web_context     (CogShell          *shell);
 WebKitSettings   *cog_shell_get_web_settings    (CogShell          *shell);


### PR DESCRIPTION
This allows to completely replace the `WebKitWebView` widget in use by a `CogShell` instance with a newly allocated one. This might be useful in certain situations in which a fresh navigation state is desired (back/forward navigation, visited links, etc).