### PR TITLE
fdo: Port to the new wpe_fdo_egl_exported_image API

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -151,7 +151,7 @@ if (COG_PLATFORM_FDO AND NOT COG_USE_WEBKITGTK)
         set(WAYLAND_1_10_OR_GREATER ON)
     endif ()
 
-    pkg_check_modules(COGPLATFORM_FDO_DEPS REQUIRED wpe-webkit-1.0>=2.23.91 wpebackend-fdo-1.0 egl xkbcommon)
+    pkg_check_modules(COGPLATFORM_FDO_DEPS REQUIRED wpe-webkit-1.0>=2.24.0 wpebackend-fdo-1.0>=1.3.1 egl xkbcommon)
     pkg_check_modules(WAYLAND_EGL wayland-egl)
 
     set(COGPLATFORM_FDO_INCLUDE_DIRS


### PR DESCRIPTION
The EGLImageKHR API is scheduled for deprecation in WPEWebKit 2.26.