### PR TITLE
core: Allow resolving base path in URI files handler

### DIFF
--- a/core/cog-directory-files-handler.c
+++ b/core/cog-directory-files-handler.c
@@ -192,17 +192,20 @@ cog_directory_files_handler_run (CogRequestHandler      *request_handler,
      * Check whether the resolved path is contained inside base_path,
      * to prevent URIs with ".." components from accessing resources
      * outside of base_path. The g_file_get_relative_path() method
-     * returns NULL when the file path is NOT descendant of base_path.
+     * returns NULL when the file path is NOT descendant of base_path,
+     * or when both paths are the same.
      */
-    g_autofree char *relative_path = g_file_get_relative_path (base_path, file);
-    if (!relative_path) {
-        g_autoptr(GError) error = g_error_new (G_FILE_ERROR,
-                                               G_FILE_ERROR_PERM,
-                                               "Resolved path '%s' not "
-                                               "contained in base path '%s'",
-                                               g_file_peek_path (file),
-                                               g_file_peek_path (base_path));
-        return webkit_uri_scheme_request_finish_error (request, error);
+    if (!g_file_equal (base_path, file)) {
+        g_autofree char *relative_path = g_file_get_relative_path (base_path, file);
+        if (!relative_path) {
+            g_autoptr(GError) error = g_error_new (G_FILE_ERROR,
+                                                   G_FILE_ERROR_PERM,
+                                                   "Resolved path '%s' not "
+                                                   "contained in base path '%s'",
+                                                   g_file_peek_path (file),
+                                                   g_file_peek_path (base_path));
+            return webkit_uri_scheme_request_finish_error (request, error);
+        }
     }
 
     g_file_query_info_async (file,


### PR DESCRIPTION
When checking whether a resolved path is a descendant of the base path in `cog_directory_files_handler_run()`, allow the resolved path to be the same as the base path. This is needed to allow URIs which point to the root of the base path (either without a path, or a single slash as path) and attempt to find an `index.html` file there.

This fixes a regression introduced by #265