### PR TITLE
cog-launcher: Move auto ptr declation before goto statement

### DIFF
--- a/core/cog-launcher.c
+++ b/core/cog-launcher.c
@@ -505,6 +505,7 @@ option_entry_parse_cookie_add (const char          *option G_GNUC_UNUSED,
                                GError             **error G_GNUC_UNUSED)
 {
     g_autoptr(GMainLoop) loop = NULL;
+    g_autoptr(SoupCookie) cookie = NULL;
     g_autofree char *domain = g_strdup (value);
 
     char *flagstr = strchr (domain, ':');
@@ -528,7 +529,7 @@ option_entry_parse_cookie_add (const char          *option G_GNUC_UNUSED,
     if (!contents[0])
         goto bad_format;
 
-    g_autoptr(SoupCookie) cookie = soup_cookie_parse (contents, NULL);
+    cookie = soup_cookie_parse (contents, NULL);
     if (!cookie)
         goto bad_format;
 


### PR DESCRIPTION
This fixes error like

/mnt/b/yoe/build/tmp/work/cortexa7t2hf-neon-vfpv4-yoe-linux-gnueabi/cog/0.5.1-r0/cog-0.5.1/core/cog-launcher.c:529:9: error: cannot jump from this goto statement to its label
goto bad_format;
^
/mnt/b/yoe/build/tmp/work/cortexa7t2hf-neon-vfpv4-yoe-linux-gnueabi/cog/0.5.1-r0/cog-0.5.1/core/cog-launcher.c:531:27: note: jump bypasses initialization of variable with __attribute__((cleanup))
g_autoptr(SoupCookie) cookie = soup_cookie_parse (contents, NULL);
^

Signed-off-by: Khem Raj <raj.khem@gmail.com>