### PR TITLE
fdo: ensure xkb_data.keymap is not null before calling xkb_keymap_key_repeats

### DIFF
--- a/platform/cog-platform-fdo.c
+++ b/platform/cog-platform-fdo.c
@@ -987,7 +987,8 @@ keyboard_on_key (void *data,
         memset (&wl_data.keyboard.repeat_data,
                 0x00,
                 sizeof (wl_data.keyboard.repeat_data));
-    } else if (state == WL_KEYBOARD_KEY_STATE_PRESSED
+    } else if (xkb_data.keymap != NULL
+               && state == WL_KEYBOARD_KEY_STATE_PRESSED
                && xkb_keymap_key_repeats (xkb_data.keymap, key)) {
         if (wl_data.keyboard.repeat_data.event_source)
             g_source_remove (wl_data.keyboard.repeat_data.event_source);


### PR DESCRIPTION
Fixes:
```c
Program terminated with signal SIGSEGV, Segmentation fault.
#0  XkbKey (kc=kc@entry=45, keymap=0x0) at ../src/keymap.h:430
```
Backtrace:
```c
#0  XkbKey (kc=kc@entry=45, keymap=0x0) at ../src/keymap.h:430
#1  xkb_keymap_key_repeats (keymap=0x0, kc=kc@entry=45) at ../src/keymap.c:515
#2  0x0000007f92cc7ea4 in keyboard_on_key (data=<optimized out>, wl_keyboard=<optimized out>, serial=<optimized out>, time=191022, key=45, state=1)
    at /home/buildroot/buildroot/rpi3/output/build/cog-0.4.0/platform/cog-platform-fdo.c:840
```