### PR TITLE
fix syntax error in Use device scale API only when available in libwpe

### DIFF
--- a/platform/cog-platform-fdo.c
+++ b/platform/cog-platform-fdo.c
@@ -475,7 +475,7 @@ registry_global (void               *data,
                                          &wl_seat_interface,
                                          version);
 #if HAVE_DEVICE_SCALING
-    else if (strcmp (interface, wl_output_interface.name) == 0) {
+    } else if (strcmp (interface, wl_output_interface.name) == 0) {
         struct wl_output* output = wl_registry_bind (registry,
                                                      name,
                                                      &wl_output_interface,


### PR DESCRIPTION
fix syntax error introduce in `fdo: Use device scale API only when
available in libwpe` (git show 86ba95ba)

```
error: ... platform/cog-platform-fdo.c:478:5: error: expected '}' before 'else'
     else if (strcmp (interface, wl_output_interface.name) == 0) {
```