### PR TITLE
Support for direct-display video content rendering

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -59,6 +59,8 @@ option(COG_PLATFORM_FDO "Build the FDO platform module" ON)
 option(COG_PLATFORM_DRM "Build the DRM platform module" OFF)
 option(COG_BUILD_PROGRAMS "Build and install programs as well" ON)
 option(INSTALL_MAN_PAGES "Install the man(1) pages if COG_BUILD_PROGRAMS is enabled" ON)
+option(COG_WESTON_DIRECT_DISPLAY "Build direct display support for the FDO platform module" OFF)
+
 set(COG_APPID "" CACHE STRING "Default GApplication unique identifier")
 set(COG_HOME_URI "" CACHE STRING "Default home URI")
 
@@ -256,6 +258,50 @@ if (COG_PLATFORM_FDO AND NOT COG_USE_WEBKITGTK)
         add_definitions(-DCOG_IM_API_SUPPORTED=0)
     endif ()
 
+    find_path(WPEBACKEND_FDO_HAS_VIDEO_PLANE_DISPLAY_DMABUF_EXT
+        NAMES wpe/extensions/video-plane-display-dmabuf.h
+        PATHS ${COGPLATFORM_FDO_DEPS_INCLUDE_DIRS}
+        NO_DEFAULT_PATH
+    )
+    if (WPEBACKEND_FDO_HAS_VIDEO_PLANE_DISPLAY_DMABUF_EXT)
+        set(WPEBACKEND_FDO_HAS_VIDEO_PLANE_DISPLAY_DMABUF_EXT ON)
+    else ()
+        set(WPEBACKEND_FDO_HAS_VIDEO_PLANE_DISPLAY_DMABUF_EXT OFF)
+    endif ()
+
+    if (COG_WESTON_DIRECT_DISPLAY AND WPEBACKEND_FDO_HAS_VIDEO_PLANE_DISPLAY_DMABUF_EXT)
+        file(MAKE_DIRECTORY ${CMAKE_BINARY_DIR}/weston)
+        pkg_check_modules(LIBWESTON REQUIRED libweston-9-protocols)
+        pkg_get_variable(LIBWESTON_PKG_DATA_DIR libweston-9-protocols "pkgdatadir")
+        find_package(WaylandScanner REQUIRED)
+        add_custom_command(
+            OUTPUT ${CMAKE_BINARY_DIR}/weston/weston-direct-display-client-protocol.h
+                   ${CMAKE_BINARY_DIR}/weston/weston-direct-display-protocol.c
+            DEPENDS ${LIBWESTON_PKG_DATA_DIR}/weston-direct-display.xml
+            COMMAND ${WAYLAND_SCANNER} client-header < ${LIBWESTON_PKG_DATA_DIR}/weston-direct-display.xml > ${CMAKE_BINARY_DIR}/weston/weston-direct-display-client-protocol.h
+            COMMAND ${WAYLAND_SCANNER} ${WAYLAND_SCANNER_CODE_ARG} < ${LIBWESTON_PKG_DATA_DIR}/weston-direct-display.xml > ${CMAKE_BINARY_DIR}/weston/weston-direct-display-protocol.c
+            VERBATIM
+        )
+
+        add_custom_command(
+            OUTPUT ${CMAKE_BINARY_DIR}/weston/weston-content-protection-client-protocol.h
+                   ${CMAKE_BINARY_DIR}/weston/weston-content-protection-protocol.c
+            DEPENDS ${LIBWESTON_PKG_DATA_DIR}/weston-content-protection.xml
+            COMMAND ${WAYLAND_SCANNER} client-header < ${LIBWESTON_PKG_DATA_DIR}/weston-content-protection.xml > ${CMAKE_BINARY_DIR}/weston/weston-content-protection-client-protocol.h
+            COMMAND ${WAYLAND_SCANNER} ${WAYLAND_SCANNER_CODE_ARG} < ${LIBWESTON_PKG_DATA_DIR}/weston-content-protection.xml > ${CMAKE_BINARY_DIR}/weston/weston-content-protection-protocol.c
+            VERBATIM
+        )
+
+        list(APPEND COGPLATFORM_FDO_SOURCES
+            ${CMAKE_BINARY_DIR}/weston/weston-direct-display-protocol.c
+            ${CMAKE_BINARY_DIR}/weston/weston-content-protection-protocol.c
+        )
+        list(APPEND COGPLATFORM_FDO_INCLUDE_DIRS ${CMAKE_BINARY_DIR}/weston)
+        set(ENABLE_WESTON_DIRECT_DISPLAY 1)
+    else ()
+        set(ENABLE_WESTON_DIRECT_DISPLAY 0)
+    endif ()
+
     add_library(cogplatform-fdo MODULE ${COGPLATFORM_FDO_SOURCES})
     set_property(TARGET cogplatform-fdo PROPERTY C_STANDARD 99)
     target_include_directories(cogplatform-fdo PUBLIC wayland ${COGPLATFORM_FDO_INCLUDE_DIRS})
@@ -264,6 +310,7 @@ if (COG_PLATFORM_FDO AND NOT COG_USE_WEBKITGTK)
         PUBLIC ${COGPLATFORM_FDO_CFLAGS}
         PRIVATE -DG_LOG_DOMAIN=\"Cog-FDO\"
     )
+    target_compile_options(cogplatform-fdo PRIVATE -DCOG_ENABLE_WESTON_DIRECT_DISPLAY=${ENABLE_WESTON_DIRECT_DISPLAY})
 
     find_package(WaylandProtocols REQUIRED)
     add_wayland_protocol(cogplatform-fdo CLIENT xdg-shell)
@@ -273,6 +320,7 @@ if (COG_PLATFORM_FDO AND NOT COG_USE_WEBKITGTK)
         add_wayland_protocol(cogplatform-fdo CLIENT text-input-unstable-v1)
         add_wayland_protocol(cogplatform-fdo CLIENT text-input-unstable-v3)
     endif ()
+    add_wayland_protocol(cogplatform-fdo CLIENT linux-dmabuf-unstable-v1)
 
     install(TARGETS cogplatform-fdo
         DESTINATION ${CMAKE_INSTALL_LIBDIR}

--- a/platform/cog-platform-fdo.c
+++ b/platform/cog-platform-fdo.c
@@ -686,7 +686,8 @@ keyboard_on_keymap (void *data,
         return;
     }
 
-    void* mapping = mmap (NULL, size, PROT_READ, MAP_SHARED, fd, 0);
+    int map_mode = wl_seat_interface.version > 6 ? MAP_PRIVATE : MAP_SHARED;
+    void* mapping = mmap (NULL, size, PROT_READ, map_mode, fd, 0);
     if (mapping == MAP_FAILED) {
         close (fd);
         return;

--- a/platform/cog-platform-fdo.c
+++ b/platform/cog-platform-fdo.c
@@ -43,6 +43,15 @@
 #include "text-input-unstable-v3-client.h"
 #endif
 
+#include "linux-dmabuf-unstable-v1-client.h"
+
+#if COG_ENABLE_WESTON_DIRECT_DISPLAY
+#include <drm_fourcc.h>
+#include <wpe/extensions/video-plane-display-dmabuf.h>
+#include "weston-direct-display-client-protocol.h"
+#include "weston-content-protection-client-protocol.h"
+#endif
+
 #define DEFAULT_WIDTH  1024
 #define DEFAULT_HEIGHT  768
 
@@ -54,6 +63,26 @@
 # define HAVE_DEVICE_SCALING 0
 #endif /* WPE_CHECK_VERSION */
 
+#if COG_ENABLE_WESTON_DIRECT_DISPLAY
+#define VIDEO_BUFFER_FORMAT DRM_FORMAT_YUYV
+struct video_buffer {
+    struct wl_buffer *buffer;
+
+    int32_t x;
+    int32_t y;
+    int32_t width;
+    int32_t height;
+    int fd;
+
+    struct wpe_video_plane_display_dmabuf_export* dmabuf_export;
+};
+
+struct video_surface {
+    struct weston_protected_surface *protected_surface;
+    struct wl_surface *wl_surface;
+    struct wl_subsurface *wl_subsurface;
+};
+#endif
 
 #ifndef EGL_WL_create_wayland_buffer_from_image
 typedef struct wl_buffer * (EGLAPIENTRYP PFNEGLCREATEWAYLANDBUFFERFROMIMAGEWL) (EGLDisplay dpy, EGLImageKHR image);
@@ -72,12 +101,19 @@ static struct {
     struct wl_display *display;
     struct wl_registry *registry;
     struct wl_compositor *compositor;
+    struct wl_subcompositor *subcompositor;
 
     struct xdg_wm_base *xdg_shell;
     struct zwp_fullscreen_shell_v1 *fshell;
     struct wl_shell *shell;
 
     struct wl_seat *seat;
+
+#if COG_ENABLE_WESTON_DIRECT_DISPLAY
+    struct zwp_linux_dmabuf_v1 *dmabuf;
+    struct weston_direct_display_v1 *direct_display;
+    struct weston_content_protection *protection;
+#endif
 
 #if HAVE_DEVICE_SCALING
     struct output_metrics metrics[16];
@@ -140,6 +176,10 @@ static struct {
     struct wl_surface *wl_surface;
     struct wl_egl_window *egl_window;
     EGLSurface egl_surface;
+
+#if COG_ENABLE_WESTON_DIRECT_DISPLAY
+    GHashTable *video_surfaces;
+#endif
 
     struct xdg_surface *xdg_surface;
     struct xdg_toplevel *xdg_toplevel;
@@ -466,6 +506,11 @@ registry_global (void               *data,
                                                name,
                                                &wl_compositor_interface,
                                                version);
+    } else if (strcmp (interface, wl_subcompositor_interface.name) == 0) {
+            wl_data.subcompositor = wl_registry_bind (registry,
+                                                      name,
+                                                      &wl_subcompositor_interface,
+                                                      version);
     } else if (strcmp (interface, wl_shell_interface.name) == 0) {
         wl_data.shell = wl_registry_bind (registry,
                                           name,
@@ -489,6 +534,24 @@ registry_global (void               *data,
                                          name,
                                          &wl_seat_interface,
                                          version);
+#if COG_ENABLE_WESTON_DIRECT_DISPLAY
+    } else if (strcmp (interface, zwp_linux_dmabuf_v1_interface.name) == 0) {
+        if (version < 3) {
+            g_warning ("Version %d of the zwp_linux_dmabuf_v1 protocol is not supported", version);
+            return;
+        }
+        wl_data.dmabuf = wl_registry_bind (registry, name, &zwp_linux_dmabuf_v1_interface, version);
+    } else if (strcmp (interface, weston_direct_display_v1_interface.name) == 0) {
+        wl_data.direct_display = wl_registry_bind (registry,
+                                                   name,
+                                                   &weston_direct_display_v1_interface,
+                                                   version);
+    } else if (strcmp (interface, weston_content_protection_interface.name) == 0) {
+        wl_data.protection = wl_registry_bind (registry,
+                                               name,
+                                               &weston_content_protection_interface,
+                                               version);
+#endif /* COG_ENABLE_WESTON_DIRECT_DISPLAY */
 #if HAVE_DEVICE_SCALING
     } else if (strcmp (interface, wl_output_interface.name) == 0) {
         struct wl_output* output = wl_registry_bind (registry,
@@ -1232,6 +1295,37 @@ static const struct wl_buffer_listener buffer_listener = {
     .release = on_buffer_release,
 };
 
+#if COG_ENABLE_WESTON_DIRECT_DISPLAY
+static void
+on_dmabuf_surface_frame (void *data, struct wl_callback *callback, uint32_t time)
+{
+    // for WAYLAND_DEBUG=1 purposes only
+    wl_callback_destroy (callback);
+}
+
+static const struct wl_callback_listener dmabuf_frame_listener = {
+    .done = on_dmabuf_surface_frame,
+};
+
+static void
+on_dmabuf_buffer_release (void* data, struct wl_buffer* buffer)
+{
+    struct video_buffer *data_buffer = data;
+    if (data_buffer->fd >= 0)
+        close(data_buffer->fd);
+
+    if (data_buffer->dmabuf_export)
+        wpe_video_plane_display_dmabuf_export_release(data_buffer->dmabuf_export);
+
+    g_slice_free (struct video_buffer, data_buffer);
+    g_clear_pointer (&buffer, wl_buffer_destroy);
+}
+
+static const struct wl_buffer_listener dmabuf_buffer_listener = {
+    .release = on_dmabuf_buffer_release,
+};
+#endif /* COG_ENABLE_WESTON_DIRECT_DISPLAY */
+
 static void
 on_export_fdo_egl_image(void *data, struct wpe_fdo_egl_exported_image *image)
 {
@@ -1269,6 +1363,128 @@ on_export_fdo_egl_image(void *data, struct wpe_fdo_egl_exported_image *image)
 
     wl_surface_commit (win_data.wl_surface);
 }
+
+#if COG_ENABLE_WESTON_DIRECT_DISPLAY
+static void
+create_succeeded(void *data, struct zwp_linux_buffer_params_v1 *params, struct wl_buffer *new_buffer)
+{
+	zwp_linux_buffer_params_v1_destroy (params);
+
+	struct video_buffer *buffer = data;
+	buffer->buffer = new_buffer;
+}
+
+static void
+create_failed(void *data, struct zwp_linux_buffer_params_v1 *params)
+{
+	zwp_linux_buffer_params_v1_destroy (params);
+
+    struct video_buffer *buffer = data;
+    buffer->buffer = NULL;
+}
+
+static const struct zwp_linux_buffer_params_v1_listener params_listener = {
+	.created = create_succeeded,
+	.failed = create_failed
+};
+
+static void
+destroy_video_surface (gpointer data)
+{
+    struct video_surface *surface = (struct video_surface*) data;
+
+    g_clear_pointer (&surface->protected_surface, weston_protected_surface_destroy);
+    g_clear_pointer (&surface->wl_subsurface, wl_subsurface_destroy);
+    g_clear_pointer (&surface->wl_surface, wl_surface_destroy);
+    g_slice_free (struct video_surface, surface);
+}
+
+static void
+on_video_plane_display_dmabuf_receiver_handle_dmabuf (void* data, struct wpe_video_plane_display_dmabuf_export* dmabuf_export, uint32_t id, int fd, int32_t x, int32_t y, int32_t width, int32_t height, uint32_t stride)
+{
+    if (fd < 0)
+        return;
+
+    if (!wl_data.dmabuf) {
+        // TODO: Replace with g_warning_once() after bumping our GLib requirement.
+        static bool warning_emitted = false;
+        if (!warning_emitted) {
+            g_warning ("DMABuf not supported by the compositor. Video won't be rendered");
+            warning_emitted = true;
+        }
+        return;
+    }
+
+    uint64_t modifier = DRM_FORMAT_MOD_INVALID;
+    struct zwp_linux_buffer_params_v1 *params = zwp_linux_dmabuf_v1_create_params (wl_data.dmabuf);
+    if (wl_data.direct_display != NULL)
+        weston_direct_display_v1_enable (wl_data.direct_display, params);
+
+    struct video_surface *surf = (struct video_surface*) g_hash_table_lookup (win_data.video_surfaces, GUINT_TO_POINTER(id));
+    if (!surf) {
+        surf = g_slice_new0 (struct video_surface);
+        surf->wl_subsurface = NULL;
+        surf->wl_surface = wl_compositor_create_surface (wl_data.compositor);
+
+        if (wl_data.protection) {
+            surf->protected_surface = weston_content_protection_get_protection (wl_data.protection, surf->wl_surface);
+            //weston_protected_surface_set_type(surf->protected_surface, WESTON_PROTECTED_SURFACE_TYPE_DC_ONLY);
+
+            weston_protected_surface_enforce (surf->protected_surface);
+        }
+        g_hash_table_insert (win_data.video_surfaces, GUINT_TO_POINTER (id), surf);
+    }
+
+    zwp_linux_buffer_params_v1_add (params, fd, 0, 0, stride, modifier >> 32, modifier & 0xffffffff);
+
+    if ((x + width) > win_data.width)
+        width -= x;
+
+    if ((y + height) > win_data.height)
+        height -= y;
+
+    struct video_buffer *buffer = g_slice_new0 (struct video_buffer);
+    buffer->fd = fd;
+    buffer->x = x;
+    buffer->y = y;
+    buffer->width = width;
+    buffer->height = height;
+	zwp_linux_buffer_params_v1_add_listener (params, &params_listener, buffer);
+
+    buffer->buffer = zwp_linux_buffer_params_v1_create_immed (params, buffer->width, buffer->height, VIDEO_BUFFER_FORMAT, 0);
+    zwp_linux_buffer_params_v1_destroy (params);
+
+    buffer->dmabuf_export = dmabuf_export;
+    wl_buffer_add_listener (buffer->buffer, &dmabuf_buffer_listener, buffer);
+
+    wl_surface_attach (surf->wl_surface, buffer->buffer, 0, 0);
+    wl_surface_damage (surf->wl_surface, 0, 0, buffer->width, buffer->height);
+
+    struct wl_callback *callback = wl_surface_frame (surf->wl_surface);
+    wl_callback_add_listener (callback, &dmabuf_frame_listener, NULL);
+
+    if (!surf->wl_subsurface) {
+        surf->wl_subsurface = wl_subcompositor_get_subsurface (wl_data.subcompositor,
+                                                               surf->wl_surface,
+                                                               win_data.wl_surface);
+        wl_subsurface_set_sync (surf->wl_subsurface);
+    }
+
+    wl_subsurface_set_position (surf->wl_subsurface, buffer->x, buffer->y);
+    wl_surface_commit (surf->wl_surface);
+}
+
+static void
+on_video_plane_display_dmabuf_receiver_end_of_stream (void* data, uint32_t id)
+{
+    g_hash_table_remove (win_data.video_surfaces, GUINT_TO_POINTER (id));
+}
+
+static const struct wpe_video_plane_display_dmabuf_receiver video_plane_display_dmabuf_receiver = {
+    .handle_dmabuf = on_video_plane_display_dmabuf_receiver_handle_dmabuf,
+    .end_of_stream = on_video_plane_display_dmabuf_receiver_end_of_stream,
+};
+#endif
 
 static gboolean
 init_wayland (GError **error)
@@ -1310,8 +1526,13 @@ clear_wayland (void)
     if (wl_data.shell != NULL)
         wl_shell_destroy (wl_data.shell);
 
-    if (wl_data.compositor != NULL)
-        wl_compositor_destroy (wl_data.compositor);
+    g_clear_pointer (&wl_data.subcompositor, wl_subcompositor_destroy);
+    g_clear_pointer (&wl_data.compositor, wl_compositor_destroy);
+
+#if COG_ENABLE_WESTON_DIRECT_DISPLAY
+    g_clear_pointer (&wl_data.protection, weston_content_protection_destroy);
+    g_clear_pointer (&wl_data.direct_display, weston_direct_display_v1_destroy);
+#endif
 
     wl_registry_destroy (wl_data.registry);
     wl_display_flush (wl_data.display);
@@ -1424,6 +1645,10 @@ create_window (GError **error)
     win_data.wl_surface = wl_compositor_create_surface (wl_data.compositor);
     g_assert (win_data.wl_surface);
 
+#if COG_ENABLE_WESTON_DIRECT_DISPLAY
+    win_data.video_surfaces = g_hash_table_new_full (g_direct_hash, g_direct_equal, NULL, destroy_video_surface);
+#endif
+
 #if HAVE_DEVICE_SCALING
     wl_surface_add_listener (win_data.wl_surface, &surface_listener, NULL);
 #endif /* HAVE_DEVICE_SCALING */
@@ -1531,6 +1756,10 @@ destroy_window (void)
     g_clear_pointer (&win_data.xdg_surface, xdg_surface_destroy);
     g_clear_pointer (&win_data.shell_surface, wl_shell_surface_destroy);
     g_clear_pointer (&win_data.wl_surface, wl_surface_destroy);
+
+#if COG_ENABLE_WESTON_DIRECT_DISPLAY
+    g_clear_pointer (&win_data.video_surfaces, g_hash_table_destroy);
+#endif
 }
 
 static gboolean
@@ -1631,6 +1860,10 @@ cog_platform_plugin_setup (CogPlatform *platform,
 
     /* init WPE host data */
     wpe_fdo_initialize_for_egl_display (egl_data.display);
+
+#if COG_ENABLE_WESTON_DIRECT_DISPLAY
+    wpe_video_plane_display_dmabuf_register_receiver (&video_plane_display_dmabuf_receiver, NULL);
+#endif
 
     return TRUE;
 }


### PR DESCRIPTION
By relying on the direct-display and content-protection Weston Wayland
protocols, the browser is now able to render video frames by passing them
directly to the display controller, without any additional GPU import in the
compositor. DMABufs are wrapped in sub-surfaces and positioned according to the
coordinates provided by WebKit.

Minimal support for multiple videos rendering support was added, although in
most cases the underlying hardware platform will be able to render only one
video at a time.
