### PR TITLE
Adjust plugin entrypoint names

### DIFF
--- a/core/cog-platform.c
+++ b/core/cog-platform.c
@@ -65,21 +65,21 @@ cog_platform_try_load (CogPlatform *platform,
     if (!platform->so)
         return FALSE;
 
-    platform->setup = dlsym (platform->so, "cog_platform_setup");
+    platform->setup = dlsym (platform->so, "cog_platform_plugin_setup");
     if (!platform->setup)
         goto err_out;
 
-    platform->teardown = dlsym (platform->so, "cog_platform_teardown");
+    platform->teardown = dlsym (platform->so, "cog_platform_plugin_teardown");
     if (!platform->teardown)
         goto err_out;
 
     platform->get_view_backend = dlsym (platform->so,
-                                        "cog_platform_get_view_backend");
+                                        "cog_platform_plugin_get_view_backend");
     if (!platform->get_view_backend)
         goto err_out;
 
     platform->create_im_context = dlsym (platform->so,
-                                         "cog_platform_create_im_context");
+                                         "cog_platform_plugin_create_im_context");
 
     return TRUE;
 

--- a/platform/cog-platform-drm.c
+++ b/platform/cog-platform-drm.c
@@ -749,10 +749,10 @@ on_export_dmabuf_resource (void *data, struct wpe_view_backend_exportable_fdo_dm
 }
 
 gboolean
-cog_platform_setup (CogPlatform *platform,
-                    CogShell    *shell G_GNUC_UNUSED,
-                    const char  *params,
-                    GError     **error)
+cog_platform_plugin_setup (CogPlatform *platform,
+                           CogShell    *shell G_GNUC_UNUSED,
+                           const char  *params,
+                           GError     **error)
 {
     g_assert (platform);
     g_return_val_if_fail (COG_IS_SHELL (shell), FALSE);
@@ -811,7 +811,7 @@ cog_platform_setup (CogPlatform *platform,
 }
 
 void
-cog_platform_teardown (CogPlatform *platform)
+cog_platform_plugin_teardown (CogPlatform *platform)
 {
     g_assert (platform);
 
@@ -825,9 +825,9 @@ cog_platform_teardown (CogPlatform *platform)
 }
 
 WebKitWebViewBackend *
-cog_platform_get_view_backend (CogPlatform   *platform,
-                               WebKitWebView *related_view,
-                               GError       **error)
+cog_platform_plugin_get_view_backend (CogPlatform   *platform,
+                                      WebKitWebView *related_view,
+                                      GError       **error)
 {
     static struct wpe_view_backend_exportable_fdo_client exportable_client = {
         .export_buffer_resource = on_export_buffer_resource,

--- a/platform/cog-platform-fdo.c
+++ b/platform/cog-platform-fdo.c
@@ -1588,10 +1588,10 @@ clear_input (void)
 }
 
 gboolean
-cog_platform_setup (CogPlatform *platform,
-                    CogShell    *shell G_GNUC_UNUSED,
-                    const char  *params,
-                    GError     **error)
+cog_platform_plugin_setup (CogPlatform *platform,
+                           CogShell    *shell G_GNUC_UNUSED,
+                           const char  *params,
+                           GError     **error)
 {
     g_assert (platform);
     g_return_val_if_fail (COG_IS_SHELL (shell), FALSE);
@@ -1632,7 +1632,7 @@ cog_platform_setup (CogPlatform *platform,
 }
 
 void
-cog_platform_teardown (CogPlatform *platform)
+cog_platform_plugin_teardown (CogPlatform *platform)
 {
     g_assert (platform);
 
@@ -1661,9 +1661,9 @@ cog_platform_teardown (CogPlatform *platform)
 }
 
 WebKitWebViewBackend*
-cog_platform_get_view_backend (CogPlatform   *platform,
-                               WebKitWebView *related_view,
-                               GError       **error)
+cog_platform_plugin_get_view_backend (CogPlatform   *platform,
+                                      WebKitWebView *related_view,
+                                      GError       **error)
 {
     static struct wpe_view_backend_exportable_fdo_egl_client exportable_egl_client = {
         .export_fdo_egl_image = on_export_fdo_egl_image,
@@ -1703,7 +1703,7 @@ cog_platform_get_view_backend (CogPlatform   *platform,
 
 #if COG_IM_API_SUPPORTED
 WebKitInputMethodContext*
-cog_platform_create_im_context (CogPlatform *platform)
+cog_platform_plugin_create_im_context (CogPlatform *platform)
 {
     if (wl_data.text_input_manager)
         return cog_im_context_fdo_new ();


### PR DESCRIPTION
To avoid cog_platform_try_load() loading equally-named symbols from
libcogcore.so when they are not defined in the specified platform
plugin, the plugin entrypoints are renamed to cog_platform_plugin_*.