### PR TITLE
cog: Make --version also show WebKit versions

### DIFF
--- a/cog.c
+++ b/cog.c
@@ -154,7 +154,16 @@ on_handle_local_options (GApplication *application,
                          void         *user_data)
 {
     if (s_options.version) {
-        g_print ("%s\n", COG_VERSION_STRING COG_VERSION_EXTRA);
+        g_print ("%s (%s %u.%u.%u)\n",
+                 COG_VERSION_STRING COG_VERSION_EXTRA,
+#if COG_USE_WEBKITGTK
+                 "WebKitGTK",
+#else
+                 "WPE WebKit",
+#endif // COG_USE_WEBKITGTK
+                 webkit_get_major_version (),
+                 webkit_get_minor_version (),
+                 webkit_get_micro_version ());
         return EXIT_SUCCESS;
     }
     if (s_options.print_appid) {


### PR DESCRIPTION
This makes `cog --version` include between parentheses which WebKit port it was built for (`WPE WebKit`, or `WebKitGTK`) and its version.

----

Follow-up to #116 :wink: 