### PR TITLE
fdo: ensure xkb_data.state is not null before calling xkb_state_key_get_one_sym

### DIFF
--- a/platform/cog-platform-fdo.c
+++ b/platform/cog-platform-fdo.c
@@ -919,6 +919,9 @@ capture_app_key_bindings (uint32_t keysym,
 static void
 handle_key_event (uint32_t key, uint32_t state, uint32_t time)
 {
+    if (xkb_data.state == NULL)
+        return;
+
     uint32_t keysym = xkb_state_key_get_one_sym (xkb_data.state, key);
     uint32_t unicode = xkb_state_key_get_utf32 (xkb_data.state, key);
 


### PR DESCRIPTION
Fixes:
```c
Program terminated with signal SIGSEGV, Segmentation fault.
#0  xkb_state_key_get_layout (state=state@entry=0x0, kc=kc@entry=50) at ../src/state.c:217
```

Backtrace:
```c
#0  xkb_state_key_get_layout (state=state@entry=0x0, kc=kc@entry=50) at ../src/state.c:217
#1  0x0000007f94c3ba6c in xkb_state_key_get_syms (state=state@entry=0x0, kc=kc@entry=50, syms_out=syms_out@entry=0x7fc6e1eba8) at ../src/state.c:864
#2  0x0000007f94c3c23c in xkb_state_key_get_one_sym (state=0x0, kc=kc@entry=50) at ../src/state.c:937
#3  0x0000007f90b6fd14 in handle_key_event (key=key@entry=50, state=state@entry=1, time=time@entry=1742858) at /home/buildroot/buildroot/rpi3/output/build/cog-0.4.0/platform/cog-platform-fdo.c:774
#4  0x0000007f90b6fe24 in keyboard_on_key (data=<optimized out>, wl_keyboard=<optimized out>, serial=<optimized out>, time=1742858, key=50, state=1)
    at /home/buildroot/buildroot/rpi3/output/build/cog-0.4.0/platform/cog-platform-fdo.c:829
```