### PR TITLE
fdo: support wpe_fdo_shm_exported_buffer exports

### DIFF
--- a/platform/fdo/cog-platform-fdo.c
+++ b/platform/fdo/cog-platform-fdo.c
@@ -1787,7 +1787,7 @@ shm_buffer_copy_contents (struct shm_buffer *buffer, struct wl_shm_buffer *expor
 }
 
 static void
-on_export_shm_buffer(void* data, struct wpe_fdo_shm_exported_buffer* exported_buffer)
+on_export_shm_buffer (void* data, struct wpe_fdo_shm_exported_buffer* exported_buffer)
 {
     struct wl_resource *exported_resource = wpe_fdo_shm_exported_buffer_get_resource (exported_buffer);
     struct wl_shm_buffer *exported_shm_buffer = wpe_fdo_shm_exported_buffer_get_shm_buffer (exported_buffer);

--- a/platform/fdo/cog-platform-fdo.c
+++ b/platform/fdo/cog-platform-fdo.c
@@ -1814,9 +1814,7 @@ on_export_shm_buffer (void* data, struct wpe_fdo_shm_exported_buffer* exported_b
 
     wl_surface_attach (win_data.wl_surface, buffer->buffer, 0, 0);
     wl_surface_damage (win_data.wl_surface,
-                       0, 0,
-                       win_data.width * wl_data.current_output.scale,
-                       win_data.height * wl_data.current_output.scale);
+                       0, 0, INT32_MAX, INT32_MAX);
     request_frame ();
     wl_surface_commit (win_data.wl_surface);
 }


### PR DESCRIPTION
When software-only GL rasterization is enforced (or when falling back
to it for whatever reason), the Wayland EGL platform implementation
can retreat to producing SHM-based buffers. When using the existing
wpe_view_backend_exportable_fdo_egl_client interface, these arrive as
wpe_fdo_shm_exported_buffer objects. This changeset introduces proper
handling for these types of exports.

This functionality is fairly new in WPEBackend-fdo, so the relevant
code is (where necessary) guarded with the HAVE_SHM_EXPORTED_BUFFER
macro that's enabled for the post-1.8.0 release series.

Once exported, we operate on the wl_resource and wl_shm_buffer objects
that relevantly describe this buffer. For any such export, we provide
a separate shared-memory region that is basis for its own wl_shm_pool
and the wl_buffer that's retrieved from that pool.

We rely on the underlying graphics driver to efficiently handle these
buffers so that our own mappings can be reused as long as the exported
buffers don't change too frequently. This allows us to cache our own
buffer objects based on the exports we receive.

Once we have our own memory regions set up or retrieved from the
cache, we copy over the contents from the exported buffer to the
buffer region we maintain, and the wl_buffer object based on that
region is pushed to the compositor. Right now we effectively mirror
the exported SHM buffer, replicating the size, stride and format of
that buffer.

Buffer objects are cached in a global wl_list. For each export, that
list is traversed to find anything reusable. Each such new cache entry
is also removed when the underlying wl_resource of the export is
destroyed or upon termination.