### PR TITLE
cmake: Make it easier to use uninstalled platform modules

### DIFF
--- a/platform/drm/CMakeLists.txt
+++ b/platform/drm/CMakeLists.txt
@@ -13,7 +13,10 @@ add_library(cogplatform-drm MODULE
     kms.c
     cursor-drm.c
 )
-set_property(TARGET cogplatform-drm PROPERTY C_STANDARD 99)
+set_target_properties(cogplatform-fdo PROPERTIES
+    C_STANDARD 99
+    LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}
+)
 target_compile_definitions(cogplatform-drm PRIVATE G_LOG_DOMAIN=\"Cog-DRM\")
 target_link_libraries(cogplatform-drm PRIVATE
     cogcore

--- a/platform/fdo/CMakeLists.txt
+++ b/platform/fdo/CMakeLists.txt
@@ -1,9 +1,10 @@
 # libcogplatform-fdo
 
 add_library(cogplatform-fdo MODULE cog-platform-fdo.c)
-
-set_property(TARGET cogplatform-fdo PROPERTY C_STANDARD 99)
-
+set_target_properties(cogplatform-fdo PROPERTIES
+    C_STANDARD 99
+    LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}
+)
 target_compile_definitions(cogplatform-fdo PRIVATE G_LOG_DOMAIN=\"Cog-FDO\")
 
 find_package(WaylandProtocols REQUIRED)


### PR DESCRIPTION
Place built modules in `${CMAKE_BINARY_DIR}`, which allows to use them uninstalled more easily due to CMake setting the `DT_RUNPATH` of binaries to the top level build directory.