### PR TITLE
CogShell: several fixes during initialization

### DIFF
--- a/core/cog-modules.c
+++ b/core/cog-modules.c
@@ -79,6 +79,10 @@ _cog_modules_get_preferred_internal (const char        *func,
             chosen = extension;
         else if (!extension)
             g_warning ("%s: cannot find module '%s'", func, preferred_module);
+        if (!chosen) {
+            g_warning ("%s: preferred module '%s' not supported", func, preferred_module);
+            return G_TYPE_INVALID;
+        }
     }
 
     for (GList *item = g_list_first (g_io_extension_point_get_extensions (ep));

--- a/core/cog-shell.c
+++ b/core/cog-shell.c
@@ -127,7 +127,7 @@ cog_shell_class_init (CogShellClass *klass)
 }
 
 static void
-cog_shell_init (CogShell *shell)
+cog_shell_init (CogShell *shell G_GNUC_UNUSED)
 {
 }
 
@@ -144,7 +144,7 @@ is_construct_property (const char  *func,
                        GType        object_type,
                        const char  *propname,
                        GParamSpec  *pspec,
-                       unsigned     n_properties)
+                       unsigned     n_properties G_GNUC_UNUSED)
 {
     if (G_UNLIKELY (pspec == NULL)) {
         g_critical ("%s: object class '%s' has no property named '%s'",
@@ -329,7 +329,7 @@ cog_shell_get_name (CogShell *shell)
 
 static void
 shell_on_notify_view_focused (CogView    *view,
-                              GParamSpec *pspec,
+                              GParamSpec *pspec G_GNUC_UNUSED,
                               CogShell   *shell)
 {
     CogShellPrivate *priv = cog_shell_get_instance_private (shell);

--- a/core/cog-shell.c
+++ b/core/cog-shell.c
@@ -173,6 +173,8 @@ string_array_contains (const char *haystack[],
     return FALSE;
 }
 
+G_DEFINE_QUARK (cog-shell-error-quark, cog_shell_error)
+
 static CogShell*
 cog_shell_new_internal (GError    **error,
                         const char *shell_name,
@@ -188,6 +190,8 @@ cog_shell_new_internal (GError    **error,
     if (shell_type == G_TYPE_INVALID) {
         g_warning ("%s: cannot find any '%s' implementation",
                    G_STRFUNC, COG_MODULES_SHELL_EXTENSION_POINT);
+        g_set_error_literal (error, COG_SHELL_ERROR, COG_SHELL_ERROR_MODULE_NOT_FOUND,
+                             "Couldn't find any suitable loadable module to initialize a CogShell instance.");
         return NULL;
     }
 

--- a/core/cog-shell.c
+++ b/core/cog-shell.c
@@ -186,8 +186,8 @@ cog_shell_new_internal (GError    **error,
                                              module_name,
                                              G_STRUCT_OFFSET (CogShellClass, is_supported));
     if (shell_type == G_TYPE_INVALID) {
-        g_critical ("%s: cannot find any '%s' implementation",
-                    G_STRFUNC, COG_MODULES_SHELL_EXTENSION_POINT);
+        g_warning ("%s: cannot find any '%s' implementation",
+                   G_STRFUNC, COG_MODULES_SHELL_EXTENSION_POINT);
         return NULL;
     }
 

--- a/core/cog-shell.h
+++ b/core/cog-shell.h
@@ -15,6 +15,12 @@
 
 G_BEGIN_DECLS
 
+#define COG_SHELL_ERROR (cog_shell_error_quark ())
+
+typedef enum {
+    COG_SHELL_ERROR_MODULE_NOT_FOUND,
+} CogShellError;
+
 #define COG_TYPE_SHELL  (cog_shell_get_type ())
 
 G_DECLARE_DERIVABLE_TYPE (CogShell, cog_shell, COG, SHELL, GObject)
@@ -31,6 +37,8 @@ struct _CogShellClass {
     void     (*padding_3)      (void);
     void     (*padding_4)      (void);
 };
+
+GQuark      cog_shell_error_quark      (void);
 
 CogShell*   cog_shell_new              (GError    **error,
                                         const char *name,


### PR DESCRIPTION
1. Fail if the preferred module is not available.
2. Change a critical to warning as module unavailability is not a programming error.
3. Fill the GError in case of shell creation failure, also add a GError domain for this.
4.A few compilation warnings fixed.