### PR TITLE
Add a runtime option to ignore TLS certificate errors

### DIFF
--- a/cog.c
+++ b/cog.c
@@ -53,11 +53,13 @@ static struct {
         enum webprocess_fail_action action_id;
     } on_failure;
     char *web_extensions_dir;
+    gboolean ignore_tls_errors;
 } s_options = {
     .scale_factor = 1.0,
 #if HAVE_DEVICE_SCALING
     .device_scale_factor = 1.0,
 #endif // HAVE_DEVICE_SCALING
+    .ignore_tls_errors = FALSE,
 };
 
 
@@ -103,6 +105,9 @@ static GOptionEntry s_cli_options[] =
     { "web-extensions-dir", '\0', 0, G_OPTION_ARG_STRING, &s_options.web_extensions_dir,
       "Load Web Extensions from given directory.",
       "PATH"},
+    { "ignore-tls-errors", '\0', 0, G_OPTION_ARG_NONE, &s_options.ignore_tls_errors,
+      "Ignore TLS erros (default: disabled)", NULL
+    },
     { G_OPTION_REMAINING, '\0', 0, G_OPTION_ARG_FILENAME_ARRAY, &s_options.arguments,
         "", "[URL]" },
     { NULL }
@@ -283,6 +288,8 @@ on_handle_local_options (GApplication *application,
         webkit_web_context_set_web_extensions_directory (cog_shell_get_web_context (shell),
                                                          s_options.web_extensions_dir);
     }
+
+    g_object_set (shell, "ignore-tls-errors", s_options.ignore_tls_errors, NULL);
 
     return -1;  /* Continue startup. */
 }

--- a/core/cog-shell.c
+++ b/core/cog-shell.c
@@ -14,6 +14,7 @@ typedef struct {
     WebKitWebContext *web_context;
     WebKitWebView    *web_view;
     GHashTable       *request_handlers;  /* (string, RequestHandlerMapEntry) */
+    gboolean          ignore_tls_errors;
 } CogShellPrivate;
 
 
@@ -28,6 +29,7 @@ enum {
     PROP_WEB_SETTINGS,
     PROP_WEB_CONTEXT,
     PROP_WEB_VIEW,
+    PROP_IGNORE_TLS_ERRORS,
     N_PROPERTIES,
 };
 
@@ -158,6 +160,9 @@ cog_shell_get_property (GObject    *object,
         case PROP_WEB_VIEW:
             g_value_set_object (value, cog_shell_get_web_view (shell));
             break;
+        case PROP_IGNORE_TLS_ERRORS:
+            g_value_set_boolean (value, cog_shell_get_ignore_tls_errors (shell));
+            break;
         default:
             G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
     }
@@ -174,6 +179,9 @@ cog_shell_set_property (GObject      *object,
     switch (prop_id) {
         case PROP_NAME:
             PRIV (shell)->name = g_value_dup_string (value);
+            break;
+        case PROP_IGNORE_TLS_ERRORS:
+            PRIV (shell)->ignore_tls_errors = g_value_get_boolean (value);
             break;
         default:
             G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
@@ -277,13 +285,21 @@ cog_shell_class_init (CogShellClass *klass)
                              G_PARAM_READABLE |
                              G_PARAM_STATIC_STRINGS);
 
+    s_properties[PROP_IGNORE_TLS_ERRORS] =
+        g_param_spec_boolean ("ignore-tls-errors",
+                              "Ignore TLS errors",
+                              "Wether to ignore TLS errors or not",
+                              FALSE,
+                              G_PARAM_READWRITE);
+
     g_object_class_install_properties (object_class, N_PROPERTIES, s_properties);
 }
 
 
 static void
-cog_shell_init (CogShell *shell G_GNUC_UNUSED)
+cog_shell_init (CogShell *shell)
 {
+    PRIV (shell)->ignore_tls_errors = FALSE;
 }
 
 
@@ -361,6 +377,12 @@ cog_shell_set_request_handler (CogShell          *shell,
     request_handler_map_entry_register (scheme, entry, priv->web_context);
 }
 
+gboolean
+cog_shell_get_ignore_tls_errors (CogShell *shell)
+{
+    g_return_val_if_fail (COG_IS_SHELL (shell), FALSE);
+    return PRIV (shell)->ignore_tls_errors;
+}
 
 void
 cog_shell_startup  (CogShell *shell)

--- a/core/cog-shell.h
+++ b/core/cog-shell.h
@@ -38,6 +38,7 @@ WebKitWebView    *cog_shell_get_web_view        (CogShell          *shell);
 void              cog_shell_set_request_handler (CogShell          *shell,
                                                  const char        *scheme,
                                                  CogRequestHandler *handler);
+gboolean          cog_shell_get_ignore_tls_errors(CogShell *shell);
 
 void              cog_shell_startup             (CogShell          *shell);
 void              cog_shell_shutdown            (CogShell          *shell);

--- a/core/cog-webkit-utils.c
+++ b/core/cog-webkit-utils.c
@@ -98,21 +98,18 @@ format_tls_error (GTlsCertificateFlags errors)
     return g_string_free (str, FALSE);
 }
 
-
 gboolean
-cog_handle_web_view_load_failed_with_tls_errors (WebKitWebView       *web_view,
-                                                 char                *failing_uri,
-                                                 GTlsCertificate     *certificate,
-                                                 GTlsCertificateFlags errors,
-                                                 void                *user_data)
+cog_web_view_load_error_page (WebKitWebView *web_view,
+                              char *failing_uri,
+                              GTlsCertificateFlags errors)
 {
+
     g_autofree char *error_string = format_tls_error (errors);
     return load_error_page (web_view,
                             failing_uri,
                             "TLS Error",
                             error_string);
 }
-
 
 gboolean
 cog_handle_web_view_web_process_terminated (WebKitWebView                     *web_view,
@@ -256,8 +253,6 @@ cog_web_view_connect_default_error_handlers (WebKitWebView *web_view)
     } handlers[] = {
         { "load-failed",
             cog_handle_web_view_load_failed },
-        { "load-failed-with-tls-errors",
-            cog_handle_web_view_load_failed_with_tls_errors },
         { "web-process-terminated",
             cog_handle_web_view_web_process_terminated },
     };

--- a/core/cog-webkit-utils.h
+++ b/core/cog-webkit-utils.h
@@ -42,12 +42,6 @@ gboolean cog_handle_web_view_load_failed (WebKitWebView  *web_view,
                                           GError         *error,
                                           void           *userdata);
 
-gboolean cog_handle_web_view_load_failed_with_tls_errors (WebKitWebView       *web_view,
-                                                          char                *failing_uri,
-                                                          GTlsCertificate     *certificate,
-                                                          GTlsCertificateFlags errors,
-                                                          void                *user_data);
-
 gboolean cog_handle_web_view_web_process_terminated (WebKitWebView                     *web_view,
                                                      WebKitWebProcessTerminationReason  reason,
                                                      void                              *userdata);
@@ -79,6 +73,9 @@ void cog_handle_web_view_load_changed (WebKitWebView  *web_view,
 
 void cog_web_view_connect_default_progress_handlers (WebKitWebView *web_view);
 
+gboolean cog_web_view_load_error_page (WebKitWebView *web_view,
+                                       char *failing_uri,
+                                       GTlsCertificateFlags errors);
 
 gboolean cog_webkit_settings_apply_from_key_file (WebKitSettings *settings,
                                                   GKeyFile       *key_file,


### PR DESCRIPTION
By default this option is disabled and an error page will be displayed when the
page load fails due to a TLS error. However, by enabling this option the page
load can resume and thus the TLS error is ignored. Use this option carefully and
consider the security implications.