### PR TITLE
fdo: Load and set a default pointer cursor

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -285,6 +285,13 @@ if (COG_PLATFORM_FDO AND NOT COG_USE_WEBKITGTK)
     else ()
         target_compile_definitions(cogplatform-fdo PRIVATE COG_ENABLE_WESTON_DIRECT_DISPLAY=0)
     endif ()
+
+    # Optional pointer support
+    pkg_check_modules(WaylandCursor IMPORTED_TARGET wayland-cursor)
+    if (TARGET PkgConfig::WaylandCursor)
+        target_compile_definitions(cogplatform-fdo PRIVATE COG_USE_WAYLAND_CURSOR)
+        target_link_libraries(cogplatform-fdo PRIVATE PkgConfig::WaylandCursor)
+    endif ()
 endif ()  # !COG_USE_WEBKITGTK
 
 # libcogplaform-drm


### PR DESCRIPTION
Load the default cursor theme and assign a surface with the left arrow image as cursor for the seat's pointer. This is a basic implementation which uses always the same cursor, even in HiDPI mode, so in that case the cursor will be tiny.
