### PR TITLE
pwl: Support multiple wl_seats

### DIFF
--- a/platform/pwl.h
+++ b/platform/pwl.h
@@ -106,7 +106,6 @@ typedef struct {
 
 typedef struct _PwlDisplay PwlDisplay;
 
-
 PwlDisplay* pwl_display_connect (const char *name, GError**);
 void        pwl_display_destroy (PwlDisplay*);
 void        pwl_display_attach_sources (PwlDisplay*, GMainContext*);
@@ -124,8 +123,6 @@ EGLContext  pwl_display_egl_get_context (const PwlDisplay*);
 struct wl_buffer*
             pwl_display_egl_create_buffer_from_image (const PwlDisplay*, EGLImage);
 bool        pwl_display_egl_has_broken_buffer_from_image (const PwlDisplay*);
-
-PwlXKBData* pwl_display_xkb_get_data (PwlDisplay*);
 
 G_DEFINE_AUTOPTR_CLEANUP_FUNC (PwlDisplay, pwl_display_destroy)
 


### PR DESCRIPTION
All the resources related to an individual wl_seat are encapsulated into a PwlSeat struct. A PwlDisplay contains a list of PwlSeat each one managing listeners and resources separately.

Signed-off-by: Pablo Saavedra <psaavedra@igalia.com>