### PR TITLE
platform: add a common EGL proc address loader with dlsym fallback

### DIFF
--- a/platform/cog-platform-drm.c
+++ b/platform/cog-platform-drm.c
@@ -16,6 +16,8 @@
 #include <EGL/egl.h>
 #include <EGL/eglext.h>
 
+#include "common/egl-proc-address.h"
+
 
 #if !defined(EGL_EXT_platform_base)
 typedef EGLDisplay (EGLAPIENTRYP PFNEGLGETPLATFORMDISPLAYEXTPROC) (EGLenum platform, void *native_display, const EGLint *attrib_list);
@@ -740,7 +742,7 @@ init_egl (void)
 {
     static PFNEGLGETPLATFORMDISPLAYEXTPROC s_eglGetPlatformDisplay = NULL;
     if (!s_eglGetPlatformDisplay)
-        s_eglGetPlatformDisplay = (PFNEGLGETPLATFORMDISPLAYEXTPROC) eglGetProcAddress ("eglGetPlatformDisplayEXT");
+        s_eglGetPlatformDisplay = (PFNEGLGETPLATFORMDISPLAYEXTPROC) load_egl_proc_address ("eglGetPlatformDisplayEXT");
 
     if (s_eglGetPlatformDisplay)
         egl_data.display = s_eglGetPlatformDisplay (EGL_PLATFORM_GBM_KHR, gbm_data.device, NULL);

--- a/platform/cog-platform-fdo.c
+++ b/platform/cog-platform-fdo.c
@@ -32,6 +32,8 @@
 #include <xkbcommon/xkbcommon-compose.h>
 #include <locale.h>
 
+#include "common/egl-proc-address.h"
+
 #include "xdg-shell-client.h"
 #include "fullscreen-shell-unstable-v1-client.h"
 #include "presentation-time-client.h"
@@ -1643,7 +1645,7 @@ on_export_fdo_egl_image(void *data, struct wpe_fdo_egl_exported_image *image)
         s_eglCreateWaylandBufferFromImageWL;
     if (s_eglCreateWaylandBufferFromImageWL == NULL) {
         s_eglCreateWaylandBufferFromImageWL = (PFNEGLCREATEWAYLANDBUFFERFROMIMAGEWL)
-            eglGetProcAddress ("eglCreateWaylandBufferFromImageWL");
+            load_egl_proc_address ("eglCreateWaylandBufferFromImageWL");
         g_assert (s_eglCreateWaylandBufferFromImageWL);
     }
 

--- a/platform/common/egl-proc-address.h
+++ b/platform/common/egl-proc-address.h
@@ -1,3 +1,10 @@
+/*
+ * egl-proc-address.h
+ * Copyright (C) 2020 Igalia S.L.
+ *
+ * Distributed under terms of the MIT license.
+ */
+
 #pragma once
 
 #define __USE_GNU

--- a/platform/common/egl-proc-address.h
+++ b/platform/common/egl-proc-address.h
@@ -1,0 +1,15 @@
+#pragma once
+
+#define __USE_GNU
+#include <dlfcn.h>
+
+#include <EGL/egl.h>
+
+static void*
+load_egl_proc_address (const char *name)
+{
+    void *proc_address = eglGetProcAddress (name);
+    if (!proc_address)
+        proc_address = dlsym (RTLD_NEXT, name);
+    return proc_address;
+}

--- a/platform/x11/cog-platform-x11.c
+++ b/platform/x11/cog-platform-x11.c
@@ -18,6 +18,8 @@
 #include <X11/Xlib.h>
 #include <X11/Xlib-xcb.h>
 
+#include "../common/egl-proc-address.h"
+
 
 #ifndef EGL_EXT_platform_base
 #define EGL_EXT_platform_base 1
@@ -593,7 +595,7 @@ clear_xkb (void)
 static gboolean
 init_egl (void)
 {
-    s_display->egl.get_platform_display = (void *) eglGetProcAddress ("eglGetPlatformDisplayEXT");
+    s_display->egl.get_platform_display = load_egl_proc_address ("eglGetPlatformDisplayEXT");
     if (s_display->egl.get_platform_display) {
         s_display->egl.display = s_display->egl.get_platform_display (EGL_PLATFORM_X11_KHR, s_display->display, NULL);
     }
@@ -646,7 +648,7 @@ init_egl (void)
         return FALSE;
 
     Window win = (Window) s_window->xcb.window;
-    s_display->egl.create_platform_window_surface = (void *) eglGetProcAddress ("eglCreatePlatformWindowSurfaceEXT");
+    s_display->egl.create_platform_window_surface = load_egl_proc_address ("eglCreatePlatformWindowSurfaceEXT");
     if (s_display->egl.create_platform_window_surface)
         s_window->egl.surface = s_display->egl.create_platform_window_surface (s_display->egl.display,
                                                                                s_display->egl.config,
@@ -654,7 +656,7 @@ init_egl (void)
     if (s_window->egl.surface == EGL_NO_SURFACE)
         return FALSE;
 
-    s_display->egl.image_target_texture = (void *) eglGetProcAddress ("glEGLImageTargetTexture2DOES");
+    s_display->egl.image_target_texture = load_egl_proc_address ("glEGLImageTargetTexture2DOES");
 
     eglMakeCurrent (s_display->egl.display, s_window->egl.surface, s_window->egl.surface, s_display->egl.context);
     return TRUE;


### PR DESCRIPTION
Provide a common EGL proc address loader function that incorporates
a dlsym-based fallback in case eglGetProcAddress() refuses to find
an otherwise-existing entrypoint.

This should avoid some drivers that fail to handle proc address
requests for specific entrypoints, but have those entrypoints
exported as regular symbols loadable through dlsym().