### PR TITLE
no globals: Moving global references and refactorings 

### DIFF
--- a/modules/cog-fdo-shell.c
+++ b/modules/cog-fdo-shell.c
@@ -156,17 +156,17 @@ on_pointer_on_axis (PwlDisplay* display, void *userdata)
 static void
 on_touch_on_down (PwlDisplay* display, void *userdata)
 {
-    CogFdoShellCallbackData *cb_userdata = userdata;
-    struct wpe_view_backend* backend = cog_shell_get_active_wpe_backend (cb_userdata->shell);
+    CogShell *shell = userdata;
+    struct wpe_view_backend* backend = cog_shell_get_active_wpe_backend (shell);
     struct wpe_input_touch_event_raw raw_event = {
         wpe_input_touch_event_type_down,
-        cb_userdata->wl_data->touch.time,
-        cb_userdata->wl_data->touch.id,
-        wl_fixed_to_int (cb_userdata->wl_data->touch.x) * cb_userdata->wl_data->current_output.scale,
-        wl_fixed_to_int (cb_userdata->wl_data->touch.y) * cb_userdata->wl_data->current_output.scale,
+        display->touch.time,
+        display->touch.id,
+        wl_fixed_to_int (display->touch.x) * wl_data.current_output.scale,
+        wl_fixed_to_int (display->touch.y) * wl_data.current_output.scale,
     };
 
-    memcpy (&touch_points[cb_userdata->wl_data->touch.id],
+    memcpy (&touch_points[display->touch.id],
             &raw_event,
             sizeof (struct wpe_input_touch_event_raw));
 
@@ -184,17 +184,17 @@ on_touch_on_down (PwlDisplay* display, void *userdata)
 static void
 on_touch_on_up (PwlDisplay* display, void *userdata)
 {
-    CogFdoShellCallbackData *cb_userdata = userdata;
-    struct wpe_view_backend* backend = cog_shell_get_active_wpe_backend (cb_userdata->shell);
+    CogShell *shell = userdata;
+    struct wpe_view_backend* backend = cog_shell_get_active_wpe_backend (shell);
     struct wpe_input_touch_event_raw raw_event = {
         wpe_input_touch_event_type_up,
-        cb_userdata->wl_data->touch.time,
-        cb_userdata->wl_data->touch.id,
-        touch_points[wl_data.touch.id].x,
-        touch_points[wl_data.touch.id].y,
+        display->touch.time,
+        display->touch.id,
+        touch_points[display->touch.id].x,
+        touch_points[display->touch.id].y,
     };
 
-    memcpy (&touch_points[cb_userdata->wl_data->touch.id],
+    memcpy (&touch_points[display->touch.id],
             &raw_event,
             sizeof (struct wpe_input_touch_event_raw));
 
@@ -208,7 +208,7 @@ on_touch_on_up (PwlDisplay* display, void *userdata)
 
     wpe_view_backend_dispatch_touch_event (backend, &event);
 
-    memset (&touch_points[cb_userdata->wl_data->touch.id],
+    memset (&touch_points[display->touch.id],
             0x00,
             sizeof (struct wpe_input_touch_event_raw));
 }
@@ -216,19 +216,19 @@ on_touch_on_up (PwlDisplay* display, void *userdata)
 static void
 on_touch_on_motion (PwlDisplay* display, void *userdata)
 {
-    CogFdoShellCallbackData *cb_userdata = userdata;
+    CogShell *shell = userdata;
 
-    struct wpe_view_backend* backend = cog_shell_get_active_wpe_backend (cb_userdata->shell);
+    struct wpe_view_backend* backend = cog_shell_get_active_wpe_backend (shell);
 
     struct wpe_input_touch_event_raw raw_event = {
         wpe_input_touch_event_type_motion,
-        cb_userdata->wl_data->touch.time,
-        cb_userdata->wl_data->touch.id,
-        wl_fixed_to_int (cb_userdata->wl_data->touch.x) * cb_userdata->wl_data->current_output.scale,
-        wl_fixed_to_int (cb_userdata->wl_data->touch.y) * cb_userdata->wl_data->current_output.scale,
+        display->touch.time,
+        display->touch.id,
+        wl_fixed_to_int (display->touch.x) * wl_data.current_output.scale,
+        wl_fixed_to_int (display->touch.y) * wl_data.current_output.scale,
     };
 
-    memcpy (&touch_points[cb_userdata->wl_data->touch.id],
+    memcpy (&touch_points[display->touch.id],
             &raw_event,
             sizeof (struct wpe_input_touch_event_raw));
 
@@ -609,11 +609,11 @@ cog_fdo_shell_initable_init (GInitable *initable,
     s_pdisplay->on_pointer_on_axis_userdata = initable;
 
     s_pdisplay->on_touch_on_down = on_touch_on_down;
-    s_pdisplay->on_touch_on_down_userdata = s_callback_userdata;
+    s_pdisplay->on_touch_on_down_userdata = initable;
     s_pdisplay->on_touch_on_up = on_touch_on_up;
-    s_pdisplay->on_touch_on_up_userdata = s_callback_userdata;
+    s_pdisplay->on_touch_on_up_userdata = initable;
     s_pdisplay->on_touch_on_motion = on_touch_on_motion;
-    s_pdisplay->on_touch_on_motion_userdata = s_callback_userdata;
+    s_pdisplay->on_touch_on_motion_userdata = initable;
 
     s_pdisplay->on_key_event = on_key_event;
     s_pdisplay->on_key_event_userdata = s_callback_userdata;

--- a/modules/cog-fdo-shell.c
+++ b/modules/cog-fdo-shell.c
@@ -186,17 +186,17 @@ on_pointer_on_axis (PwlDisplay* display, void *userdata)
 static void
 on_touch_on_down (PwlDisplay* display, void *userdata)
 {
-    CogShell *shell = userdata;
-    struct wpe_view_backend* backend = cog_shell_get_active_wpe_backend (shell);
+    CogFdoShellCallbackData *cb_userdata = userdata;
+    struct wpe_view_backend* backend = cog_shell_get_active_wpe_backend (cb_userdata->shell);
     struct wpe_input_touch_event_raw raw_event = {
         wpe_input_touch_event_type_down,
-        wl_data.touch.time,
-        wl_data.touch.id,
-        wl_fixed_to_int (wl_data.touch.x) * wl_data.current_output.scale,
-        wl_fixed_to_int (wl_data.touch.y) * wl_data.current_output.scale,
+        cb_userdata->wl_data->touch.time,
+        cb_userdata->wl_data->touch.id,
+        wl_fixed_to_int (cb_userdata->wl_data->touch.x) * cb_userdata->wl_data->current_output.scale,
+        wl_fixed_to_int (cb_userdata->wl_data->touch.y) * cb_userdata->wl_data->current_output.scale,
     };
 
-    memcpy (&touch_points[wl_data.touch.id],
+    memcpy (&touch_points[cb_userdata->wl_data->touch.id],
             &raw_event,
             sizeof (struct wpe_input_touch_event_raw));
 
@@ -214,17 +214,17 @@ on_touch_on_down (PwlDisplay* display, void *userdata)
 static void
 on_touch_on_up (PwlDisplay* display, void *userdata)
 {
-    CogShell *shell = userdata;
-    struct wpe_view_backend* backend = cog_shell_get_active_wpe_backend (shell);
+    CogFdoShellCallbackData *cb_userdata = userdata;
+    struct wpe_view_backend* backend = cog_shell_get_active_wpe_backend (cb_userdata->shell);
     struct wpe_input_touch_event_raw raw_event = {
         wpe_input_touch_event_type_up,
-        wl_data.touch.time,
-        wl_data.touch.id,
+        cb_userdata->wl_data->touch.time,
+        cb_userdata->wl_data->touch.id,
         touch_points[wl_data.touch.id].x,
         touch_points[wl_data.touch.id].y,
     };
 
-    memcpy (&touch_points[wl_data.touch.id],
+    memcpy (&touch_points[cb_userdata->wl_data->touch.id],
             &raw_event,
             sizeof (struct wpe_input_touch_event_raw));
 
@@ -238,7 +238,7 @@ on_touch_on_up (PwlDisplay* display, void *userdata)
 
     wpe_view_backend_dispatch_touch_event (backend, &event);
 
-    memset (&touch_points[wl_data.touch.id],
+    memset (&touch_points[cb_userdata->wl_data->touch.id],
             0x00,
             sizeof (struct wpe_input_touch_event_raw));
 }
@@ -246,19 +246,19 @@ on_touch_on_up (PwlDisplay* display, void *userdata)
 static void
 on_touch_on_motion (PwlDisplay* display, void *userdata)
 {
-    CogShell *shell = userdata;
+    CogFdoShellCallbackData *cb_userdata = userdata;
 
-    struct wpe_view_backend* backend = cog_shell_get_active_wpe_backend (shell);
+    struct wpe_view_backend* backend = cog_shell_get_active_wpe_backend (cb_userdata->shell);
 
     struct wpe_input_touch_event_raw raw_event = {
         wpe_input_touch_event_type_motion,
-        wl_data.touch.time,
-        wl_data.touch.id,
-        wl_fixed_to_int (wl_data.touch.x) * wl_data.current_output.scale,
-        wl_fixed_to_int (wl_data.touch.y) * wl_data.current_output.scale,
+        cb_userdata->wl_data->touch.time,
+        cb_userdata->wl_data->touch.id,
+        wl_fixed_to_int (cb_userdata->wl_data->touch.x) * cb_userdata->wl_data->current_output.scale,
+        wl_fixed_to_int (cb_userdata->wl_data->touch.y) * cb_userdata->wl_data->current_output.scale,
     };
 
-    memcpy (&touch_points[wl_data.touch.id],
+    memcpy (&touch_points[cb_userdata->wl_data->touch.id],
             &raw_event,
             sizeof (struct wpe_input_touch_event_raw));
 
@@ -689,8 +689,11 @@ cog_fdo_shell_initable_init (GInitable *initable,
     s_pdisplay->on_pointer_on_axis_userdata = s_callback_userdata;
 
     s_pdisplay->on_touch_on_down = on_touch_on_down;
+    s_pdisplay->on_touch_on_down_userdata = s_callback_userdata;
     s_pdisplay->on_touch_on_up = on_touch_on_up;
+    s_pdisplay->on_touch_on_up_userdata = s_callback_userdata;
     s_pdisplay->on_touch_on_motion = on_touch_on_motion;
+    s_pdisplay->on_touch_on_motion_userdata = s_callback_userdata;
 
     if (!init_wayland (s_pdisplay, error))
         return FALSE;

--- a/modules/cog-fdo-shell.c
+++ b/modules/cog-fdo-shell.c
@@ -96,8 +96,8 @@ cog_shell_get_active_wpe_backend (CogShell *shell)
 static void
 on_surface_enter (PwlDisplay* display, void *userdata)
 {
-    CogFdoShellCallbackData *cb_userdata = userdata;
-    struct wpe_view_backend* backend = cog_shell_get_active_wpe_backend (cb_userdata->shell);
+    CogShell *shell = userdata;
+    struct wpe_view_backend* backend = cog_shell_get_active_wpe_backend (shell);
     wpe_view_backend_dispatch_set_device_scale_factor (backend, wl_data.current_output.scale);
 }
 #endif /* HAVE_DEVICE_SCALING */
@@ -598,7 +598,7 @@ cog_fdo_shell_initable_init (GInitable *initable,
 
 #if HAVE_DEVICE_SCALING
     s_pdisplay->on_surface_enter = on_surface_enter;
-    s_pdisplay->on_surface_enter_userdata = s_callback_userdata;
+    s_pdisplay->on_surface_enter_userdata = initable;
 #endif /* HAVE_DEVICE_SCALING */
     s_pdisplay->on_pointer_on_motion = on_pointer_on_motion;
     s_pdisplay->on_pointer_on_motion_userdata = initable;

--- a/modules/cog-fdo-shell.c
+++ b/modules/cog-fdo-shell.c
@@ -126,8 +126,8 @@ cog_shell_get_active_wpe_backend (CogShell *shell)
 static void
 on_surface_enter (PwlDisplay* display, void *userdata)
 {
-    CogShell *shell = (CogShell*) userdata;
-    struct wpe_view_backend* backend = cog_shell_get_active_wpe_backend (shell);
+    CogFdoShellCallbackData *cb_userdata = userdata;
+    struct wpe_view_backend* backend = cog_shell_get_active_wpe_backend (cb_userdata->shell);
     wpe_view_backend_dispatch_set_device_scale_factor (backend, wl_data.current_output.scale);
 }
 #endif /* HAVE_DEVICE_SCALING */
@@ -679,6 +679,7 @@ cog_fdo_shell_initable_init (GInitable *initable,
     wl_data.output_listener = output_listener;
 
     s_pdisplay->on_surface_enter = on_surface_enter;
+    s_pdisplay->on_surface_enter_userdata = s_callback_userdata;
 #endif /* HAVE_DEVICE_SCALING */
     s_pdisplay->on_pointer_on_motion = on_pointer_on_motion;
     s_pdisplay->on_pointer_on_button = on_pointer_on_button;

--- a/modules/cog-fdo-shell.c
+++ b/modules/cog-fdo-shell.c
@@ -86,33 +86,6 @@ wpe_view_backend_data_free (WpeViewBackendData *data)
 
 /* Output scale */
 #if HAVE_DEVICE_SCALING
-static void
-noop()
-{
-}
-
-static void
-output_handle_scale (void *data,
-                     struct wl_output *output,
-                     int32_t factor)
-{
-    bool found = false;
-    for (int i = 0; i < G_N_ELEMENTS (wl_data.metrics); i++)
-    {
-        if (wl_data.metrics[i].output == output) {
-            found = true;
-            wl_data.metrics[i].scale = factor;
-            break;
-        }
-    }
-    if (!found)
-    {
-        g_warning ("Unknown output %p\n", output);
-        return;
-    }
-    g_info ("Got scale factor %i for output %p\n", factor, output);
-}
-
 struct wpe_view_backend*
 cog_shell_get_active_wpe_backend (CogShell *shell)
 {
@@ -626,14 +599,6 @@ cog_fdo_shell_initable_init (GInitable *initable,
     s_callback_userdata->win_data = s_win_data;
 
 #if HAVE_DEVICE_SCALING
-    const struct wl_output_listener output_listener = {
-        .geometry = noop,
-        .mode = noop,
-        .done = noop,
-        .scale = output_handle_scale,
-    };
-    wl_data.output_listener = output_listener;
-
     s_pdisplay->on_surface_enter = on_surface_enter;
     s_pdisplay->on_surface_enter_userdata = s_callback_userdata;
 #endif /* HAVE_DEVICE_SCALING */

--- a/modules/cog-fdo-shell.c
+++ b/modules/cog-fdo-shell.c
@@ -853,15 +853,6 @@ cog_fdo_shell_initable_init (GInitable *initable,
     xkb_data.modifier.control = wpe_input_keyboard_modifier_control;
     xkb_data.modifier.alt = wpe_input_keyboard_modifier_alt;
     xkb_data.modifier.shift = wpe_input_keyboard_modifier_shift;
-    const struct wl_keyboard_listener keyboard_listener = {
-        .keymap = keyboard_on_keymap,
-        .enter = keyboard_on_enter,
-        .leave = keyboard_on_leave,
-        .key = keyboard_on_key,
-        .modifiers = keyboard_on_modifiers,
-        .repeat_info = keyboard_on_repeat_info,
-    };
-    wl_data.keyboard.listener = keyboard_listener;
 
     const struct wl_touch_listener touch_listener = {
         .down = touch_on_down,

--- a/modules/cog-fdo-shell.c
+++ b/modules/cog-fdo-shell.c
@@ -339,8 +339,8 @@ cog_fdo_shell_class_finalize (CogFdoShellClass *klass)
 static void
 on_window_resize (PwlWinData *win_data, void *userdata)
 {
-    CogFdoShellCallbackData *cb_userdata = userdata;
-    struct wpe_view_backend* backend = cog_shell_get_active_wpe_backend (cb_userdata->shell);
+    CogShell *shell = userdata;
+    struct wpe_view_backend* backend = cog_shell_get_active_wpe_backend (shell);
     wpe_view_backend_dispatch_set_size (backend,
                                         win_data->width,
                                         win_data->height);
@@ -631,7 +631,7 @@ cog_fdo_shell_initable_init (GInitable *initable,
     }
 
     s_win_data->on_window_resize = on_window_resize;
-    s_win_data->on_window_resize_userdata = s_callback_userdata;
+    s_win_data->on_window_resize_userdata = initable;
 
     xkb_data.modifier.control = wpe_input_keyboard_modifier_control;
     xkb_data.modifier.alt = wpe_input_keyboard_modifier_alt;

--- a/modules/cog-fdo-shell.c
+++ b/modules/cog-fdo-shell.c
@@ -50,14 +50,6 @@ typedef struct {
     CogShell parent;
 } CogFdoShell;
 
-typedef struct {
-    CogShell *shell;
-    PwlData  *wl_data;
-    PwlWinData  *win_data;
-} CogFdoShellCallbackData;
-
-static CogFdoShellCallbackData *s_callback_userdata = NULL;
-
 static void cog_fdo_shell_initable_iface_init (GInitableIface *iface);
 
 struct wpe_input_touch_event_raw touch_points[10];
@@ -327,8 +319,6 @@ cog_fdo_shell_class_finalize (CogFdoShellClass *klass)
     wpe_view_backend_exportable_fdo_destroy (wpe_host_data.exportable);
     * /
 */
-    g_free(s_callback_userdata);
-
     clear_input (s_pdisplay);
 
     destroy_window (s_pdisplay, s_win_data);
@@ -591,10 +581,6 @@ cog_fdo_shell_initable_init (GInitable *initable,
 
     TRACE ("");
     s_win_data = g_new0 (PwlWinData, 1);
-    s_callback_userdata = g_new0 (CogFdoShellCallbackData, 1);
-    s_callback_userdata->shell = (CogShell*) initable;
-    s_callback_userdata->wl_data = &wl_data;
-    s_callback_userdata->win_data = s_win_data;
 
 #if HAVE_DEVICE_SCALING
     s_pdisplay->on_surface_enter = on_surface_enter;

--- a/modules/cog-fdo-shell.c
+++ b/modules/cog-fdo-shell.c
@@ -350,14 +350,13 @@ on_window_resize (PwlWinData *win_data, void *userdata)
 static bool
 on_capture_app_key (PwlDisplay *display, void *userdata)
 {
-    CogFdoShellCallbackData *cb_userdata = userdata;
     CogLauncher *launcher = cog_launcher_get_default ();
     WebKitWebView *web_view = WEBKIT_WEB_VIEW(cog_shell_get_active_view (cog_launcher_get_shell (launcher)));
 
-    uint32_t keysym = cb_userdata->wl_data->keyboard.event.keysym;
-    uint32_t unicode = cb_userdata->wl_data->keyboard.event.unicode;
-    uint32_t state = cb_userdata->wl_data->keyboard.event.state;
-    uint8_t modifiers =cb_userdata->wl_data->keyboard.event.modifiers;
+    uint32_t keysym = display->keyboard.event.keysym;
+    uint32_t unicode = display->keyboard.event.unicode;
+    uint32_t state = display->keyboard.event.state;
+    uint8_t modifiers =display->keyboard.event.modifiers;
 
     if (state == WL_KEYBOARD_KEY_STATE_PRESSED) {
         /* Ctrl+W, exit the application */
@@ -412,16 +411,16 @@ on_capture_app_key (PwlDisplay *display, void *userdata)
 static void
 on_key_event (PwlDisplay* display, void *userdata)
 {
-    CogFdoShellCallbackData *cb_userdata = userdata;
+    CogShell *shell = userdata;
 
-    struct wpe_view_backend* backend = cog_shell_get_active_wpe_backend (cb_userdata->shell);
+    struct wpe_view_backend* backend = cog_shell_get_active_wpe_backend (shell);
 
     struct wpe_input_keyboard_event event = {
-        cb_userdata->wl_data->keyboard.event.timestamp,
-        cb_userdata->wl_data->keyboard.event.keysym,
-        cb_userdata->wl_data->keyboard.event.unicode,
-        cb_userdata->wl_data->keyboard.event.state == true,
-        cb_userdata->wl_data->keyboard.event.modifiers
+        display->keyboard.event.timestamp,
+        display->keyboard.event.keysym,
+        display->keyboard.event.unicode,
+        display->keyboard.event.state == true,
+        display->keyboard.event.modifiers
     };
 
     wpe_view_backend_dispatch_keyboard_event (backend, &event);
@@ -616,9 +615,9 @@ cog_fdo_shell_initable_init (GInitable *initable,
     s_pdisplay->on_touch_on_motion_userdata = initable;
 
     s_pdisplay->on_key_event = on_key_event;
-    s_pdisplay->on_key_event_userdata = s_callback_userdata;
+    s_pdisplay->on_key_event_userdata = initable;
     s_pdisplay->on_capture_app_key = on_capture_app_key;
-    s_pdisplay->on_capture_app_key_userdata = s_callback_userdata;
+    s_pdisplay->on_capture_app_key_userdata = initable;
 
     if (!init_wayland (s_pdisplay, error))
         return FALSE;

--- a/modules/cog-fdo-shell.c
+++ b/modules/cog-fdo-shell.c
@@ -83,9 +83,6 @@ wpe_view_backend_data_free (WpeViewBackendData *data)
     g_free (data);
 }
 
-
-/* Output scale */
-#if HAVE_DEVICE_SCALING
 struct wpe_view_backend*
 cog_shell_get_active_wpe_backend (CogShell *shell)
 {
@@ -94,6 +91,8 @@ cog_shell_get_active_wpe_backend (CogShell *shell)
     return webkit_web_view_backend_get_wpe_backend (webkit_web_view_get_backend (webview));
 }
 
+/* Output scale */
+#if HAVE_DEVICE_SCALING
 static void
 on_surface_enter (PwlDisplay* display, void *userdata)
 {

--- a/modules/cog-fdo-shell.c
+++ b/modules/cog-fdo-shell.c
@@ -137,15 +137,15 @@ on_surface_enter (PwlDisplay* display, void *userdata)
 static void
 on_pointer_on_motion (PwlDisplay* display, void *userdata)
 {
-    CogShell *shell = userdata;
-    struct wpe_view_backend* backend = cog_shell_get_active_wpe_backend (shell);
+    CogFdoShellCallbackData *cb_userdata = userdata;
+    struct wpe_view_backend* backend = cog_shell_get_active_wpe_backend (cb_userdata->shell);
     struct wpe_input_pointer_event event = {
         wpe_input_pointer_event_type_motion,
-        wl_data.pointer.time,
-        wl_data.pointer.x * wl_data.current_output.scale,
-        wl_data.pointer.y * wl_data.current_output.scale,
-        wl_data.pointer.button,
-        wl_data.pointer.state
+        cb_userdata->wl_data->pointer.time,
+        cb_userdata->wl_data->pointer.x * cb_userdata->wl_data->current_output.scale,
+        cb_userdata->wl_data->pointer.y * cb_userdata->wl_data->current_output.scale,
+        cb_userdata->wl_data->pointer.button,
+        cb_userdata->wl_data->pointer.state
     };
     wpe_view_backend_dispatch_pointer_event (backend, &event);
 }
@@ -153,15 +153,15 @@ on_pointer_on_motion (PwlDisplay* display, void *userdata)
 static void
 on_pointer_on_button (PwlDisplay* display, void *userdata)
 {
-    CogShell *shell = userdata;
-    struct wpe_view_backend* backend = cog_shell_get_active_wpe_backend (shell);
+    CogFdoShellCallbackData *cb_userdata = userdata;
+    struct wpe_view_backend* backend = cog_shell_get_active_wpe_backend (cb_userdata->shell);
     struct wpe_input_pointer_event event = {
         wpe_input_pointer_event_type_button,
-        wl_data.pointer.time,
-        wl_data.pointer.x * wl_data.current_output.scale,
-        wl_data.pointer.y * wl_data.current_output.scale,
-        wl_data.pointer.button,
-        wl_data.pointer.state,
+        cb_userdata->wl_data->pointer.time,
+        cb_userdata->wl_data->pointer.x * cb_userdata->wl_data->current_output.scale,
+        cb_userdata->wl_data->pointer.y * cb_userdata->wl_data->current_output.scale,
+        cb_userdata->wl_data->pointer.button,
+        cb_userdata->wl_data->pointer.state,
     };
     wpe_view_backend_dispatch_pointer_event (backend, &event);
 }
@@ -169,15 +169,15 @@ on_pointer_on_button (PwlDisplay* display, void *userdata)
 static void
 on_pointer_on_axis (PwlDisplay* display, void *userdata)
 {
-    CogShell *shell = userdata;
-    struct wpe_view_backend* backend = cog_shell_get_active_wpe_backend (shell);
+    CogFdoShellCallbackData *cb_userdata = userdata;
+    struct wpe_view_backend* backend = cog_shell_get_active_wpe_backend (cb_userdata->shell);
     struct wpe_input_axis_event event = {
         wpe_input_axis_event_type_motion,
-        wl_data.pointer.time,
-        wl_data.pointer.x * wl_data.current_output.scale,
-        wl_data.pointer.y * wl_data.current_output.scale,
-        wl_data.pointer.axis,
-        wl_data.pointer.value,
+        cb_userdata->wl_data->pointer.time,
+        cb_userdata->wl_data->pointer.x * cb_userdata->wl_data->current_output.scale,
+        cb_userdata->wl_data->pointer.y * cb_userdata->wl_data->current_output.scale,
+        cb_userdata->wl_data->pointer.axis,
+        cb_userdata->wl_data->pointer.value,
     };
     wpe_view_backend_dispatch_axis_event (backend, &event);
 }
@@ -682,8 +682,11 @@ cog_fdo_shell_initable_init (GInitable *initable,
     s_pdisplay->on_surface_enter_userdata = s_callback_userdata;
 #endif /* HAVE_DEVICE_SCALING */
     s_pdisplay->on_pointer_on_motion = on_pointer_on_motion;
+    s_pdisplay->on_pointer_on_motion_userdata = s_callback_userdata;
     s_pdisplay->on_pointer_on_button = on_pointer_on_button;
+    s_pdisplay->on_pointer_on_button_userdata = s_callback_userdata;
     s_pdisplay->on_pointer_on_axis = on_pointer_on_axis;
+    s_pdisplay->on_pointer_on_axis_userdata = s_callback_userdata;
 
     s_pdisplay->on_touch_on_down = on_touch_on_down;
     s_pdisplay->on_touch_on_up = on_touch_on_up;

--- a/modules/cog-fdo-shell.c
+++ b/modules/cog-fdo-shell.c
@@ -107,15 +107,15 @@ on_surface_enter (PwlDisplay* display, void *userdata)
 static void
 on_pointer_on_motion (PwlDisplay* display, void *userdata)
 {
-    CogFdoShellCallbackData *cb_userdata = userdata;
-    struct wpe_view_backend* backend = cog_shell_get_active_wpe_backend (cb_userdata->shell);
+    CogShell *shell = userdata;
+    struct wpe_view_backend* backend = cog_shell_get_active_wpe_backend (shell);
     struct wpe_input_pointer_event event = {
         wpe_input_pointer_event_type_motion,
-        cb_userdata->wl_data->pointer.time,
-        cb_userdata->wl_data->pointer.x * cb_userdata->wl_data->current_output.scale,
-        cb_userdata->wl_data->pointer.y * cb_userdata->wl_data->current_output.scale,
-        cb_userdata->wl_data->pointer.button,
-        cb_userdata->wl_data->pointer.state
+        display->pointer.time,
+        display->pointer.x * wl_data.current_output.scale,
+        display->pointer.y * wl_data.current_output.scale,
+        display->pointer.button,
+        display->pointer.state
     };
     wpe_view_backend_dispatch_pointer_event (backend, &event);
 }
@@ -123,15 +123,15 @@ on_pointer_on_motion (PwlDisplay* display, void *userdata)
 static void
 on_pointer_on_button (PwlDisplay* display, void *userdata)
 {
-    CogFdoShellCallbackData *cb_userdata = userdata;
-    struct wpe_view_backend* backend = cog_shell_get_active_wpe_backend (cb_userdata->shell);
+    CogShell *shell = userdata;
+    struct wpe_view_backend* backend = cog_shell_get_active_wpe_backend (shell);
     struct wpe_input_pointer_event event = {
         wpe_input_pointer_event_type_button,
-        cb_userdata->wl_data->pointer.time,
-        cb_userdata->wl_data->pointer.x * cb_userdata->wl_data->current_output.scale,
-        cb_userdata->wl_data->pointer.y * cb_userdata->wl_data->current_output.scale,
-        cb_userdata->wl_data->pointer.button,
-        cb_userdata->wl_data->pointer.state,
+        display->pointer.time,
+        display->pointer.x * wl_data.current_output.scale,
+        display->pointer.y * wl_data.current_output.scale,
+        display->pointer.button,
+        display->pointer.state,
     };
     wpe_view_backend_dispatch_pointer_event (backend, &event);
 }
@@ -139,15 +139,15 @@ on_pointer_on_button (PwlDisplay* display, void *userdata)
 static void
 on_pointer_on_axis (PwlDisplay* display, void *userdata)
 {
-    CogFdoShellCallbackData *cb_userdata = userdata;
-    struct wpe_view_backend* backend = cog_shell_get_active_wpe_backend (cb_userdata->shell);
+    CogShell *shell = userdata;
+    struct wpe_view_backend* backend = cog_shell_get_active_wpe_backend (shell);
     struct wpe_input_axis_event event = {
         wpe_input_axis_event_type_motion,
-        cb_userdata->wl_data->pointer.time,
-        cb_userdata->wl_data->pointer.x * cb_userdata->wl_data->current_output.scale,
-        cb_userdata->wl_data->pointer.y * cb_userdata->wl_data->current_output.scale,
-        cb_userdata->wl_data->pointer.axis,
-        cb_userdata->wl_data->pointer.value,
+        display->pointer.time,
+        display->pointer.x * wl_data.current_output.scale,
+        display->pointer.y * wl_data.current_output.scale,
+        display->pointer.axis,
+        display->pointer.value,
     };
     wpe_view_backend_dispatch_axis_event (backend, &event);
 }
@@ -602,11 +602,11 @@ cog_fdo_shell_initable_init (GInitable *initable,
     s_pdisplay->on_surface_enter_userdata = s_callback_userdata;
 #endif /* HAVE_DEVICE_SCALING */
     s_pdisplay->on_pointer_on_motion = on_pointer_on_motion;
-    s_pdisplay->on_pointer_on_motion_userdata = s_callback_userdata;
+    s_pdisplay->on_pointer_on_motion_userdata = initable;
     s_pdisplay->on_pointer_on_button = on_pointer_on_button;
-    s_pdisplay->on_pointer_on_button_userdata = s_callback_userdata;
+    s_pdisplay->on_pointer_on_button_userdata = initable;
     s_pdisplay->on_pointer_on_axis = on_pointer_on_axis;
-    s_pdisplay->on_pointer_on_axis_userdata = s_callback_userdata;
+    s_pdisplay->on_pointer_on_axis_userdata = initable;
 
     s_pdisplay->on_touch_on_down = on_touch_on_down;
     s_pdisplay->on_touch_on_down_userdata = s_callback_userdata;

--- a/modules/cog-fdo-shell.c
+++ b/modules/cog-fdo-shell.c
@@ -619,7 +619,6 @@ cog_fdo_shell_initable_init (GInitable *initable,
     }
 
     TRACE ("");
-    s_pdisplay->userdata = initable;
     s_win_data = g_new0 (PwlWinData, 1);
     s_callback_userdata = g_new0 (CogFdoShellCallbackData, 1);
     s_callback_userdata->shell = (CogShell*) initable;

--- a/modules/cog-fdo-shell.c
+++ b/modules/cog-fdo-shell.c
@@ -437,7 +437,7 @@ request_frame (struct wpe_view_backend_exportable_fdo *exportable)
 static void
 on_buffer_release (void* data, struct wl_buffer* buffer)
 {
-    WpeViewBackendData *backend_data = (WpeViewBackendData*) data;
+    WpeViewBackendData *backend_data = data;
 
     /* TODO: These asserts might be unnecessary, but having for now. */
     g_assert (backend_data);
@@ -458,7 +458,7 @@ static const struct wl_buffer_listener buffer_listener = {
 static void
 on_export_fdo_egl_image (void *data, struct wpe_fdo_egl_exported_image *image)
 {
-    WpeViewBackendData *backend_data = (WpeViewBackendData*) data;
+    WpeViewBackendData *backend_data = data;
     g_assert (backend_data);
 
     backend_data->image = image;

--- a/modules/cog-fdo-shell.c
+++ b/modules/cog-fdo-shell.c
@@ -117,7 +117,8 @@ cog_shell_get_active_wpe_backend (CogShell *shell)
 static void
 surface_handle_enter (void *data, struct wl_surface *surface, struct wl_output *output)
 {
-    CogShell *shell = COG_SHELL (data);
+    PwlDisplay *display = (PwlDisplay*) data;
+    CogShell *shell = (CogShell*) display->userdata;
 
     struct wpe_view_backend* backend = cog_shell_get_active_wpe_backend (shell);
 
@@ -167,7 +168,8 @@ pointer_on_motion (void* data,
                    wl_fixed_t fixed_x,
                    wl_fixed_t fixed_y)
 {
-    CogShell *shell = COG_SHELL (data);
+    PwlDisplay *display = (PwlDisplay*) data;
+    CogShell *shell = (CogShell*) display->userdata;
 
     struct wpe_view_backend* backend = cog_shell_get_active_wpe_backend (shell);
 
@@ -193,7 +195,8 @@ pointer_on_button (void* data,
                    uint32_t button,
                    uint32_t state)
 {
-    CogShell *shell = COG_SHELL (data);
+    PwlDisplay *display = (PwlDisplay*) data;
+    CogShell *shell = (CogShell*) display->userdata;
 
     struct wpe_view_backend* backend = cog_shell_get_active_wpe_backend (shell);
 
@@ -226,7 +229,8 @@ pointer_on_axis (void* data,
                  uint32_t axis,
                  wl_fixed_t value)
 {
-    CogShell *shell = COG_SHELL (data);
+    PwlDisplay *display = (PwlDisplay*) data;
+    CogShell *shell = (CogShell*) display->userdata;
 
     struct wpe_view_backend* backend = cog_shell_get_active_wpe_backend (shell);
 
@@ -293,7 +297,8 @@ touch_on_down (void *data,
     if (id < 0 || id >= 10)
         return;
 
-    CogShell *shell = COG_SHELL (data);
+    PwlDisplay *display = (PwlDisplay*) data;
+    CogShell *shell = (CogShell*) display->userdata;
 
     struct wpe_view_backend* backend = cog_shell_get_active_wpe_backend (shell);
 
@@ -330,7 +335,8 @@ touch_on_up (void *data,
     if (id < 0 || id >= 10)
         return;
 
-    CogShell *shell = COG_SHELL (data);
+    PwlDisplay *display = (PwlDisplay*) data;
+    CogShell *shell = (CogShell*) display->userdata;
 
     struct wpe_view_backend* backend = cog_shell_get_active_wpe_backend (shell);
 
@@ -372,7 +378,8 @@ touch_on_motion (void *data,
     if (id < 0 || id >= 10)
         return;
 
-    CogShell *shell = COG_SHELL (data);
+    PwlDisplay *display = (PwlDisplay*) data;
+    CogShell *shell = (CogShell*) display->userdata;
 
     struct wpe_view_backend* backend = cog_shell_get_active_wpe_backend (shell);
 
@@ -497,7 +504,7 @@ cog_fdo_shell_class_finalize (CogFdoShellClass *klass)
     wpe_view_backend_exportable_fdo_destroy (wpe_host_data.exportable);
     * /
 */
-    clear_input ();
+    clear_input (s_pdisplay);
 
     destroy_window (s_pdisplay);
     pwl_display_egl_deinit (s_pdisplay);
@@ -510,7 +517,9 @@ resize_window (void *data)
     int32_t pixel_width = win_data.width * wl_data.current_output.scale;
     int32_t pixel_height = win_data.height * wl_data.current_output.scale;
 
-    CogShell *shell = COG_SHELL (data);
+    PwlDisplay *display = (PwlDisplay*) data;
+    CogShell *shell = (CogShell*) display->userdata;
+
     struct wpe_view_backend* backend = cog_shell_get_active_wpe_backend (shell);
 
     if (win_data.egl_window)
@@ -598,7 +607,8 @@ capture_app_key_bindings (uint32_t keysym,
 static void
 handle_key_event (void *data, uint32_t key, uint32_t state, uint32_t time)
 {
-    CogShell *shell = COG_SHELL (data);
+    PwlDisplay *display = (PwlDisplay*) data;
+    CogShell *shell = (CogShell*) display->userdata;
 
     struct wpe_view_backend* backend = cog_shell_get_active_wpe_backend (shell);
 
@@ -795,6 +805,7 @@ cog_fdo_shell_initable_init (GInitable *initable,
     }
 
     TRACE ("");
+    s_pdisplay->userdata = initable;
 
 #if HAVE_DEVICE_SCALING
     const struct wl_output_listener output_listener = {
@@ -818,7 +829,7 @@ cog_fdo_shell_initable_init (GInitable *initable,
     if (!pwl_display_egl_init (s_pdisplay, error))
         return FALSE;
 
-    if (!create_window (s_pdisplay, (void*)initable, error)) {
+    if (!create_window (s_pdisplay, error)) {
         pwl_display_egl_deinit (s_pdisplay);
         return FALSE;
     }
@@ -861,7 +872,7 @@ cog_fdo_shell_initable_init (GInitable *initable,
     };
     wl_data.touch.listener = touch_listener;
 
-    if (!init_input ((void*)initable, error)) {
+    if (!init_input (s_pdisplay, error)) {
         destroy_window (s_pdisplay);
         pwl_display_egl_deinit (s_pdisplay);
         return FALSE;

--- a/platform/pwl.c
+++ b/platform/pwl.c
@@ -148,6 +148,27 @@ setup_wayland_event_source (GMainContext *main_context,
 }
 
 static void
+resize_window (PwlWinData *win_data)
+{
+    int32_t pixel_width = win_data->width * wl_data.current_output.scale;
+    int32_t pixel_height = win_data->height * wl_data.current_output.scale;
+
+    if (win_data->egl_window)
+        wl_egl_window_resize (win_data->egl_window,
+			                pixel_width,
+			                pixel_height,
+			                0, 0);
+
+    g_debug ("Resized EGL buffer to: (%u, %u) @%ix\n",
+            pixel_width, pixel_height, wl_data.current_output.scale);
+
+    if (win_data->on_window_resize) {
+        (*win_data->on_window_resize) (win_data, win_data->on_window_resize_userdata);
+    }
+}
+
+
+static void
 configure_surface_geometry (PwlWinData *win_data, int32_t width, int32_t height)
 {
     const char* env_var;
@@ -189,7 +210,7 @@ shell_surface_configure (void *data,
 
     g_debug ("New wl_shell configuration: (%" PRIu32 ", %" PRIu32 ")", width, height);
 
-    wl_data.resize_window (win_data);
+    resize_window (win_data);
 }
 
 static const struct wl_shell_surface_listener shell_surface_listener = {
@@ -457,7 +478,7 @@ xdg_toplevel_on_configure (void *data,
 
     g_debug ("New XDG toplevel configuration: (%" PRIu32 ", %" PRIu32 ")", width, height);
 
-    wl_data.resize_window (data);
+    resize_window (data);
 }
 
 static void

--- a/platform/pwl.c
+++ b/platform/pwl.c
@@ -760,7 +760,15 @@ seat_on_capabilities (void* data, struct wl_seat* seat, uint32_t capabilities)
     if (has_keyboard && wl_data.keyboard.obj == NULL) {
         wl_data.keyboard.obj = wl_seat_get_keyboard (display->seat);
         g_assert (wl_data.keyboard.obj);
-        wl_keyboard_add_listener (wl_data.keyboard.obj, &wl_data.keyboard.listener, data);
+        static const struct wl_keyboard_listener keyboard_listener = {
+            .keymap = keyboard_on_keymap,
+            .enter = keyboard_on_enter,
+            .leave = keyboard_on_leave,
+            .key = keyboard_on_key,
+            .modifiers = keyboard_on_modifiers,
+            .repeat_info = keyboard_on_repeat_info,
+        };
+        wl_keyboard_add_listener (wl_data.keyboard.obj, &keyboard_listener, data);
         g_debug ("  - Keyboard");
     } else if (! has_keyboard && wl_data.keyboard.obj != NULL) {
         wl_keyboard_release (wl_data.keyboard.obj);

--- a/platform/pwl.c
+++ b/platform/pwl.c
@@ -840,10 +840,10 @@ touch_on_down (void *data,
         return;
 
     PwlDisplay *display = data;
-    wl_data.touch.id = id;
-    wl_data.touch.time = time;
-    wl_data.touch.x = x;
-    wl_data.touch.y = y;
+    display->touch.id = id;
+    display->touch.time = time;
+    display->touch.x = x;
+    display->touch.y = y;
     if (display->on_touch_on_down) {
         display->on_touch_on_down (display, display->on_touch_on_down_userdata);
     }
@@ -858,9 +858,9 @@ touch_on_up (void *data,
 {
     if (id < 0 || id >= 10)
         return;
-    wl_data.touch.id = id;
-    wl_data.touch.time = time;
     PwlDisplay *display = data;
+    display->touch.id = id;
+    display->touch.time = time;
     if (display->on_touch_on_up) {
         display->on_touch_on_up (display, display->on_touch_on_up_userdata);
     }
@@ -876,11 +876,11 @@ touch_on_motion (void *data,
 {
     if (id < 0 || id >= 10)
         return;
-    wl_data.touch.id = id;
-    wl_data.touch.time = time;
-    wl_data.touch.x = x;
-    wl_data.touch.y = y;
     PwlDisplay *display = (PwlDisplay*) data;
+    display->touch.id = id;
+    display->touch.time = time;
+    display->touch.x = x;
+    display->touch.y = y;
     if (display->on_touch_on_motion) {
         display->on_touch_on_motion (display, display->on_touch_on_motion_userdata);
     }
@@ -1123,9 +1123,9 @@ seat_on_capabilities (void* data, struct wl_seat* seat, uint32_t capabilities)
 
     /* Touch */
     const bool has_touch = capabilities & WL_SEAT_CAPABILITY_TOUCH;
-    if (has_touch && wl_data.touch.obj == NULL) {
-        wl_data.touch.obj = wl_seat_get_touch (display->seat);
-        g_assert (wl_data.touch.obj);
+    if (has_touch && display->touch.obj == NULL) {
+        display->touch.obj = wl_seat_get_touch (display->seat);
+        g_assert (display->touch.obj);
         static const struct wl_touch_listener touch_listener = {
             .down = touch_on_down,
             .up = touch_on_up,
@@ -1133,11 +1133,11 @@ seat_on_capabilities (void* data, struct wl_seat* seat, uint32_t capabilities)
             .frame = touch_on_frame,
             .cancel = touch_on_cancel,
         };
-        wl_touch_add_listener (wl_data.touch.obj, &touch_listener, data);
+        wl_touch_add_listener (display->touch.obj, &touch_listener, data);
         g_debug ("  - Touch");
-    } else if (! has_touch && wl_data.touch.obj != NULL) {
-        wl_touch_release (wl_data.touch.obj);
-        wl_data.touch.obj = NULL;
+    } else if (! has_touch && display->touch.obj != NULL) {
+        wl_touch_release (display->touch.obj);
+        display->touch.obj = NULL;
     }
 
     g_debug ("Done enumerating seat capabilities.");

--- a/platform/pwl.c
+++ b/platform/pwl.c
@@ -734,7 +734,7 @@ touch_on_down (void *data,
     wl_data.touch.x = x;
     wl_data.touch.y = y;
     if (display->on_touch_on_down) {
-        display->on_touch_on_down (display, display->userdata);
+        display->on_touch_on_down (display, display->on_touch_on_down_userdata);
     }
 }
 
@@ -751,7 +751,7 @@ touch_on_up (void *data,
     wl_data.touch.time = time;
     PwlDisplay *display = data;
     if (display->on_touch_on_up) {
-        display->on_touch_on_up (display, display->userdata);
+        display->on_touch_on_up (display, display->on_touch_on_up_userdata);
     }
 }
 
@@ -771,7 +771,7 @@ touch_on_motion (void *data,
     wl_data.touch.y = y;
     PwlDisplay *display = (PwlDisplay*) data;
     if (display->on_touch_on_motion) {
-        display->on_touch_on_motion (display, display->userdata);
+        display->on_touch_on_motion (display, display->on_touch_on_motion_userdata);
     }
 }
 

--- a/platform/pwl.c
+++ b/platform/pwl.c
@@ -152,7 +152,7 @@ output_handle_scale (void *data,
                      struct wl_output *output,
                      int32_t factor)
 {
-    PwlDisplay *display = (PwlDisplay*) data;
+    PwlDisplay *display = data;
     bool found = false;
     for (int i = 0; i < G_N_ELEMENTS (display->metrics); i++)
     {
@@ -314,7 +314,7 @@ shell_surface_configure (void *data,
                          uint32_t edges,
                          int32_t width, int32_t height)
 {
-    PwlWinData *win_data = (PwlWinData*) data;
+    PwlWinData *win_data = data;
     configure_surface_geometry (win_data, width, height);
 
     g_debug ("New wl_shell configuration: (%" PRIu32 ", %" PRIu32 ")", width, height);
@@ -344,7 +344,7 @@ registry_global (void               *data,
                  const char         *interface,
                  uint32_t            version)
 {
-    PwlDisplay *display = (PwlDisplay*) data;
+    PwlDisplay *display = data;
     gboolean interface_used = TRUE;
 
     if (strcmp (interface, wl_compositor_interface.name) == 0) {
@@ -412,7 +412,7 @@ registry_global (void               *data,
 static void
 registry_global_remove (void *data, struct wl_registry *registry, uint32_t name)
 {
-    PwlDisplay *display = (PwlDisplay*) data;
+    PwlDisplay *display = data;
     for (int i = 0; i < G_N_ELEMENTS (display->metrics); i++)
     {
         if (display->metrics[i].name == name) {
@@ -560,7 +560,7 @@ xdg_toplevel_on_configure (void *data,
                            int32_t width, int32_t height,
                            struct wl_array *states)
 {
-    PwlWinData *win_data = (PwlWinData*) data;
+    PwlWinData *win_data = data;
     configure_surface_geometry (win_data, width, height);
 
     g_debug ("New XDG toplevel configuration: (%" PRIu32 ", %" PRIu32 ")", width, height);
@@ -873,7 +873,7 @@ touch_on_motion (void *data,
 {
     if (id < 0 || id >= 10)
         return;
-    PwlDisplay *display = (PwlDisplay*) data;
+    PwlDisplay *display = data;
     display->touch.id = id;
     display->touch.time = time;
     display->touch.x = x;
@@ -902,7 +902,7 @@ keyboard_on_keymap (void *data,
                     int32_t fd,
                     uint32_t size)
 {
-    PwlDisplay *display = (PwlDisplay*) data;
+    PwlDisplay *display = data;
 
     if (format != WL_KEYBOARD_KEYMAP_FORMAT_XKB_V1) {
         close (fd);
@@ -945,7 +945,7 @@ keyboard_on_enter (void *data,
                    struct wl_surface *surface,
                    struct wl_array *keys)
 {
-    PwlDisplay *display = (PwlDisplay*) data;
+    PwlDisplay *display = data;
     display->keyboard.serial = serial;
 }
 
@@ -955,14 +955,14 @@ keyboard_on_leave (void *data,
                    uint32_t serial,
                    struct wl_surface *surface)
 {
-    PwlDisplay *display = (PwlDisplay*) data;
+    PwlDisplay *display = data;
     display->keyboard.serial = serial;
 }
 
 gboolean
 repeat_delay_timeout (void *data)
 {
-    PwlDisplay *display = (PwlDisplay*) data;
+    PwlDisplay *display = data;
     handle_key_event (data, display->keyboard.repeat_data.key,
                       display->keyboard.repeat_data.state,
                       display->keyboard.repeat_data.time);
@@ -982,7 +982,7 @@ keyboard_on_key (void *data,
                  uint32_t key,
                  uint32_t state)
 {
-    PwlDisplay *display = (PwlDisplay*) data;
+    PwlDisplay *display = data;
     /* @FIXME: investigate why is this necessary */
     // IDK.
     key += 8;
@@ -1024,7 +1024,7 @@ keyboard_on_modifiers (void *data,
                        uint32_t mods_locked,
                        uint32_t group)
 {
-    PwlDisplay *display = (PwlDisplay*) data;
+    PwlDisplay *display = data;
     xkb_state_update_mask (display->xkb_data.state,
                            mods_depressed,
                            mods_latched,
@@ -1060,7 +1060,7 @@ keyboard_on_repeat_info (void *data,
                          int32_t rate,
                          int32_t delay)
 {
-    PwlDisplay *display = (PwlDisplay*) data;
+    PwlDisplay *display = data;
     display->keyboard.repeat_info.rate = rate;
     display->keyboard.repeat_info.delay = delay;
 
@@ -1078,7 +1078,7 @@ static void
 seat_on_capabilities (void* data, struct wl_seat* seat, uint32_t capabilities)
 {
     g_debug ("Enumerating seat capabilities:");
-    PwlDisplay *display = (PwlDisplay*) data;
+    PwlDisplay *display = data;
 
     /* Pointer */
     static const struct wl_pointer_listener pointer_listener = {

--- a/platform/pwl.c
+++ b/platform/pwl.c
@@ -739,9 +739,9 @@ pointer_on_motion (void* data,
                    wl_fixed_t fixed_y)
 {
     PwlDisplay *display = data;
-    wl_data.pointer.time = time;
-    wl_data.pointer.x = wl_fixed_to_int (fixed_x);
-    wl_data.pointer.y = wl_fixed_to_int (fixed_y);
+    display->pointer.time = time;
+    display->pointer.x = wl_fixed_to_int (fixed_x);
+    display->pointer.y = wl_fixed_to_int (fixed_y);
     if (display->on_pointer_on_motion) {
         display->on_pointer_on_motion (display, display->on_pointer_on_motion_userdata);
     }
@@ -764,9 +764,9 @@ pointer_on_button (void* data,
         button = 0;
     */
 
-    wl_data.pointer.button = !!state ? button : 0;
-    wl_data.pointer.state = state;
-    wl_data.pointer.time = time;
+    display->pointer.button = !!state ? button : 0;
+    display->pointer.state = state;
+    display->pointer.time = time;
 
     if (display->on_pointer_on_button) {
         display->on_pointer_on_button (display, display->on_pointer_on_button_userdata);
@@ -781,9 +781,9 @@ pointer_on_axis (void* data,
                  wl_fixed_t value)
 {
     PwlDisplay *display = data;
-    wl_data.pointer.axis = axis;
-    wl_data.pointer.time = time;
-    wl_data.pointer.value = wl_fixed_to_int(value) > 0 ? -1 : 1;
+    display->pointer.axis = axis;
+    display->pointer.time = time;
+    display->pointer.value = wl_fixed_to_int(value) > 0 ? -1 : 1;
     if (display->on_pointer_on_axis) {
         display->on_pointer_on_axis (display, display->on_pointer_on_axis_userdata);
     }
@@ -1090,15 +1090,15 @@ seat_on_capabilities (void* data, struct wl_seat* seat, uint32_t capabilities)
     #endif /* WAYLAND_1_10_OR_GREATER */
     };
     const bool has_pointer = capabilities & WL_SEAT_CAPABILITY_POINTER;
-    if (has_pointer && wl_data.pointer.obj == NULL) {
-        wl_data.pointer.obj = wl_seat_get_pointer (display->seat);
-        g_assert (wl_data.pointer.obj);
+    if (has_pointer && display->pointer.obj == NULL) {
+        display->pointer.obj = wl_seat_get_pointer (display->seat);
+        g_assert (display->pointer.obj);
         g_assert (data);
-        wl_pointer_add_listener (wl_data.pointer.obj, &pointer_listener, data);
+        wl_pointer_add_listener (display->pointer.obj, &pointer_listener, data);
         g_debug ("  - Pointer");
-    } else if (! has_pointer && wl_data.pointer.obj != NULL) {
-        wl_pointer_release (wl_data.pointer.obj);
-        wl_data.pointer.obj = NULL;
+    } else if (! has_pointer && display->pointer.obj != NULL) {
+        wl_pointer_release (display->pointer.obj);
+        display->pointer.obj = NULL;
     }
 
     /* Keyboard */
@@ -1178,7 +1178,7 @@ gboolean init_input (PwlDisplay *display, GError **error)
 
 void clear_input (PwlDisplay* display)
 {
-    g_clear_pointer (&wl_data.pointer.obj, wl_pointer_destroy);
+    g_clear_pointer (&(display->pointer.obj), wl_pointer_destroy);
     g_clear_pointer (&wl_data.keyboard.obj, wl_keyboard_destroy);
     g_clear_pointer (&(display->seat), wl_seat_destroy);
 

--- a/platform/pwl.c
+++ b/platform/pwl.c
@@ -632,7 +632,7 @@ pointer_on_motion (void* data,
     wl_data.pointer.x = wl_fixed_to_int (fixed_x);
     wl_data.pointer.y = wl_fixed_to_int (fixed_y);
     if (display->on_pointer_on_motion) {
-        display->on_pointer_on_motion (display, display->userdata);
+        display->on_pointer_on_motion (display, display->on_pointer_on_motion_userdata);
     }
 }
 
@@ -658,7 +658,7 @@ pointer_on_button (void* data,
     wl_data.pointer.time = time;
 
     if (display->on_pointer_on_button) {
-        display->on_pointer_on_button (display, display->userdata);
+        display->on_pointer_on_button (display, display->on_pointer_on_button_userdata);
     }
 }
 
@@ -674,7 +674,7 @@ pointer_on_axis (void* data,
     wl_data.pointer.time = time;
     wl_data.pointer.value = wl_fixed_to_int(value) > 0 ? -1 : 1;
     if (display->on_pointer_on_axis) {
-        display->on_pointer_on_axis (display, display->userdata);
+        display->on_pointer_on_axis (display, display->on_pointer_on_axis_userdata);
     }
 }
 #if WAYLAND_1_10_OR_GREATER

--- a/platform/pwl.c
+++ b/platform/pwl.c
@@ -298,7 +298,9 @@ surface_handle_enter (void *data, struct wl_surface *surface, struct wl_output *
     g_debug ("Surface entered output %p with scale factor %i\n", output, scale_factor);
     wl_surface_set_buffer_scale (surface, scale_factor);
     wl_data.current_output.scale = scale_factor;
-    display->on_surface_enter(display, display->userdata);
+    if (display->on_surface_enter) {
+        display->on_surface_enter(display, display->on_surface_enter_userdata);
+    }
 }
 static void
 registry_global_remove (void *data, struct wl_registry *registry, uint32_t name)

--- a/platform/pwl.c
+++ b/platform/pwl.c
@@ -248,7 +248,7 @@ registry_global (void               *data,
                                            &zwp_fullscreen_shell_v1_interface,
                                            version);
     } else if (strcmp (interface, wl_seat_interface.name) == 0) {
-        wl_data.seat = wl_registry_bind (registry,
+        display->seat = wl_registry_bind (registry,
                                          name,
                                          &wl_seat_interface,
                                          version);
@@ -746,7 +746,7 @@ seat_on_capabilities (void* data, struct wl_seat* seat, uint32_t capabilities)
     /* Pointer */
     const bool has_pointer = capabilities & WL_SEAT_CAPABILITY_POINTER;
     if (has_pointer && wl_data.pointer.obj == NULL) {
-        wl_data.pointer.obj = wl_seat_get_pointer (wl_data.seat);
+        wl_data.pointer.obj = wl_seat_get_pointer (display->seat);
         g_assert (wl_data.pointer.obj);
         wl_pointer_add_listener (wl_data.pointer.obj, &wl_data.pointer.listener, data);
         g_debug ("  - Pointer");
@@ -758,7 +758,7 @@ seat_on_capabilities (void* data, struct wl_seat* seat, uint32_t capabilities)
     /* Keyboard */
     const bool has_keyboard = capabilities & WL_SEAT_CAPABILITY_KEYBOARD;
     if (has_keyboard && wl_data.keyboard.obj == NULL) {
-        wl_data.keyboard.obj = wl_seat_get_keyboard (wl_data.seat);
+        wl_data.keyboard.obj = wl_seat_get_keyboard (display->seat);
         g_assert (wl_data.keyboard.obj);
         wl_keyboard_add_listener (wl_data.keyboard.obj, &wl_data.keyboard.listener, data);
         g_debug ("  - Keyboard");
@@ -770,7 +770,7 @@ seat_on_capabilities (void* data, struct wl_seat* seat, uint32_t capabilities)
     /* Touch */
     const bool has_touch = capabilities & WL_SEAT_CAPABILITY_TOUCH;
     if (has_touch && wl_data.touch.obj == NULL) {
-        wl_data.touch.obj = wl_seat_get_touch (wl_data.seat);
+        wl_data.touch.obj = wl_seat_get_touch (display->seat);
         g_assert (wl_data.touch.obj);
         wl_touch_add_listener (wl_data.touch.obj, &wl_data.touch.listener, data);
         g_debug ("  - Touch");
@@ -796,8 +796,8 @@ static const struct wl_seat_listener seat_listener = {
 
 gboolean init_input (PwlDisplay *display, GError **error)
 {
-    if (wl_data.seat != NULL) {
-        wl_seat_add_listener (wl_data.seat, &seat_listener, display);
+    if (display->seat != NULL) {
+        wl_seat_add_listener (display->seat, &seat_listener, display);
 
         xkb_data.context = xkb_context_new (XKB_CONTEXT_NO_FLAGS);
         g_assert (xkb_data.context);
@@ -819,7 +819,7 @@ void clear_input (PwlDisplay* display)
 {
     g_clear_pointer (&wl_data.pointer.obj, wl_pointer_destroy);
     g_clear_pointer (&wl_data.keyboard.obj, wl_keyboard_destroy);
-    g_clear_pointer (&wl_data.seat, wl_seat_destroy);
+    g_clear_pointer (&(display->seat), wl_seat_destroy);
 
     g_clear_pointer (&xkb_data.state, xkb_state_unref);
     g_clear_pointer (&xkb_data.compose_state, xkb_compose_state_unref);

--- a/platform/pwl.h
+++ b/platform/pwl.h
@@ -35,7 +35,9 @@
 
 G_BEGIN_DECLS
 
-typedef struct {
+typedef struct _PwlDisplay PwlDisplay;
+
+struct _PwlDisplay {
     struct wl_display *display;
     struct wl_registry *registry;
     struct wl_compositor *compositor;
@@ -43,8 +45,11 @@ typedef struct {
     struct egl_display *egl_display;
     EGLContext egl_context;
     EGLConfig egl_config;
+
+    void (*on_surface_enter) (PwlDisplay*, void *userdata);
+
     void *userdata;
-} PwlDisplay;
+};
 
 typedef struct {
     struct xkb_context* context;

--- a/platform/pwl.h
+++ b/platform/pwl.h
@@ -50,6 +50,10 @@ struct _PwlDisplay {
     void (*on_pointer_on_motion) (PwlDisplay*, void *userdata);
     void (*on_pointer_on_button) (PwlDisplay*, void *userdata);
     void (*on_pointer_on_axis) (PwlDisplay*, void *userdata);
+    
+    void (*on_touch_on_down)     (PwlDisplay*, void *userdata);
+    void (*on_touch_on_up)       (PwlDisplay*, void *userdata);
+    void (*on_touch_on_motion)   (PwlDisplay*, void *userdata);
 
     void *userdata;
 };
@@ -129,7 +133,10 @@ typedef struct {
 
     struct {
         struct wl_touch *obj;
-        struct wl_touch_listener listener;
+        int32_t id;
+        uint32_t time;
+        wl_fixed_t x;
+        wl_fixed_t y;
     } touch;
 
     GSource *event_src;

--- a/platform/pwl.h
+++ b/platform/pwl.h
@@ -42,6 +42,7 @@ typedef struct {
     struct egl_display *egl_display;
     EGLContext egl_context;
     EGLConfig egl_config;
+    void *userdata;
 } PwlDisplay;
 
 typedef struct {
@@ -172,11 +173,11 @@ void pwl_display_egl_deinit (PwlDisplay*);
 
 gboolean init_wayland (PwlDisplay*, GError **error);
 
-gboolean create_window (PwlDisplay*, void *data, GError **error);
+gboolean create_window (PwlDisplay*, GError **error);
 void destroy_window (PwlDisplay*);
 
-gboolean init_input (void *data, GError **error);
-void clear_input (void);
+gboolean init_input (PwlDisplay*, GError **error);
+void clear_input (PwlDisplay*);
 
 /* Keyboard */
 void

--- a/platform/pwl.h
+++ b/platform/pwl.h
@@ -49,8 +49,11 @@ struct _PwlDisplay {
     void (*on_surface_enter) (PwlDisplay*, void *userdata);
     void *on_surface_enter_userdata;
     void (*on_pointer_on_motion) (PwlDisplay*, void *userdata);
+    void *on_pointer_on_motion_userdata;
     void (*on_pointer_on_button) (PwlDisplay*, void *userdata);
+    void *on_pointer_on_button_userdata;
     void (*on_pointer_on_axis) (PwlDisplay*, void *userdata);
+    void *on_pointer_on_axis_userdata;
     
     void (*on_touch_on_down)     (PwlDisplay*, void *userdata);
     void (*on_touch_on_up)       (PwlDisplay*, void *userdata);

--- a/platform/pwl.h
+++ b/platform/pwl.h
@@ -62,6 +62,11 @@ struct _PwlDisplay {
     void (*on_touch_on_motion)   (PwlDisplay*, void *userdata);
     void *on_touch_on_motion_userdata;
 
+    void (*on_key_event) (PwlDisplay*, void *userdata);
+    void *on_key_event_userdata;
+    bool (*on_capture_app_key) (PwlDisplay*, void *userdata);
+    void *on_capture_app_key_userdata;
+
     void *userdata;
 };
 
@@ -135,6 +140,14 @@ typedef struct {
             uint32_t event_source;
         } repeat_data;
 
+        struct {
+            uint32_t keysym;
+            uint32_t unicode;
+            uint32_t state;
+            uint8_t modifiers;
+            uint32_t timestamp;
+        } event;
+
         uint32_t serial;
     } keyboard;
 
@@ -147,8 +160,6 @@ typedef struct {
     } touch;
 
     GSource *event_src;
-
-    void (*handle_key_event)(void* data, uint32_t key, uint32_t state, uint32_t time);
 
     struct wl_output_listener output_listener;
 } PwlData;

--- a/platform/pwl.h
+++ b/platform/pwl.h
@@ -39,6 +39,7 @@ typedef struct {
     struct wl_display *display;
     struct wl_registry *registry;
     struct wl_compositor *compositor;
+    struct wl_seat *seat;
     struct egl_display *egl_display;
     EGLContext egl_context;
     EGLConfig egl_config;
@@ -80,8 +81,6 @@ typedef struct {
     struct xdg_wm_base *xdg_shell;
     struct zwp_fullscreen_shell_v1 *fshell;
     struct wl_shell *shell;
-
-    struct wl_seat *seat;
 
 #if HAVE_DEVICE_SCALING
     struct output_metrics metrics[16];

--- a/platform/pwl.h
+++ b/platform/pwl.h
@@ -47,6 +47,7 @@ struct _PwlDisplay {
     EGLConfig egl_config;
 
     void (*on_surface_enter) (PwlDisplay*, void *userdata);
+    void *on_surface_enter_userdata;
     void (*on_pointer_on_motion) (PwlDisplay*, void *userdata);
     void (*on_pointer_on_button) (PwlDisplay*, void *userdata);
     void (*on_pointer_on_axis) (PwlDisplay*, void *userdata);

--- a/platform/pwl.h
+++ b/platform/pwl.h
@@ -35,6 +35,14 @@
 
 G_BEGIN_DECLS
 
+#if HAVE_DEVICE_SCALING
+typedef struct output_metrics {
+  struct wl_output *output;
+  int32_t name;
+  int32_t scale;
+} output_metrics;
+#endif /* HAVE_DEVICE_SCALING */
+
 typedef struct {
     struct wl_keyboard *obj;
 
@@ -81,43 +89,6 @@ typedef struct {
     wl_fixed_t y;
 } PwlTouch;
 
-typedef struct _PwlDisplay PwlDisplay;
-
-struct _PwlDisplay {
-    struct wl_display *display;
-    struct wl_registry *registry;
-    struct wl_compositor *compositor;
-    struct wl_seat *seat;
-    struct egl_display *egl_display;
-    EGLContext egl_context;
-    EGLConfig egl_config;
-
-    PwlKeyboard keyboard;
-    PwlPointer pointer;
-    PwlTouch touch;
-
-    void (*on_surface_enter) (PwlDisplay*, void *userdata);
-    void *on_surface_enter_userdata;
-    void (*on_pointer_on_motion) (PwlDisplay*, void *userdata);
-    void *on_pointer_on_motion_userdata;
-    void (*on_pointer_on_button) (PwlDisplay*, void *userdata);
-    void *on_pointer_on_button_userdata;
-    void (*on_pointer_on_axis) (PwlDisplay*, void *userdata);
-    void *on_pointer_on_axis_userdata;
-    
-    void (*on_touch_on_down)     (PwlDisplay*, void *userdata);
-    void *on_touch_on_down_userdata;
-    void (*on_touch_on_up)       (PwlDisplay*, void *userdata);
-    void *on_touch_on_up_userdata;
-    void (*on_touch_on_motion)   (PwlDisplay*, void *userdata);
-    void *on_touch_on_motion_userdata;
-
-    void (*on_key_event) (PwlDisplay*, void *userdata);
-    void *on_key_event_userdata;
-    bool (*on_capture_app_key) (PwlDisplay*, void *userdata);
-    void *on_capture_app_key_userdata;
-};
-
 typedef struct {
     struct xkb_context* context;
     struct xkb_keymap* keymap;
@@ -141,15 +112,23 @@ typedef struct {
     uint8_t modifiers;
 } PwlXKBData;
 
-#if HAVE_DEVICE_SCALING
-typedef struct output_metrics {
-  struct wl_output *output;
-  int32_t name;
-  int32_t scale;
-} output_metrics;
-#endif /* HAVE_DEVICE_SCALING */
+typedef struct _PwlDisplay PwlDisplay;
 
-typedef struct {
+struct _PwlDisplay {
+    struct wl_display *display;
+    struct wl_registry *registry;
+    struct wl_compositor *compositor;
+    struct wl_seat *seat;
+    struct egl_display *egl_display;
+    EGLContext egl_context;
+    EGLConfig egl_config;
+
+    PwlKeyboard keyboard;
+    PwlPointer pointer;
+    PwlTouch touch;
+
+    PwlXKBData xkb_data;
+
     struct xdg_wm_base *xdg_shell;
     struct zwp_fullscreen_shell_v1 *fshell;
     struct wl_shell *shell;
@@ -163,7 +142,28 @@ typedef struct {
     } current_output;
 
     GSource *event_src;
-} PwlData;
+
+    void (*on_surface_enter) (PwlDisplay*, void *userdata);
+    void *on_surface_enter_userdata;
+    void (*on_pointer_on_motion) (PwlDisplay*, void *userdata);
+    void *on_pointer_on_motion_userdata;
+    void (*on_pointer_on_button) (PwlDisplay*, void *userdata);
+    void *on_pointer_on_button_userdata;
+    void (*on_pointer_on_axis) (PwlDisplay*, void *userdata);
+    void *on_pointer_on_axis_userdata;
+
+    void (*on_touch_on_down)     (PwlDisplay*, void *userdata);
+    void *on_touch_on_down_userdata;
+    void (*on_touch_on_up)       (PwlDisplay*, void *userdata);
+    void *on_touch_on_up_userdata;
+    void (*on_touch_on_motion)   (PwlDisplay*, void *userdata);
+    void *on_touch_on_motion_userdata;
+
+    void (*on_key_event) (PwlDisplay*, void *userdata);
+    void *on_key_event_userdata;
+    bool (*on_capture_app_key) (PwlDisplay*, void *userdata);
+    void *on_capture_app_key_userdata;
+};
 
 PwlDisplay* pwl_display_connect (const char *name, GError**);
 void        pwl_display_destroy (PwlDisplay*);

--- a/platform/pwl.h
+++ b/platform/pwl.h
@@ -47,6 +47,9 @@ struct _PwlDisplay {
     EGLConfig egl_config;
 
     void (*on_surface_enter) (PwlDisplay*, void *userdata);
+    void (*on_pointer_on_motion) (PwlDisplay*, void *userdata);
+    void (*on_pointer_on_button) (PwlDisplay*, void *userdata);
+    void (*on_pointer_on_axis) (PwlDisplay*, void *userdata);
 
     void *userdata;
 };
@@ -97,11 +100,13 @@ typedef struct {
 
     struct {
         struct wl_pointer *obj;
+        uint32_t time;
+        uint32_t axis;
         int32_t x;
         int32_t y;
         uint32_t button;
         uint32_t state;
-        struct wl_pointer_listener listener;
+        wl_fixed_t value;
     } pointer;
 
     struct {

--- a/platform/pwl.h
+++ b/platform/pwl.h
@@ -146,6 +146,8 @@ struct pwl_event_source {
 };
 
 typedef struct {
+    PwlDisplay *display;
+
     struct wl_surface *wl_surface;
     struct wl_surface_listener surface_listener;
     struct wl_egl_window *egl_window;
@@ -171,8 +173,8 @@ void pwl_display_egl_deinit (PwlDisplay*);
 
 gboolean init_wayland (PwlDisplay*, GError **error);
 
-gboolean create_window (PwlDisplay*, GError **error);
-void destroy_window (PwlDisplay*);
+gboolean create_window (PwlDisplay*, PwlWinData*, GError **error);
+void destroy_window (PwlDisplay*, PwlWinData*);
 
 gboolean init_input (PwlDisplay*, GError **error);
 void clear_input (PwlDisplay*);

--- a/platform/pwl.h
+++ b/platform/pwl.h
@@ -66,8 +66,6 @@ struct _PwlDisplay {
     void *on_key_event_userdata;
     bool (*on_capture_app_key) (PwlDisplay*, void *userdata);
     void *on_capture_app_key_userdata;
-
-    void *userdata;
 };
 
 typedef struct {

--- a/platform/pwl.h
+++ b/platform/pwl.h
@@ -148,7 +148,6 @@ typedef struct {
 
     GSource *event_src;
 
-    void (*resize_window)(void* data);
     void (*handle_key_event)(void* data, uint32_t key, uint32_t state, uint32_t time);
 
     struct wl_output_listener output_listener;
@@ -169,7 +168,9 @@ struct pwl_event_source {
     struct wl_display* display;
 };
 
-typedef struct {
+typedef struct _PwlWinData PwlWinData;
+
+struct _PwlWinData {
     PwlDisplay *display;
 
     struct wl_surface *wl_surface;
@@ -186,7 +187,10 @@ typedef struct {
 
     bool is_fullscreen;
     bool is_maximized;
-} PwlWinData;
+
+    void (*on_window_resize) (PwlWinData*, void *userdata);
+    void *on_window_resize_userdata;
+};
 
 GSource *
 setup_wayland_event_source (GMainContext *main_context,

--- a/platform/pwl.h
+++ b/platform/pwl.h
@@ -35,6 +35,18 @@
 
 G_BEGIN_DECLS
 
+typedef struct {
+    struct wl_pointer *obj;
+    uint32_t time;
+    uint32_t axis;
+    int32_t x;
+    int32_t y;
+    uint32_t button;
+    uint32_t state;
+    wl_fixed_t value;
+    void *data;
+} PwlPointer;
+
 typedef struct _PwlDisplay PwlDisplay;
 
 struct _PwlDisplay {
@@ -45,6 +57,8 @@ struct _PwlDisplay {
     struct egl_display *egl_display;
     EGLContext egl_context;
     EGLConfig egl_config;
+
+    PwlPointer pointer;
 
     void (*on_surface_enter) (PwlDisplay*, void *userdata);
     void *on_surface_enter_userdata;
@@ -111,17 +125,6 @@ typedef struct {
     struct {
         int32_t scale;
     } current_output;
-
-    struct {
-        struct wl_pointer *obj;
-        uint32_t time;
-        uint32_t axis;
-        int32_t x;
-        int32_t y;
-        uint32_t button;
-        uint32_t state;
-        wl_fixed_t value;
-    } pointer;
 
     struct {
         struct wl_keyboard *obj;

--- a/platform/pwl.h
+++ b/platform/pwl.h
@@ -36,6 +36,32 @@
 G_BEGIN_DECLS
 
 typedef struct {
+    struct wl_keyboard *obj;
+
+    struct {
+        int32_t rate;
+        int32_t delay;
+    } repeat_info;
+
+    struct {
+        uint32_t key;
+        uint32_t time;
+        uint32_t state;
+        uint32_t event_source;
+    } repeat_data;
+
+    struct {
+        uint32_t keysym;
+        uint32_t unicode;
+        uint32_t state;
+        uint8_t modifiers;
+        uint32_t timestamp;
+    } event;
+
+    uint32_t serial;
+} PwlKeyboard;
+
+typedef struct {
     struct wl_pointer *obj;
     uint32_t time;
     uint32_t axis;
@@ -66,6 +92,7 @@ struct _PwlDisplay {
     EGLContext egl_context;
     EGLConfig egl_config;
 
+    PwlKeyboard keyboard;
     PwlPointer pointer;
     PwlTouch touch;
 
@@ -134,32 +161,6 @@ typedef struct {
     struct {
         int32_t scale;
     } current_output;
-
-    struct {
-        struct wl_keyboard *obj;
-
-        struct {
-            int32_t rate;
-            int32_t delay;
-        } repeat_info;
-
-        struct {
-            uint32_t key;
-            uint32_t time;
-            uint32_t state;
-            uint32_t event_source;
-        } repeat_data;
-
-        struct {
-            uint32_t keysym;
-            uint32_t unicode;
-            uint32_t state;
-            uint8_t modifiers;
-            uint32_t timestamp;
-        } event;
-
-        uint32_t serial;
-    } keyboard;
 
     GSource *event_src;
 } PwlData;

--- a/platform/pwl.h
+++ b/platform/pwl.h
@@ -47,6 +47,14 @@ typedef struct {
     void *data;
 } PwlPointer;
 
+typedef struct {
+    struct wl_touch *obj;
+    int32_t id;
+    uint32_t time;
+    wl_fixed_t x;
+    wl_fixed_t y;
+} PwlTouch;
+
 typedef struct _PwlDisplay PwlDisplay;
 
 struct _PwlDisplay {
@@ -59,6 +67,7 @@ struct _PwlDisplay {
     EGLConfig egl_config;
 
     PwlPointer pointer;
+    PwlTouch touch;
 
     void (*on_surface_enter) (PwlDisplay*, void *userdata);
     void *on_surface_enter_userdata;
@@ -151,14 +160,6 @@ typedef struct {
 
         uint32_t serial;
     } keyboard;
-
-    struct {
-        struct wl_touch *obj;
-        int32_t id;
-        uint32_t time;
-        wl_fixed_t x;
-        wl_fixed_t y;
-    } touch;
 
     GSource *event_src;
 } PwlData;

--- a/platform/pwl.h
+++ b/platform/pwl.h
@@ -115,7 +115,6 @@ typedef struct {
         } repeat_data;
 
         uint32_t serial;
-        struct wl_keyboard_listener listener;
     } keyboard;
 
     struct {
@@ -177,48 +176,5 @@ void destroy_window (PwlDisplay*);
 
 gboolean init_input (PwlDisplay*, GError **error);
 void clear_input (PwlDisplay*);
-
-/* Keyboard */
-void
-keyboard_on_keymap (void *data,
-                    struct wl_keyboard *wl_keyboard,
-                    uint32_t format,
-                    int32_t fd,
-                    uint32_t size);
-void
-keyboard_on_enter (void *data,
-                   struct wl_keyboard *wl_keyboard,
-                   uint32_t serial,
-                   struct wl_surface *surface,
-                   struct wl_array *keys);
-
-void
-keyboard_on_leave (void *data,
-                   struct wl_keyboard *wl_keyboard,
-                   uint32_t serial,
-                   struct wl_surface *surface);
-
-void
-keyboard_on_key (void *data,
-                 struct wl_keyboard *wl_keyboard,
-                 uint32_t serial,
-                 uint32_t time,
-                 uint32_t key,
-                 uint32_t state);
-
-void
-keyboard_on_modifiers (void *data,
-                       struct wl_keyboard *wl_keyboard,
-                       uint32_t serial,
-                       uint32_t mods_depressed,
-                       uint32_t mods_latched,
-                       uint32_t mods_locked,
-                       uint32_t group);
-
-void
-keyboard_on_repeat_info (void *data,
-                         struct wl_keyboard *wl_keyboard,
-                         int32_t rate,
-                         int32_t delay);
 
 G_END_DECLS

--- a/platform/pwl.h
+++ b/platform/pwl.h
@@ -158,8 +158,6 @@ typedef struct {
     } touch;
 
     GSource *event_src;
-
-    struct wl_output_listener output_listener;
 } PwlData;
 
 PwlDisplay* pwl_display_connect (const char *name, GError**);

--- a/platform/pwl.h
+++ b/platform/pwl.h
@@ -56,8 +56,11 @@ struct _PwlDisplay {
     void *on_pointer_on_axis_userdata;
     
     void (*on_touch_on_down)     (PwlDisplay*, void *userdata);
+    void *on_touch_on_down_userdata;
     void (*on_touch_on_up)       (PwlDisplay*, void *userdata);
+    void *on_touch_on_up_userdata;
     void (*on_touch_on_motion)   (PwlDisplay*, void *userdata);
+    void *on_touch_on_motion_userdata;
 
     void *userdata;
 };


### PR DESCRIPTION
* pwl: PwlDisplay has a 'void* shell' element what is used to attach the CogShell initialized:
    * create_window() and clear_input uses the PwlDisplay as argument.
    * The WL handlers receives the PwlDisplay as data context
* pwl: wl_seat moved from PwlData to PwlDisplay
* pwl: Remove shared win_data global. Remove the win_data global exported from the "pwl" module.
  * Instead, use the s_win_data as static variable in cog-fdo-shell.
  * Functions in pwl receives the PwlWinData structure as argument or as part of the contexts, for the case of callbacks.
 * pwl: callbacks for keyboard_listener encapsulated in pwl.c  The handlers for the keyboard_listener are defined in the  seat_on_capabilities() during the initialization of the Wayland platform.
* pwl: pointer_on_*()  moved to pwl and added the *on_pointer_*() callbacks in the PwlDisplay. These callback are used to for especific code for the modules.
* pwl: surface_handle_enter() moved to pwl and added the *on_surface_enter() callback in the PwlDisplay.  This callback is used to for specific code for the modules.   In a future, when each CogView uses its own surface, this callback   should be moved to the PwlWinData.
* pwl: Remove shared win_data global. Remove the win_data global exported from the "pwl" module. Instead, use the s_win_data as static variable in cog-fdo-shell.   Functions in pwl receives the PwlWinData struct as argument or   as part of the contexts, for the case of callbacks.

