### PR TITLE
cog: Load target URI instead of ignoring window.open()

### DIFF
--- a/cog.c
+++ b/cog.c
@@ -345,6 +345,13 @@ on_shutdown (CogLauncher *launcher G_GNUC_UNUSED, void *user_data G_GNUC_UNUSED)
 }
 #endif // !COG_USE_WEBKITGTK
 
+static void*
+on_web_view_create (WebKitWebView          *web_view,
+                    WebKitNavigationAction *action)
+{
+    webkit_web_view_load_request (web_view, webkit_navigation_action_get_request (action));
+    return NULL;
+}
 
 static WebKitWebView*
 on_create_view (CogShell *shell, void *user_data G_GNUC_UNUSED)
@@ -397,6 +404,8 @@ on_create_view (CogShell *shell, void *user_data G_GNUC_UNUSED)
                                                       "backend", view_backend,
 #endif
                                                       NULL);
+
+    g_signal_connect (web_view, "create", G_CALLBACK (on_web_view_create), NULL);
 
 #if !COG_USE_WEBKITGTK
     if (s_options.platform) {


### PR DESCRIPTION
Load the URI passed as target to `window.open()` instead of leaving the signal unhandled, which results in no navigation at all. For now the same `WebKitWebView` is used because multiple views are not supported yet, but at least this makes certain websites usable.