### PR TITLE
core: ignore cancellation errors as the active URI may be changing

### DIFF
--- a/core/cog-webkit-utils.c
+++ b/core/cog-webkit-utils.c
@@ -58,6 +58,12 @@ cog_handle_web_view_load_failed (WebKitWebView  *web_view,
     if (g_error_matches (error,
                          WEBKIT_PLUGIN_ERROR,
                          WEBKIT_PLUGIN_ERROR_WILL_HANDLE_LOAD))
+      return FALSE;
+
+    // Ignore cancellation errors as the active URI may be changing
+    if (g_error_matches (error,
+			 WEBKIT_NETWORK_ERROR,
+			 WEBKIT_NETWORK_ERROR_CANCELLED))
         return FALSE;
 
     return load_error_page (web_view,


### PR DESCRIPTION
If the user clicks on a link before the current page has been fully
loaded, the view gets a "network error cancelled". We could safely
ignore these and go on.

Easy to reproduce on high-latency links (e.g. satellite links).