### PR TITLE
cog-shell: make critical ref counting warning debugging message

### DIFF
--- a/core/cog-shell.c
+++ b/core/cog-shell.c
@@ -526,7 +526,7 @@ cog_shell_remove_view (CogShell   *shell,
     g_object_unref (view);  /* Drop the (hopefully last) ref. */
 
     if (weak_pointer)
-        g_critical ("%s: User code has refs to CogView %p", G_STRFUNC, view);
+        g_debug ("%s: User code has refs to CogView %p", G_STRFUNC, view);
 }
 
 


### PR DESCRIPTION
User code might still be using a view asynchronously when this
is removed from the shell. Since it's not 100% certain that
having a reference to the object after it's removed from the
view means that it's leaked, make it a debugging message instead
of a critical warning instead.