### PR TITLE
CMake: Simplify FDO platform plug-in build definitions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -222,110 +222,69 @@ install(FILES ${CMAKE_CURRENT_BINARY_DIR}/cogcore.pc
 # libcogplaform-fdo
 
 if (COG_PLATFORM_FDO AND NOT COG_USE_WEBKITGTK)
-    set(WAYLAND_1_10_OR_GREATER OFF)
-    pkg_check_modules(WAYLAND REQUIRED wayland-client)
-    if (NOT (WAYLAND_VERSION VERSION_LESS 1.10))
-        set(WAYLAND_1_10_OR_GREATER ON)
-    endif ()
+    add_library(cogplatform-fdo MODULE platform/cog-platform-fdo.c)
 
-    pkg_check_modules(COGPLATFORM_FDO_DEPS REQUIRED wpe-webkit-1.0>=2.24.0 wpebackend-fdo-1.0>=1.3.1 egl xkbcommon)
-    pkg_check_modules(WAYLAND_EGL wayland-egl)
-
-    set(COGPLATFORM_FDO_INCLUDE_DIRS
-        ${COGPLATFORM_FDO_DEPS_INCLUDE_DIRS}
-        ${WAYLAND_INCLUDE_DIRS}
-        ${WAYLAND_EGL_INCLUDE_DIRS}
-    )
-    set(COGPLATFORM_FDO_CFLAGS
-        ${COGPLATFORM_FDO_DEPS_CFLAGS_OTHER}
-        ${WAYLAND_CFLAGS_OTHER}
-        ${WAYLAND_EGL_CFLAGS_OTHER}
-    )
-    set(COGPLATFORM_FDO_LDFLAGS
-        ${COGPLATFORM_FDO_DEPS_LDFLAGS}
-        ${WAYLAND_LDFLAGS}
-        ${WAYLAND_EGL_LDFLAGS}
-    )
-    set(COGPLATFORM_FDO_SOURCES platform/cog-platform-fdo.c)
-
-    if (COG_IM_API_SUPPORTED)
-        list(APPEND COGPLATFORM_FDO_SOURCES
-            platform/cog-im-context-fdo.c
-            platform/cog-im-context-fdo-v1.c
-        )
-        add_definitions(-DCOG_IM_API_SUPPORTED=1)
-    else ()
-        add_definitions(-DCOG_IM_API_SUPPORTED=0)
-    endif ()
-
-    find_path(WPEBACKEND_FDO_HAS_VIDEO_PLANE_DISPLAY_DMABUF_EXT
-        NAMES wpe/extensions/video-plane-display-dmabuf.h
-        PATHS ${COGPLATFORM_FDO_DEPS_INCLUDE_DIRS}
-        NO_DEFAULT_PATH
-    )
-    if (WPEBACKEND_FDO_HAS_VIDEO_PLANE_DISPLAY_DMABUF_EXT)
-        set(WPEBACKEND_FDO_HAS_VIDEO_PLANE_DISPLAY_DMABUF_EXT ON)
-    else ()
-        set(WPEBACKEND_FDO_HAS_VIDEO_PLANE_DISPLAY_DMABUF_EXT OFF)
-    endif ()
-
-    if (COG_WESTON_DIRECT_DISPLAY AND WPEBACKEND_FDO_HAS_VIDEO_PLANE_DISPLAY_DMABUF_EXT)
-        file(MAKE_DIRECTORY ${CMAKE_BINARY_DIR}/weston)
-        pkg_check_modules(LIBWESTON REQUIRED libweston-9-protocols)
-        pkg_get_variable(LIBWESTON_PKG_DATA_DIR libweston-9-protocols "pkgdatadir")
-        find_package(WaylandScanner REQUIRED)
-        add_custom_command(
-            OUTPUT ${CMAKE_BINARY_DIR}/weston/weston-direct-display-client-protocol.h
-                   ${CMAKE_BINARY_DIR}/weston/weston-direct-display-protocol.c
-            DEPENDS ${LIBWESTON_PKG_DATA_DIR}/weston-direct-display.xml
-            COMMAND ${WAYLAND_SCANNER} client-header < ${LIBWESTON_PKG_DATA_DIR}/weston-direct-display.xml > ${CMAKE_BINARY_DIR}/weston/weston-direct-display-client-protocol.h
-            COMMAND ${WAYLAND_SCANNER} ${WAYLAND_SCANNER_CODE_ARG} < ${LIBWESTON_PKG_DATA_DIR}/weston-direct-display.xml > ${CMAKE_BINARY_DIR}/weston/weston-direct-display-protocol.c
-            VERBATIM
-        )
-
-        add_custom_command(
-            OUTPUT ${CMAKE_BINARY_DIR}/weston/weston-content-protection-client-protocol.h
-                   ${CMAKE_BINARY_DIR}/weston/weston-content-protection-protocol.c
-            DEPENDS ${LIBWESTON_PKG_DATA_DIR}/weston-content-protection.xml
-            COMMAND ${WAYLAND_SCANNER} client-header < ${LIBWESTON_PKG_DATA_DIR}/weston-content-protection.xml > ${CMAKE_BINARY_DIR}/weston/weston-content-protection-client-protocol.h
-            COMMAND ${WAYLAND_SCANNER} ${WAYLAND_SCANNER_CODE_ARG} < ${LIBWESTON_PKG_DATA_DIR}/weston-content-protection.xml > ${CMAKE_BINARY_DIR}/weston/weston-content-protection-protocol.c
-            VERBATIM
-        )
-
-        list(APPEND COGPLATFORM_FDO_SOURCES
-            ${CMAKE_BINARY_DIR}/weston/weston-direct-display-protocol.c
-            ${CMAKE_BINARY_DIR}/weston/weston-content-protection-protocol.c
-        )
-        list(APPEND COGPLATFORM_FDO_INCLUDE_DIRS ${CMAKE_BINARY_DIR}/weston)
-        set(ENABLE_WESTON_DIRECT_DISPLAY 1)
-    else ()
-        set(ENABLE_WESTON_DIRECT_DISPLAY 0)
-    endif ()
-
-    add_library(cogplatform-fdo MODULE ${COGPLATFORM_FDO_SOURCES})
     set_property(TARGET cogplatform-fdo PROPERTY C_STANDARD 99)
-    target_include_directories(cogplatform-fdo PUBLIC wayland ${COGPLATFORM_FDO_INCLUDE_DIRS})
-    target_link_libraries(cogplatform-fdo cogcore ${COGPLATFORM_FDO_LDFLAGS})
-    target_compile_options(cogplatform-fdo
-        PUBLIC ${COGPLATFORM_FDO_CFLAGS}
-        PRIVATE -DG_LOG_DOMAIN=\"Cog-FDO\"
-    )
-    target_compile_options(cogplatform-fdo PRIVATE -DCOG_ENABLE_WESTON_DIRECT_DISPLAY=${ENABLE_WESTON_DIRECT_DISPLAY})
+
+    target_compile_definitions(cogplatform-fdo PRIVATE G_LOG_DOMAIN=\"Cog-FDO\")
 
     find_package(WaylandProtocols REQUIRED)
     add_wayland_protocol(cogplatform-fdo CLIENT xdg-shell)
     add_wayland_protocol(cogplatform-fdo CLIENT fullscreen-shell-unstable-v1)
     add_wayland_protocol(cogplatform-fdo CLIENT presentation-time)
-    if (COG_IM_API_SUPPORTED)
-        add_wayland_protocol(cogplatform-fdo CLIENT text-input-unstable-v1)
-        add_wayland_protocol(cogplatform-fdo CLIENT text-input-unstable-v3)
-    endif ()
     add_wayland_protocol(cogplatform-fdo CLIENT linux-dmabuf-unstable-v1)
+
+    set(WAYLAND_1_10_OR_GREATER OFF)
+    pkg_check_modules(WAYLAND IMPORTED_TARGET REQUIRED wayland-client)
+    if (NOT (WAYLAND_VERSION VERSION_LESS 1.10))
+        set(WAYLAND_1_10_OR_GREATER ON)
+    endif ()
+
+    pkg_check_modules(COGPLATFORM_FDO_DEPS IMPORTED_TARGET REQUIRED
+        wpe-webkit-1.0>=2.24.0 wpebackend-fdo-1.0>=1.3.1 egl xkbcommon)
+
+    target_link_libraries(cogplatform-fdo PRIVATE
+        cogcore PkgConfig::WAYLAND PkgConfig::COGPLATFORM_FDO_DEPS)
+
+    pkg_check_modules(WAYLAND_EGL IMPORTED_TARGET wayland-egl)
+    if (TARGET PkgConfig::WAYLAND_EGL)
+        target_link_libraries(cogplatform-fdo PRIVATE PkgConfig::WAYLAND_EGL)
+    endif ()
 
     install(TARGETS cogplatform-fdo
         DESTINATION ${CMAKE_INSTALL_LIBDIR}
         COMPONENT "runtime"
     )
+
+    # Input methods extension.
+    if (COG_IM_API_SUPPORTED)
+        target_sources(cogplatform-fdo PRIVATE
+            platform/cog-im-context-fdo.c
+            platform/cog-im-context-fdo-v1.c
+        )
+        add_wayland_protocol(cogplatform-fdo CLIENT text-input-unstable-v1)
+        add_wayland_protocol(cogplatform-fdo CLIENT text-input-unstable-v3)
+        target_compile_definitions(cogplatform-fdo PRIVATE COG_IM_API_SUPPORTED=1)
+    else ()
+        target_compile_definitions(cogplatform-fdo PRIVATE COG_IM_API_SUPPORTED=0)
+    endif ()
+
+    # Direct video display extension.
+    find_path(WPEBACKEND_FDO_HAS_VIDEO_PLANE_DISPLAY_DMABUF_EXT
+        NAMES wpe/extensions/video-plane-display-dmabuf.h
+        PATHS ${COGPLATFORM_FDO_DEPS_INCLUDE_DIRS}
+        NO_DEFAULT_PATH
+    )
+
+    if (COG_WESTON_DIRECT_DISPLAY AND WPEBACKEND_FDO_HAS_VIDEO_PLANE_DISPLAY_DMABUF_EXT)
+        pkg_check_modules(LIBWESTON REQUIRED libweston-9-protocols)
+        pkg_get_variable(LIBWESTON_PKG_DATA_DIR libweston-9-protocols "pkgdatadir")
+        add_wayland_protocol(cogplatform-fdo CLIENT "${LIBWESTON_PKG_DATA_DIR}/weston-direct-display.xml")
+        add_wayland_protocol(cogplatform-fdo CLIENT "${LIBWESTON_PKG_DATA_DIR}/weston-content-protection.xml")
+        target_compile_definitions(cogplatform-fdo PRIVATE COG_ENABLE_WESTON_DIRECT_DISPLAY=1)
+    else ()
+        target_compile_definitions(cogplatform-fdo PRIVATE COG_ENABLE_WESTON_DIRECT_DISPLAY=0)
+    endif ()
 endif ()  # !COG_USE_WEBKITGTK
 
 # libcogplaform-drm


### PR DESCRIPTION
Improve `FindWaylandProtocols.cmake` to allow passing full paths (among other goodies) to `add_wayland_protocol()`, then use that to simplify the top-level `CMakeLists.txt`, along with imported targets and commands which modify the target instead of carrying around list variables.

----

Fixes #178 
