### PR TITLE
Add an option to control permission requests

### DIFF
--- a/cog.c
+++ b/cog.c
@@ -430,6 +430,7 @@ main (int argc, char *argv[])
     g_application_add_main_option_entries (app, s_cli_options);
     cog_launcher_add_web_settings_option_entries (COG_LAUNCHER (app));
     cog_launcher_add_web_cookies_option_entries (COG_LAUNCHER (app));
+    cog_launcher_add_web_permissions_option_entries (COG_LAUNCHER (app));
 
 #if !COG_USE_WEBKITGTK
     g_signal_connect (app, "shutdown", G_CALLBACK (on_shutdown), NULL);

--- a/core/cog-launcher.h
+++ b/core/cog-launcher.h
@@ -42,11 +42,12 @@ struct _CogLauncherClass
     CogLauncherBaseClass parent_class;
 };
 
-CogLauncher *cog_launcher_get_default              (void);
-CogShell    *cog_launcher_get_shell                (CogLauncher *launcher);
+CogLauncher *cog_launcher_get_default                  (void);
+CogShell    *cog_launcher_get_shell                    (CogLauncher *launcher);
 
-void  cog_launcher_add_web_settings_option_entries (CogLauncher *launcher);
-void  cog_launcher_add_web_cookies_option_entries  (CogLauncher *launcher);
+void  cog_launcher_add_web_settings_option_entries     (CogLauncher *launcher);
+void  cog_launcher_add_web_cookies_option_entries      (CogLauncher *launcher);
+void  cog_launcher_add_web_permissions_option_entries  (CogLauncher *launcher);
 
 G_END_DECLS
 

--- a/core/cog-shell.c
+++ b/core/cog-shell.c
@@ -121,6 +121,7 @@ cog_shell_startup_base (CogShell *shell)
 
     g_signal_emit (shell, s_signals[CREATE_VIEW], 0, &priv->web_view);
     g_object_ref_sink (priv->web_view);
+    g_object_notify (G_OBJECT (shell), "web-view");
 
     /*
      * The web context and settings being used by the web view must be


### PR DESCRIPTION
This adds the following API function:

  * cog_launcher_add_web_permissions_option_entries

Currently only 2 values are accepted 'all' and 'none', by default
no permissions are granted.

Long term, we will be able to add a more complete synthax to let the
user decide what to accept and what not.