### PR TITLE
Add manual pages for cog and cogctl

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -58,6 +58,7 @@ option(COG_USE_WEBKITGTK "Use WebKitGTK+ instead of WPEWebKit" OFF)
 option(COG_PLATFORM_FDO "Build the FDO platform module" ON)
 option(COG_PLATFORM_DRM "Build the DRM platform module" OFF)
 option(COG_BUILD_PROGRAMS "Build and install programs as well" ON)
+option(INSTALL_MAN_PAGES "Install the man(1) pages if COG_BUILD_PROGRAMS is enabled" ON)
 set(COG_APPID "" CACHE STRING "Default GApplication unique identifier")
 set(COG_HOME_URI "" CACHE STRING "Default home URI")
 
@@ -187,6 +188,12 @@ if (COG_BUILD_PROGRAMS)
         DESTINATION ${CMAKE_INSTALL_BINDIR}
         COMPONENT "runtime"
     )
+    if (INSTALL_MAN_PAGES)
+        install(FILES data/cog.1 data/cogctl.1
+            DESTINATION ${CMAKE_INSTALL_MANDIR}/man1
+            COMPONENT "runtime"
+        )
+    endif ()
 endif ()
 
 

--- a/data/cog.1
+++ b/data/cog.1
@@ -1,0 +1,83 @@
+.\"                                      Hey, EMACS: -*- nroff -*-
+.\" First parameter, NAME, should be all caps
+.\" Second parameter, SECTION, should be 1-8, maybe w/ subsection
+.\" other parameters are allowed: see man(7), man(1)
+.TH cog 1 "Jan 25, 2020"
+.\" Please adjust this date whenever revising the manpage.
+.\"
+.\" Some roff macros, for reference:
+.\" .nh        disable hyphenation
+.\" .hy        enable hyphenation
+.\" .ad l      left justify
+.\" .ad b      justify to both left and right margins
+.\" .nf        disable filling
+.\" .fi        enable filling
+.\" .br        insert line break
+.\" .sp <n>    insert n+1 empty lines
+.\" for manpage-specific macros, see man(7)
+.SH NAME
+cog \- single-window web browser
+.SH SYNOPSIS
+.B cog
+.RI [ options ]
+.RI [ URL ]
+.SH DESCRIPTION
+\fBcog\fP is a small, single-window web browser based on WPE WebKit.
+It provides no user interface and is suitable to be used as a web
+application container for embedded devices in kiosk mode.
+
+The URL of the website to be opened can be passed either from the
+command-line or with the \fBCOG_URL\fP environment variable.
+
+.SH OPTIONS
+.TP
+.B \-h,\ \-\-help
+Show help options
+.TP
+.B \-\-version
+Print version and exit
+.TP
+.B \-\-print\-appid
+Print application ID and exit
+.TP
+.B \-\-scale=FACTOR
+Zoom/Scaling factor applied to Web content (default: 1.0, no scaling)
+.TP
+.B \-\-device\-scale=FACTOR
+Output device scaling factor (default: 1.0, no scaling, 96 DPI)
+.TP
+.B \-\-doc\-viewer
+Document viewer mode: optimizes for local loading of Web content. This
+reduces memory usage at the cost of reducing caching of resources
+loaded from the network.
+.TP
+.B \-d,\ \-\-dir\-handler=SCHEME:PATH
+Add a URI scheme handler for a directory
+.TP
+.B \-\-webprocess\-failure=ACTION
+Action on WebProcess failures: error-page (default), exit, exit-ok,
+restart.
+.TP
+.B \-C,\ \-\-config=PATH
+Path to a configuration file
+.TP
+.B \-b,\ \-\-bg\-color=BG_COLOR
+Background color, as a CSS name or in #RRGGBBAA hex syntax (default:
+white)
+.TP
+.B \-P,\ \-\-platform=NAME
+Platform plug-in to use.
+.TP
+.B \-\-web\-extensions\-dir=PATH
+Load Web Extensions from given directory.
+
+.SH ENVIRONMENT
+.PP
+.B COG_URL
+URL of the website to be opened
+
+.SH SEE ALSO
+.BR cogctl (1)
+
+.SH AUTHOR
+This manual page was written by Alberto Garcia <berto@igalia.com>

--- a/data/cogctl.1
+++ b/data/cogctl.1
@@ -1,0 +1,76 @@
+.\"                                      Hey, EMACS: -*- nroff -*-
+.\" First parameter, NAME, should be all caps
+.\" Second parameter, SECTION, should be 1-8, maybe w/ subsection
+.\" other parameters are allowed: see man(7), man(1)
+.TH cogctl 1 "Jan 25, 2020"
+.\" Please adjust this date whenever revising the manpage.
+.\"
+.\" Some roff macros, for reference:
+.\" .nh        disable hyphenation
+.\" .hy        enable hyphenation
+.\" .ad l      left justify
+.\" .ad b      justify to both left and right margins
+.\" .nf        disable filling
+.\" .fi        enable filling
+.\" .br        insert line break
+.\" .sp <n>    insert n+1 empty lines
+.\" for manpage-specific macros, see man(7)
+.SH NAME
+cogctl \- tool to control a running Cog instance
+.SH SYNOPSIS
+.B cogctl
+.RI [ options ]
+.RI < command >
+.RI [ command\ options ]
+.SH DESCRIPTION
+\fBcogctl\fP is a tool to control a running Cog instance.
+
+.SH OPTIONS
+.TP
+.B \-h,\ \-\-help
+Show help options
+.TP
+.B \-A,\ \-\-appid=ID
+Application identifier of the Cog instance to control
+.TP
+.B \-o,\ \-\-object\-path=PATH
+Object path implementing the org.gtk.Actions interface
+.TP
+.B \-y,\ \-\-system
+Use the system bus instead of the session bus
+
+.SH COMMANDS
+.TP
+.B help [command]
+Show a list of commands. If followed by a command name then it shows
+additional information about that command.
+.TP
+.B appid
+Display application ID being remotely controlled
+.TP
+.B objpath
+Display the D-Bus object path being used
+.TP
+.B open <URL>
+Open a URL
+.TP
+.B previous
+Navigate backward in the page view history
+.TP
+.B next
+Navigate forward in the page view history
+.TP
+.B ping
+Check whether Cog is running
+.TP
+.B quit
+Exit the application
+.TP
+.B reload
+Reload the current page
+
+.SH SEE ALSO
+.BR cog (1)
+
+.SH AUTHOR
+This manual page was written by Alberto Garcia <berto@igalia.com>


### PR DESCRIPTION
Import manual pages `cog(1)` and `cogctl(1)` from the Debian Cog  packaging repository at
  https://salsa.debian.org/berto/cog/tree/6ebc0d4288463799a3480a78d45d9331fda63b60/debian

plus the needed CMake bits to install them, controlled by the `INSTALL_MAN_PAGES` configuration option (enabled by default) if the `COG_BUILD_PROGRAMS` is also enabled.

Thanks to Alberto Garcia for writing the manual pages and pointing them to us for inclusion in the repository.