### PR TITLE
CI: Enable building the KMS/DRM platform module

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -57,6 +57,7 @@ script:
         -DCMAKE_BUILD_TYPE=${BUILD_TYPE} \
         -DCOG_DBUS_SYSTEM_BUS=ON \
         -DCOG_PLATFORM_FDO=ON \
+        -DCOG_PLATFORM_DRM=ON \
         ..
   - |-
     : 'Building'


### PR DESCRIPTION
Because it's a good idea to make sure PRs don't break it :smile: 