### PR TITLE
drm: crtc continuously being reset

### DIFF
--- a/platform/cog-platform-drm.c
+++ b/platform/cog-platform-drm.c
@@ -280,7 +280,7 @@ drm_update_from_bo (struct gbm_bo *bo, struct wl_resource *buffer_resource, uint
             return;
         }
 
-        drm_data.mode_set = 0;
+        drm_data.mode_set = true;
     }
 
     struct buffer_object *buffer = g_new0 (struct buffer_object, 1);


### PR DESCRIPTION
Assign a better value to the variable that should be preventing constant
crtc updates but was failing to do so.