### PR TITLE
Create Wayland event source after the WPE view backend

### DIFF
--- a/platform/cog-platform-fdo.c
+++ b/platform/cog-platform-fdo.c
@@ -1083,10 +1083,6 @@ init_wayland (GError **error)
               wl_data.shell != NULL ||
               wl_data.fshell != NULL);
 
-    wl_data.event_src =
-        setup_wayland_event_source (g_main_context_get_thread_default (),
-                                    wl_data.display);
-
     return TRUE;
 }
 
@@ -1455,6 +1451,13 @@ cog_platform_get_view_backend (CogPlatform   *platform,
                        (GDestroyNotify) wpe_view_backend_exportable_fdo_destroy,
                                      wpe_host_data.exportable);
     g_assert_nonnull (wk_view_backend);
+
+    if (!wl_data.event_src) {
+        wl_data.event_src =
+            setup_wayland_event_source (g_main_context_get_thread_default (),
+                                        wl_data.display);
+        g_unix_signal_add (SIGUSR1, handle_sigusr1, NULL);
+    }
 
     return wk_view_backend;
 }


### PR DESCRIPTION
Certain Wayland events cause `libwpe` functions to be used, many of which need a valid WPE view backend available. To avoid trying to use a `NULL` view backend, this moves the creation of the `GSource` which integrates Wayland event dispatch with the GLib main loop to be done always after the first view backend is created.

This fixes a crash which was possible to trigger in the short window of time between using `cog_platform_setup()` and `cog_platform_get_view_backend()` by producing using input (e.g. pointer, key, or touch events) during the time window.