### PR TITLE
cog-shell: Use g_object_notify_by_pspec()

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -93,7 +93,7 @@ set(COGCORE_SOURCES
     core/cog-webkit-utils.c
 )
 
-pkg_check_modules(GIO REQUIRED gio-2.0)
+pkg_check_modules(GIO REQUIRED gio-2.0>=2.44)
 pkg_check_modules(SOUP REQUIRED libsoup-2.4)
 if (COG_USE_WEBKITGTK)
     list(APPEND COGCORE_SOURCES core/cog-gtk-utils.c)

--- a/core/cog-shell.c
+++ b/core/cog-shell.c
@@ -121,7 +121,7 @@ cog_shell_startup_base (CogShell *shell)
 
     g_signal_emit (shell, s_signals[CREATE_VIEW], 0, &priv->web_view);
     g_object_ref_sink (priv->web_view);
-    g_object_notify (G_OBJECT (shell), "web-view");
+    g_object_notify_by_pspec (G_OBJECT (shell), s_properties[PROP_WEB_VIEW]);
 
     /*
      * The web context and settings being used by the web view must be


### PR DESCRIPTION
Using `g_object_notify_by_pspec()` instead of `g_object_notify()` is preferred in the implementation of GObject classes because it avoids the lookup of the property given its string.