### PR TITLE
cog-platform-fdo: Use xdg-shell instead of xdg-shell-v6

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -225,7 +225,7 @@ if (COG_PLATFORM_FDO AND NOT COG_USE_WEBKITGTK)
     )
 
     find_package(WaylandProtocols REQUIRED)
-    add_wayland_protocol(cogplatform-fdo CLIENT xdg-shell-unstable-v6)
+    add_wayland_protocol(cogplatform-fdo CLIENT xdg-shell)
     add_wayland_protocol(cogplatform-fdo CLIENT fullscreen-shell-unstable-v1)
 
     install(TARGETS cogplatform-fdo


### PR DESCRIPTION
The xdg-shell interface is stable and xdg-shell-v6 is deprecated.