### PR TITLE
drm: optionally limit max video mode width/height

### DIFF
--- a/platform/cog-platform-drm.c
+++ b/platform/cog-platform-drm.c
@@ -203,10 +203,17 @@ init_drm (void)
 
     const char* user_selected_mode = g_getenv("COG_PLATFORM_DRM_VIDEO_MODE");
 
-    const char* user_max_width_str = g_getenv("COG_PLATFORM_DRM_VIDEO_MAX_WIDTH");
-    const char* user_max_height_str = g_getenv("COG_PLATFORM_DRM_VIDEO_MAX_HEIGHT");
-    const int user_max_width = user_max_width_str ? atoi(user_max_width_str) : 0;
-    const int user_max_height = user_max_height_str ? atoi(user_max_height_str) : 0;
+    int user_max_width = 0;
+    int user_max_height = 0;
+    const char *user_mode_max = g_getenv("COG_PLATFORM_DRM_MODE_MAX");
+    if (user_mode_max) {
+        if (sscanf(user_mode_max, "%dx%d", &user_max_width, &user_max_height) != 2 ||
+            user_max_width < 0 || user_max_height < 0) {
+            fprintf(stderr, "invalid value for COG_PLATFORM_DRM_MODE_MAX\n");
+            user_max_width = 0;
+            user_max_height = 0;
+        }
+    }
 
     for (int i = 0, area = 0; i < drm_data.connector->count_modes; ++i) {
         drmModeModeInfo *current_mode = &drm_data.connector->modes[i];
@@ -214,10 +221,10 @@ init_drm (void)
             continue;
         }
 
-        if (user_max_width_str && current_mode->hdisplay > user_max_width) {
+        if (user_max_width && current_mode->hdisplay > user_max_width) {
             continue;
         }
-        if (user_max_height_str && current_mode->vdisplay > user_max_height) {
+        if (user_max_height && current_mode->vdisplay > user_max_height) {
             continue;
         }
 

--- a/platform/cog-platform-drm.c
+++ b/platform/cog-platform-drm.c
@@ -203,9 +203,21 @@ init_drm (void)
 
     const char* user_selected_mode = g_getenv("COG_PLATFORM_DRM_VIDEO_MODE");
 
+    const char* user_max_width_str = g_getenv("COG_PLATFORM_DRM_VIDEO_MAX_WIDTH");
+    const char* user_max_height_str = g_getenv("COG_PLATFORM_DRM_VIDEO_MAX_HEIGHT");
+    const int user_max_width = user_max_width_str ? atoi(user_max_width_str) : 0;
+    const int user_max_height = user_max_height_str ? atoi(user_max_height_str) : 0;
+
     for (int i = 0, area = 0; i < drm_data.connector->count_modes; ++i) {
         drmModeModeInfo *current_mode = &drm_data.connector->modes[i];
         if (user_selected_mode && strcmp(user_selected_mode, current_mode->name) != 0) {
+            continue;
+        }
+
+        if (user_max_width_str && current_mode->hdisplay > user_max_width) {
+            continue;
+        }
+        if (user_max_height_str && current_mode->vdisplay > user_max_height) {
             continue;
         }
 


### PR DESCRIPTION
Limit max video mode width/height so the selection of best video mode is limited by these boundaries. It's useful, for example, on Raspberry Pi 4 that supports 4K. If I connect it to 4K screen, it will by default automatically select 4K mode but in some cases that's not what I want. When there's a lot of elements on the screen, CSS animations, etc., performance seems to suffer in 4K so I'd prefer to just force it to be max Full HD.