### PR TITLE
cog-shell: Do not leak the name property string

### DIFF
--- a/core/cog-shell.c
+++ b/core/cog-shell.c
@@ -215,6 +215,7 @@ cog_shell_dispose (GObject *object)
     g_clear_object (&priv->web_settings);
 
     g_clear_pointer (&priv->request_handlers, g_hash_table_unref);
+    g_clear_pointer (&priv->name, g_free);
 
     G_OBJECT_CLASS (cog_shell_parent_class)->dispose (object);
 }


### PR DESCRIPTION
Deallocate the string used as shell name in the `cog_shell_dispose()` method to avoid leaking it.