### PR TITLE
drm: cache imported gbm_bo objects and corresponding DRM framebuffers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -255,7 +255,7 @@ endif ()  # !COG_USE_WEBKITGTK
 # libcogplaform-drm-experimental
 
 if (COG_PLATFORM_DRM AND NOT COG_USE_WEBKITGTK)
-    pkg_check_modules(COGPLATFORM_DRM_DEPS REQUIRED wpe-webkit-1.0>=2.24.0 wpebackend-fdo-1.0>=1.3.1 libdrm>=2.4.71 gbm>=13.0 egl libinput libudev)
+    pkg_check_modules(COGPLATFORM_DRM_DEPS REQUIRED wpe-webkit-1.0>=2.24.0 wpebackend-fdo-1.0>=1.3.1 libdrm>=2.4.71 gbm>=13.0 egl libinput libudev wayland-server)
 
     set(COGPLATFORM_DRM_INCLUDE_DIRS
         ${COGPLATFORM_DRM_DEPS_INCLUDE_DIRS}


### PR DESCRIPTION
For each exported wl_resource, we now cache the imported gbm_bo object and the
corresponding framebuffer object, avoiding constant cycling of these resources.

Upon first export, we spawn all the relevant resources. On further exports, we
iterate over the buffer list to find the cached object, and reuse such an object
if it exists.

Each cached buffer is associated to the wl_resource lifetime through the
destroy listener that's set up on the resource object. The cached buffers are
cleaned up during teardown.