### PR TITLE
Turn device scaling factor into a CogShell property

### DIFF
--- a/cog.c
+++ b/cog.c
@@ -13,11 +13,6 @@
 
 #if !COG_USE_WEBKITGTK
 # include "cog-platform.h"
-#if defined(WPE_CHECK_VERSION) && WPE_CHECK_VERSION(1, 3, 0)
-# define HAVE_DEVICE_SCALING 1
-#else
-# define HAVE_DEVICE_SCALING 0
-#endif /* WPE_CHECK_VERSION */
 #endif /* !COG_USE_WEBKITGTK */
 
 enum webprocess_fail_action {
@@ -36,9 +31,7 @@ static struct {
     gboolean print_appid;
     gboolean doc_viewer;
     gdouble  scale_factor;
-#if HAVE_DEVICE_SCALING
     gdouble  device_scale_factor;
-#endif // HAVE_DEVICE_SCALING
     GStrv    dir_handlers;
     GStrv    arguments;
     char    *background_color;
@@ -55,9 +48,7 @@ static struct {
     char *web_extensions_dir;
 } s_options = {
     .scale_factor = 1.0,
-#if HAVE_DEVICE_SCALING
     .device_scale_factor = 1.0,
-#endif // HAVE_DEVICE_SCALING
 };
 
 
@@ -72,11 +63,9 @@ static GOptionEntry s_cli_options[] =
     { "scale", '\0', 0, G_OPTION_ARG_DOUBLE, &s_options.scale_factor,
         "Zoom/Scaling factor applied to Web content (default: 1.0, no scaling)",
         "FACTOR" },
-#if HAVE_DEVICE_SCALING
     { "device-scale", '\0', 0, G_OPTION_ARG_DOUBLE, &s_options.device_scale_factor,
         "Output device scaling factor (default: 1.0, no scaling, 96 DPI)",
         "FACTOR" },
-#endif // HAVE_DEVICE_SCALING
     { "doc-viewer", '\0', 0, G_OPTION_ARG_NONE, &s_options.doc_viewer,
         "Document viewer mode: optimizes for local loading of Web content. "
         "This reduces memory usage at the cost of reducing caching of "
@@ -284,6 +273,8 @@ on_handle_local_options (GApplication *application,
                                                          s_options.web_extensions_dir);
     }
 
+    cog_shell_set_device_scale (shell, s_options.device_scale_factor);
+
     return -1;  /* Continue startup. */
 }
 
@@ -378,13 +369,6 @@ on_create_view (CogShell *shell, void *user_data G_GNUC_UNUSED)
     // must have succeeded in providing a WebKitWebViewBackend* instance.
     if (!view_backend)
         g_error ("Could not instantiate any WPE backend.");
-
-#if HAVE_DEVICE_SCALING
-    struct wpe_view_backend* wpe_backend =
-        webkit_web_view_backend_get_wpe_backend (view_backend);
-    wpe_view_backend_dispatch_set_device_scale_factor (wpe_backend,
-                                                       s_options.device_scale_factor);
-#endif // HAVE_DEVICE_SCALING
 #endif // !COG_USE_WEBKITGTK
 
     g_autoptr(WebKitWebView) web_view = g_object_new (WEBKIT_TYPE_WEB_VIEW,

--- a/core/cog-shell.h
+++ b/core/cog-shell.h
@@ -32,6 +32,9 @@ struct _CogShellClass {
 
 CogShell         *cog_shell_new                 (const char        *name);
 const char       *cog_shell_get_name            (CogShell          *shell);
+gdouble           cog_shell_get_device_scale    (CogShell          *shell);
+void              cog_shell_set_device_scale    (CogShell          *shell,
+                                                 gdouble            scale);
 WebKitWebContext *cog_shell_get_web_context     (CogShell          *shell);
 WebKitSettings   *cog_shell_get_web_settings    (CogShell          *shell);
 WebKitWebView    *cog_shell_get_web_view        (CogShell          *shell);


### PR DESCRIPTION
This allows platform plug-ins reading the value of the property during their initialization, and shifts to them the responsibility of applying the device scaling factor in which way and moment is better for the pltform plug-in.

The FDO platform plug-in does not need any changes, as it picks the scaling factor from the Wayland compositor. The experimental DRM plug-in is changed to take into account the value of the `CogShell::device-scale` during view backend creation.