### PR TITLE
fdo: ensure xkb_data.state is not null before calling xkb_state_update_mask

### DIFF
--- a/platform/cog-platform-fdo.c
+++ b/platform/cog-platform-fdo.c
@@ -894,6 +894,9 @@ keyboard_on_modifiers (void *data,
                        uint32_t mods_locked,
                        uint32_t group)
 {
+    if (xkb_data.state == NULL)
+        return;
+
     xkb_state_update_mask (xkb_data.state,
                            mods_depressed,
                            mods_latched,


### PR DESCRIPTION
Fixes:
```c
Thread 1 "cog" received signal SIGSEGV, Segmentation fault.
xkb_state_update_mask (state=0x0, base_mods=0, latched_mods=0, locked_mods=0, base_group=base_group@entry=0, latched_group=latched_group@entry=0, locked_group=0) at ../src/state.c:814
814	    prev_components = state->components;
```