### PR TITLE
cog: Add a runtime option to ignore TLS certificate errors

### DIFF
--- a/cog.c
+++ b/cog.c
@@ -53,6 +53,7 @@ static struct {
         enum webprocess_fail_action action_id;
     } on_failure;
     char *web_extensions_dir;
+    gboolean ignore_tls_errors;
 } s_options = {
     .scale_factor = 1.0,
 #if HAVE_DEVICE_SCALING
@@ -103,6 +104,8 @@ static GOptionEntry s_cli_options[] =
     { "web-extensions-dir", '\0', 0, G_OPTION_ARG_STRING, &s_options.web_extensions_dir,
       "Load Web Extensions from given directory.",
       "PATH"},
+    { "ignore-tls-errors", '\0', 0, G_OPTION_ARG_NONE, &s_options.ignore_tls_errors,
+        "Ignore TLS errors (default: disabled).", NULL },
     { G_OPTION_REMAINING, '\0', 0, G_OPTION_ARG_FILENAME_ARRAY, &s_options.arguments,
         "", "[URL]" },
     { NULL }
@@ -285,6 +288,11 @@ on_handle_local_options (GApplication *application,
         webkit_web_context_set_web_extensions_directory (cog_shell_get_web_context (shell),
                                                          s_options.web_extensions_dir);
     }
+
+    webkit_web_context_set_tls_errors_policy (cog_shell_get_web_context (shell),
+                                              s_options.ignore_tls_errors
+                                              ? WEBKIT_TLS_ERRORS_POLICY_IGNORE
+                                              : WEBKIT_TLS_ERRORS_POLICY_FAIL);
 
     return -1;  /* Continue startup. */
 }


### PR DESCRIPTION
By default this option is disabled and an error page will be displayed when the page load fails due to a TLS error. However, by enabling this option the page load can resume and thus the TLS error is ignored. Use this option carefully and consider the security implications.

Based on #138, initially written by Philippe Normand (thanks @philn!)