### PR TITLE
shell: Avoid G_ADD_PRIVATE warning

### DIFF
--- a/core/cog-shell.c
+++ b/core/cog-shell.c
@@ -20,7 +20,7 @@ typedef struct {
 G_DEFINE_TYPE_WITH_PRIVATE (CogShell, cog_shell, G_TYPE_OBJECT)
 
 #define PRIV(obj) \
-        G_TYPE_INSTANCE_GET_PRIVATE ((obj), COG_TYPE_SHELL, CogShellPrivate)
+        ((CogShellPrivate*) cog_shell_get_instance_private (COG_SHELL (obj)))
 
 enum {
     PROP_0,


### PR DESCRIPTION
Building with GLib 2.62 produces a bunch of the following warnings:

```
  ../core/cog-shell.c: In function ‘cog_shell_startup_base’:
  ../core/cog-shell.c:114:13: warning: G_ADD_PRIVATE
    114 |     CogShellPrivate *priv = PRIV (shell);
        |                           ^~~~~~~~~~~~~~~
```

This uses `cog_shell_get_instance_private()`, which is defined automatically by the `G_DEFINE_TYPE_*` macros and is the preferred way of obtaining a pointer to the instance private area anyway. GLib 2.4 or newer is needed, which was released in 2004, so this is not expected to introduce any issue.