### PR TITLE
Fix build with -DCOG_USE_WEBKITGTK=ON

### DIFF
--- a/cog.c
+++ b/cog.c
@@ -13,14 +13,12 @@
 
 #if !COG_USE_WEBKITGTK
 # include "cog-platform.h"
-#endif
-
 #if defined(WPE_CHECK_VERSION) && WPE_CHECK_VERSION(1, 3, 0)
 # define HAVE_DEVICE_SCALING 1
 #else
 # define HAVE_DEVICE_SCALING 0
 #endif /* WPE_CHECK_VERSION */
-
+#endif /* COG_USE_WEBKITGTK */
 
 enum webprocess_fail_action {
     WEBPROCESS_FAIL_UNKNOWN = 0,


### PR DESCRIPTION
The following build error was happening:
```
 cog.c:18:52: error: missing binary operator before token "("
  #if defined(WPE_CHECK_VERSION) && WPE_CHECK_VERSION(1, 3, 0)
```