### PR TITLE
enable -Wall option when supported

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -82,8 +82,13 @@ else ()
     endif ()
 endif ()
 
+include(CheckCCompilerFlag)
+check_c_compiler_flag(-Wall HAS_WALL)
 set(COGCORE_INCLUDE_DIRS ${WEB_ENGINE_INCLUDE_DIRS} ${SOUP_INCLUDE_DIRS})
 set(COGCORE_CFLAGS ${WEB_ENGINE_CFLAGS_OTHER} ${SOUP_CFLAGS_OTHER})
+if (HAS_WALL)
+  set(COGCORE_CFLAGS ${WEB_ENGINE_CFLAGS_OTHER} ${SOUP_CFLAGS_OTHER} "-Wall")
+endif ()
 set(COGCORE_LDFLAGS ${WEB_ENGINE_LDFLAGS} ${SOUP_LDFLAGS})
 
 
@@ -114,12 +119,18 @@ target_compile_options(cogcore
 if (COG_BUILD_PROGRAMS)
     add_executable(cog cog.c)
     set_property(TARGET cog PROPERTY C_STANDARD 99)
+    if (HAS_WALL)
+      target_compile_options(cog PUBLIC "-Wall")
+    endif ()
     target_link_libraries(cog cogcore -ldl)
 
     add_executable(cogctl cogctl.c core/cog-utils.c)
     set_property(TARGET cogctl PROPERTY C_STANDARD 99)
     target_include_directories(cogctl PUBLIC ${GIO_INCLUDE_DIRS} ${SOUP_INCLUDE_DIRS})
     target_compile_options(cogctl PUBLIC ${GIO_CFLAGS_OTHER} ${SOUP_CFLAGS_OTHER})
+    if (HAS_WALL)
+      target_compile_options(cogctl PUBLIC "-Wall")
+    endif ()
     target_link_libraries(cogctl ${GIO_LDFLAGS} ${SOUP_LDFLAGS})
 
     install(TARGETS cog cogctl

--- a/core/cog-launcher.c
+++ b/core/cog-launcher.c
@@ -460,6 +460,7 @@ option_entry_parse_cookie_add (const char          *option G_GNUC_UNUSED,
                                WebKitCookieManager *cookie_manager,
                                GError             **error G_GNUC_UNUSED)
 {
+    g_autoptr(GMainLoop) loop = NULL;
     g_autofree char *domain = g_strdup (value);
 
     char *flagstr = strchr (domain, ':');
@@ -523,7 +524,7 @@ option_entry_parse_cookie_add (const char          *option G_GNUC_UNUSED,
 
     // Adding a cookie is an asynchronous operation, so spin up an
     // event loop until to block until the operation completes.
-    g_autoptr(GMainLoop) loop = g_main_loop_new (NULL, FALSE);
+    loop = g_main_loop_new (NULL, FALSE);
     webkit_cookie_manager_add_cookie (cookie_manager,
                                       cookie,
                                       NULL,  // GCancellable

--- a/core/cog-shell.c
+++ b/core/cog-shell.c
@@ -133,9 +133,8 @@ cog_shell_startup_base (CogShell *shell)
 
 
 static void
-cog_shell_shutdown_base (CogShell *shell)
+cog_shell_shutdown_base (CogShell *shell G_GNUC_UNUSED)
 {
-    CogShellPrivate *priv = PRIV (shell);
 }
 
 

--- a/core/cog-utils.c
+++ b/core/cog-utils.c
@@ -212,8 +212,8 @@ option_entry_parse_to_property (const char *option,
             char *end = NULL;
             guint64 prop_value = g_ascii_strtoull (value, &end, 0);
             if (errno == ERANGE ||
-                (prop_type == G_TYPE_UINT && prop_value > UINT_MAX ||
-                (prop_type == G_TYPE_ULONG && prop_value > ULONG_MAX)))
+                ((prop_type == G_TYPE_UINT && prop_value > UINT_MAX) ||
+                 (prop_type == G_TYPE_ULONG && prop_value > ULONG_MAX)))
             {
                 g_set_error (error,
                              G_OPTION_ERROR,


### PR DESCRIPTION
This also fixes some warnings that existed. The only tricky one was to
do with g_autoptr. I'm not sure why, but I had to hoist and initialize
this further up the scope to stop GCC complaining about it being
potentially uninitialized in _GLIB_AUTOPTR_CLEAR_FUNC_NAME.