### PR TITLE
Keep a reference to the config GKeyFile on CogShell

### DIFF
--- a/cog.c
+++ b/cog.c
@@ -277,6 +277,8 @@ on_handle_local_options (GApplication *application,
                         g_get_prgname (), error->message);
             return EXIT_FAILURE;
         }
+
+        g_object_set (shell, "config-file", g_key_file_ref (key_file), NULL);
     }
 
     if (s_options.web_extensions_dir != NULL) {

--- a/core/cog-shell.c
+++ b/core/cog-shell.c
@@ -13,6 +13,7 @@ typedef struct {
     WebKitSettings   *web_settings;
     WebKitWebContext *web_context;
     WebKitWebView    *web_view;
+    GKeyFile         *config_file;
     GHashTable       *request_handlers;  /* (string, RequestHandlerMapEntry) */
 } CogShellPrivate;
 
@@ -28,6 +29,7 @@ enum {
     PROP_WEB_SETTINGS,
     PROP_WEB_CONTEXT,
     PROP_WEB_VIEW,
+    PROP_CONFIG_FILE,
     N_PROPERTIES,
 };
 
@@ -175,6 +177,9 @@ cog_shell_set_property (GObject      *object,
         case PROP_NAME:
             PRIV (shell)->name = g_value_dup_string (value);
             break;
+        case PROP_CONFIG_FILE:
+            PRIV (shell)->config_file = g_value_get_boxed (value);
+            break;
         default:
             G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
     }
@@ -216,6 +221,7 @@ cog_shell_dispose (GObject *object)
 
     g_clear_pointer (&priv->request_handlers, g_hash_table_unref);
     g_clear_pointer (&priv->name, g_free);
+    g_clear_pointer (&priv->config_file, g_key_file_unref);
 
     G_OBJECT_CLASS (cog_shell_parent_class)->dispose (object);
 }
@@ -278,6 +284,14 @@ cog_shell_class_init (CogShellClass *klass)
                              G_PARAM_READABLE |
                              G_PARAM_STATIC_STRINGS);
 
+    s_properties[PROP_CONFIG_FILE] =
+        g_param_spec_boxed ("config-file",
+                            "Configuration File",
+                            "Configuration file made available to the platform plugin",
+                            G_TYPE_KEY_FILE,
+                            G_PARAM_READWRITE |
+                            G_PARAM_STATIC_STRINGS);
+
     g_object_class_install_properties (object_class, N_PROPERTIES, s_properties);
 }
 
@@ -329,6 +343,14 @@ cog_shell_get_name (CogShell *shell)
 {
     g_return_val_if_fail (COG_IS_SHELL (shell), NULL);
     return PRIV (shell)->name;
+}
+
+
+GKeyFile*
+cog_shell_get_config_file (CogShell *shell)
+{
+    g_return_val_if_fail (COG_IS_SHELL (shell), NULL);
+    return PRIV (shell)->config_file;
 }
 
 

--- a/core/cog-shell.h
+++ b/core/cog-shell.h
@@ -35,6 +35,7 @@ const char       *cog_shell_get_name            (CogShell          *shell);
 WebKitWebContext *cog_shell_get_web_context     (CogShell          *shell);
 WebKitSettings   *cog_shell_get_web_settings    (CogShell          *shell);
 WebKitWebView    *cog_shell_get_web_view        (CogShell          *shell);
+GKeyFile         *cog_shell_get_config_file     (CogShell          *shell);
 void              cog_shell_set_request_handler (CogShell          *shell,
                                                  const char        *scheme,
                                                  CogRequestHandler *handler);


### PR DESCRIPTION
Store a reference of the GKeyFile configuration file specified on
the command line on the CogShell object, also providing a
cog_shell_get_config_file() accessor.

This makes the configuration file accessible from the platform
module, allowing access to any module-specific configuration.