### PR TITLE
feat: user defined video mode selection

### DIFF
--- a/platform/cog-platform-drm.c
+++ b/platform/cog-platform-drm.c
@@ -201,8 +201,14 @@ init_drm (void)
         return FALSE;
     }
 
+    const char* user_selected_mode = g_getenv("COG_PLATFORM_DRM_VIDEO_MODE");
+
     for (int i = 0, area = 0; i < drm_data.connector->count_modes; ++i) {
         drmModeModeInfo *current_mode = &drm_data.connector->modes[i];
+        if (user_selected_mode && strcmp(user_selected_mode, current_mode->name) != 0) {
+            continue;
+        }
+
         if (current_mode->type & DRM_MODE_TYPE_PREFERRED) {
             drm_data.mode = current_mode;
             break;


### PR DESCRIPTION
Adding an env variable to specify preferred video mode for DRM platform.

Usage: 
```
export COG_PLATFORM_DRM_VIDEO_MODE=1920x1080
cog --platform drm http://google.com
```