### PR TITLE
pointer_on_axis: fix the axis-scrolling issues

### DIFF
--- a/platform/cog-platform-fdo.c
+++ b/platform/cog-platform-fdo.c
@@ -587,7 +587,7 @@ pointer_on_axis (void* data,
         wl_data.pointer.x * wl_data.current_output.scale,
         wl_data.pointer.y * wl_data.current_output.scale,
         axis,
-        - wl_fixed_to_int (value),
+        wl_fixed_to_int(value) > 0 ? -1 : 1,
     };
 
     wpe_view_backend_dispatch_axis_event (wpe_view_data.backend, &event);


### PR DESCRIPTION
The pointer_on_axis callback can receive a floating-point value that
represents the current vector distance of movement along that axis.
Current libwpe API cannot accomodate that value, so instead we should
only take the sign of that value and accordingly pass -1 or 1 as the
scrolling value for the axis event.