### PR TITLE
fix syntax error in Use device scale API only when available in libwpe

### DIFF
--- a/platform/cog-platform-fdo.c
+++ b/platform/cog-platform-fdo.c
@@ -496,7 +496,6 @@ registry_global (void               *data,
         } else {
             g_message ("Wayland: Got a wl_output interface\n");
         }
-    }
 #endif /* HAVE_DEVICE_SCALING */
     } else {
         interface_used = FALSE;


### PR DESCRIPTION
fix syntax error introduce in `fdo: Use device scale API only when
available in libwpe` (git show 86ba95ba)