### PR TITLE
cog-shell: Apply g_get_prgname() fallback in _init method

### DIFF
--- a/core/cog-shell.c
+++ b/core/cog-shell.c
@@ -284,6 +284,9 @@ cog_shell_class_init (CogShellClass *klass)
 static void
 cog_shell_init (CogShell *shell G_GNUC_UNUSED)
 {
+    CogShellPrivate *priv = PRIV (shell);
+    if (!priv->name)
+        priv->name = g_strdup (g_get_prgname ());
 }
 
 
@@ -291,7 +294,7 @@ CogShell*
 cog_shell_new (const char *name)
 {
     return g_object_new (COG_TYPE_SHELL,
-                         "name", name ? name : g_get_prgname (),
+                         "name", name,
                          NULL);
 }
 


### PR DESCRIPTION
This is needed to ensure that `g_get_prgname()` is used as fallback name when instantiation is done through `g_object_new()` and the value of the property is not explicitly set to a non-`NULL` value.

Without this fix, the `g_get_prgname()` fallback would be only applied when instantiation is done using `cog_shell_new()`.