### PR TITLE
fdo: Fix include after #269

### DIFF
--- a/platform/fdo/cog-platform-fdo.c
+++ b/platform/fdo/cog-platform-fdo.c
@@ -6,7 +6,7 @@
  * Distributed under terms of the MIT license.
  */
 
-#include "../core/cog.h"
+#include "../../core/cog.h"
 
 #include <errno.h>
 #include <stdbool.h>


### PR DESCRIPTION
Sadly the CI didn't run in #269 :disappointed:  but it will now after #271 was merged :raised_hands: 