### PR TITLE
drm: support wpe_fdo_shm_exported_buffer exports

### DIFF
--- a/platform/drm/cog-platform-drm.c
+++ b/platform/drm/cog-platform-drm.c
@@ -787,7 +787,7 @@ drm_copy_shm_buffer_into_bo (struct wl_shm_buffer *shm_buffer, struct gbm_bo *bo
             }
         }
     } else
-        memcpy(dst, src, stride * height);
+        memcpy (dst, src, stride * height);
 
     wl_shm_buffer_end_access (shm_buffer);
     gbm_bo_unmap (bo, map_data);


### PR DESCRIPTION
Handle the wpe_fdo_shm_exported_buffer exports that might arrive on
the wpe_view_backend_exportable_fdo_client interface.

When that occurs, we craft a gbm_bo with the necessary flags that
would allow us to map the bo's underlying memory and write into it.
We still create a framebuffer object off of it, pretty much like we
do it for other types of bos.

The new buffer objects use the existing caching facilities. Each
buffer object, cached or newly created, is updated by mapping the bo
memory into the address space and copying over the data contained
in the shm area.

For now, only ARGB8888 and XRGB8888 SHM formats are handled. In both
cases the corresponding gbm bo will use the XRGB8888 format.