### PR TITLE
dir-handler: Allow usage of URI host as path component

### DIFF
--- a/core/cog-directory-files-handler.c
+++ b/core/cog-directory-files-handler.c
@@ -15,7 +15,6 @@ struct _CogDirectoryFilesHandler {
 };
 
 
-enum { MIME_PEEK_BYTES = 64 };
 
 static const char s_file_query_attributes[] =
     G_FILE_ATTRIBUTE_STANDARD_CONTENT_TYPE ","

--- a/core/cog-directory-files-handler.h
+++ b/core/cog-directory-files-handler.h
@@ -42,6 +42,9 @@ GQuark             cog_directory_files_handler_error_quark      (void);
 CogRequestHandler* cog_directory_files_handler_new              (GFile   *file);
 gboolean           cog_directory_files_handler_is_suitable_path (GFile   *file,
                                                                  GError **error);
+gboolean           cog_directory_files_handler_get_use_host     (CogDirectoryFilesHandler *self);
+void               cog_directory_files_handler_set_use_host     (CogDirectoryFilesHandler *self,
+                                                                 gboolean                  use_host);
 
 G_END_DECLS
 


### PR DESCRIPTION
Support using the URI host as the first path component, when the `CogDirectoryFilesHandler.use-host` property is set. The default value of the property is `FALSE` to make the new behaviour opt-in and avoid breaking existing code.

There is also a commit to turn the base path into a construct-only property (which is good practice for `GObject` construction parameters), and another one to remove an unused definition.

Closes #225
