### PR TITLE
CI: Add a CI job that runs clang-format on PR changes

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,148 @@
+---
+Language: Cpp
+# BasedOnStyle:  LLVM
+AccessModifierOffset: -2
+AlignAfterOpenBracket: Align
+AlignConsecutiveMacros: true
+AlignConsecutiveAssignments: false
+AlignConsecutiveBitFields: true
+AlignConsecutiveDeclarations: false
+AlignEscapedNewlines: Right
+AlignOperands: Align
+AlignTrailingComments: true
+AllowAllArgumentsOnNextLine: false
+AllowAllConstructorInitializersOnNextLine: false
+AllowAllParametersOfDeclarationOnNextLine: false
+AllowShortEnumsOnASingleLine: true
+AllowShortBlocksOnASingleLine: Never
+AllowShortCaseLabelsOnASingleLine: false
+AllowShortFunctionsOnASingleLine: All
+AllowShortLambdasOnASingleLine: All
+AllowShortIfStatementsOnASingleLine: Never
+AllowShortLoopsOnASingleLine: false
+AlwaysBreakAfterDefinitionReturnType: None
+AlwaysBreakAfterReturnType: TopLevelDefinitions
+AlwaysBreakBeforeMultilineStrings: false
+AlwaysBreakTemplateDeclarations: MultiLine
+BinPackArguments: false
+BinPackParameters: false
+BraceWrapping:
+  AfterCaseLabel: false
+  AfterClass: false
+  AfterControlStatement: Never
+  AfterEnum: false
+  AfterFunction: false
+  AfterNamespace: false
+  AfterObjCDeclaration: false
+  AfterStruct: false
+  AfterUnion: false
+  AfterExternBlock: false
+  BeforeCatch: false
+  BeforeElse: false
+  BeforeLambdaBody: false
+  BeforeWhile: false
+  IndentBraces: false
+  SplitEmptyFunction: true
+  SplitEmptyRecord: true
+  SplitEmptyNamespace: true
+BreakBeforeBinaryOperators: None
+BreakBeforeBraces: WebKit
+BreakBeforeInheritanceComma: false
+BreakInheritanceList: BeforeColon
+BreakBeforeTernaryOperators: true
+BreakConstructorInitializersBeforeComma: false
+BreakConstructorInitializers: BeforeColon
+BreakAfterJavaFieldAnnotations: false
+BreakStringLiterals: true
+ColumnLimit: 80
+CommentPragmas: '^ IWYU pragma:'
+CompactNamespaces: false
+ConstructorInitializerAllOnOneLineOrOnePerLine: false
+ConstructorInitializerIndentWidth: 4
+ContinuationIndentWidth: 4
+Cpp11BracedListStyle: true
+DeriveLineEnding: true
+DerivePointerAlignment: false
+DisableFormat: false
+ExperimentalAutoDetectBinPacking: true
+FixNamespaceComments: true
+ForEachMacros:
+  - foreach
+  - Q_FOREACH
+  - BOOST_FOREACH
+IncludeBlocks: Preserve
+IncludeCategories:
+  - Regex: '^"(llvm|llvm-c|clang|clang-c)/'
+    Priority: 2
+    SortPriority: 0
+  - Regex: '^(<|"(gtest|gmock|isl|json)/)'
+    Priority: 3
+    SortPriority: 0
+  - Regex: '.*'
+    Priority: 1
+    SortPriority: 0
+IncludeIsMainRegex: '(Test)?$'
+IncludeIsMainSourceRegex: ''
+IndentCaseLabels: false
+IndentCaseBlocks: false
+IndentGotoLabels: true
+IndentPPDirectives: None
+IndentExternBlock: AfterExternBlock
+IndentWidth: 4
+IndentWrappedFunctionNames: false
+InsertTrailingCommas: None
+JavaScriptQuotes: Leave
+JavaScriptWrapImports: true
+KeepEmptyLinesAtTheStartOfBlocks: true
+MacroBlockBegin: ''
+MacroBlockEnd: ''
+MaxEmptyLinesToKeep: 1
+NamespaceIndentation: None
+ObjCBinPackProtocolList: Auto
+ObjCBlockIndentWidth: 2
+ObjCBreakBeforeNestedBlockParam: true
+ObjCSpaceAfterProperty: false
+ObjCSpaceBeforeProtocolList: true
+PenaltyBreakAssignment: 2
+PenaltyBreakBeforeFirstCallParameter: 19
+PenaltyBreakComment: 300
+PenaltyBreakFirstLessLess: 120
+PenaltyBreakString: 1000
+PenaltyBreakTemplateDeclaration: 10
+PenaltyExcessCharacter: 1000000
+PenaltyReturnTypeOnItsOwnLine: 60
+PointerAlignment: Right
+ReflowComments: false
+SortIncludes: true
+SortUsingDeclarations: true
+SpaceAfterCStyleCast: true
+SpaceAfterLogicalNot: false
+SpaceAfterTemplateKeyword: true
+SpaceBeforeAssignmentOperators: true
+SpaceBeforeCpp11BracedList: false
+SpaceBeforeCtorInitializerColon: true
+SpaceBeforeInheritanceColon: true
+SpaceBeforeParens: Always
+SpaceBeforeRangeBasedForLoopColon: true
+SpaceInEmptyBlock: false
+SpaceInEmptyParentheses: false
+SpacesBeforeTrailingComments: 1
+SpacesInAngles: false
+SpacesInConditionalStatement: false
+SpacesInContainerLiterals: true
+SpacesInCStyleCastParentheses: false
+SpacesInParentheses: false
+SpacesInSquareBrackets: false
+SpaceBeforeSquareBrackets: false
+Standard: Latest
+StatementMacros:
+  - Q_UNUSED
+  - QT_REQUIRE_VERSION
+TabWidth: 4
+UseCRLF: false
+UseTab: Never
+WhitespaceSensitiveMacros:
+  - STRINGIZE
+  - PP_STRINGIZE
+  - BOOST_PP_STRINGIZE
+...

--- a/.github/workflows/codestyle.yml
+++ b/.github/workflows/codestyle.yml
@@ -1,0 +1,30 @@
+---
+name: Code Style
+on: [pull_request]
+
+jobs:
+  check:
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Install clang-format
+        run: |
+          sudo apt update
+          sudo apt install -y clang-format
+      - name: Checkout Head
+        uses: actions/checkout@v2
+        with:
+          path: head
+      - name: Checkout Base
+        uses: actions/checkout@v2
+        with:
+          ref: ${{ github.base_ref }}
+          path: base
+      - name: Check
+        run: |
+          diff -NaurU0 base head | head/data/check-style -d -ocode-style.diff
+      - name: Archive Diff
+        uses: actions/upload-artifact@v2
+        if: failure()
+        with:
+          name: diff
+          path: code-style.diff

--- a/data/check-style
+++ b/data/check-style
@@ -1,0 +1,127 @@
+#! /bin/bash
+set -eu -o pipefail
+
+FILE=
+BASE=
+HEAD=
+
+declare -a args=()
+diff_input=false
+show_help=false
+
+for opt in "$@" ; do
+    case "${opt}" in
+        -h | --help)
+            show_help=true
+            ;;
+        -d | --diff)
+            diff_input=true
+            ;;
+        -o*)
+            FILE=${opt#-o}
+            ;;
+        *)
+            args+=("${opt}")
+            ;;
+    esac
+done
+declare -r diff_input show_help
+
+show_help ()
+{
+    echo "Usage: $0 [-o<file>] [-d|--diff] [<committish> [<committish>]]"
+}
+
+if ${show_help} ; then
+    show_help
+    exit
+fi
+
+if [[ ${#args[@]} -eq 1 ]] ; then
+    BASE=${args[0]}
+elif [[ ${#args[@]} -eq 2 ]] ; then
+    BASE=${args[0]}
+    HEAD=${args[1]}
+elif [[ ${#args[@]} -eq 0 ]] && ${diff_input} ; then
+    : no-op
+else
+    show_help 1>&2
+    exit 1
+fi
+declare -r BASE HEAD
+
+declare -ra clang_format_diff_candidates=(
+    # Search in $PATH (Ubuntu, Debian, maybe others)
+    clang-format-diff
+    clang-format-diff.py
+    # Arch Linux, Fedora.
+    /usr/share/clang/clang-format-diff.py
+)
+
+find_program ()
+{
+    local candidate path
+    for candidate in "$@" ; do
+        path=$(type -P "${candidate}")
+        if [[ -x ${path} ]] ; then
+            echo "${path}"
+            return
+        fi
+    done
+
+    # Not found.
+    return 1
+}
+
+clang_format_diff=$(find_program "${clang_format_diff_candidates[@]}")
+clang_format=$(find_program clang-format)
+declare -r clang_format_diff clang_format
+
+if [[ ! -x ${clang_format_diff} ]] ; then
+    echo "$0: clang-format-diff does not seem to be installed" 1>&2
+    exit 1
+fi
+
+if [[ ! -x ${clang_format} ]] ; then
+    echo "$0: clang-format does not seem to be installed" 1>&2
+    exit 1
+fi
+
+#
+# Check the version of clang-format, to make sure that it will support the
+# configuration file. The output of "clang-format --version" is formatted
+# as follows:
+#
+#   clang-format version X.Y.Z
+#
+declare -r clang_format_min_version=10
+
+clang_format_version=$("${clang_format}" --version)
+if [[ ${clang_format_version} =~ ^clang-format[[:space:]]+version[[:space:]]+([[:digit:]]+)\. ]] ; then
+    clang_format_version=${BASH_REMATCH[1]}
+    if [[ ${clang_format_version} -lt ${clang_format_min_version} ]] ; then
+        echo "$0: clang-format ${clang_format_min_version}+ is needed, ${clang_format_version} detected" 1>&2
+        exit 1
+    fi
+else
+    echo "$0: clang-format did not report its version number"
+    exit 1
+fi
+
+if [[ -z ${FILE} ]] ; then
+    FILE=$(mktemp)
+    trap "rm -f '${FILE}'" EXIT
+fi
+
+declare -a input_cmd
+if ${diff_input} ; then
+    input_cmd=(cat)
+else
+    input_cmd=(git diff --no-color -U0 "${BASE}...${HEAD}")
+fi
+
+"${input_cmd[@]}" \
+    | "${clang_format_diff}" -p1 -style=file -regex='.+\.(c|h)' \
+    | tee "${FILE}"
+
+[[ ! -s ${FILE} ]]


### PR DESCRIPTION
Introduce tooling to check the coding style,and a CI worflow which runs it only on the changes introduced by a PR. The goal of checking only the changed code is to avoid having to run a full reformatting of the tree: instead, changes that modified existing code will slowly make the tree drift towards the desired status without introducing noise in the repository history.

There are is some trickery involved in getting this to work reliably:

- The `clang-format-diff` helper script is installed at different locations depending on the distribution. The `check-style` script checks a few locations that cover popular GNU/Linux distributions (Ubuntu, Debian, Arch Linux, Fedora); it can be improved as we see fit in the future.
- The `actions/checkout` step defaults to shallow clones of the single commit which triggered a PR, which is enough to build, but not to find the differences between it and the base commit. To avoid forcing a full fetch of the history, the job uses a second instance of the action to fetch only the base tree in a separate directory.
- Even with both trees checked out, Git will refuse to calculate a diff because the commits are not linked to one another. But both trees are now checked out, so instead it is possible to use a plain   `diff` and feed its output to `check-style --diff`.

As a bonus, the `check-style` script can be run by developers locally from the command line in order to verify their changes prior to filing merge requests, e.g:

```sh
git co -b my-meature
$EDITOR cog.c
git ci -m'Awesome improvements'
data/check-style master
```

The output from the script is an unified diff, which can be piped back into `patch` or `git apply` to get the suggested changes applied to the tree:

```sh
data/check-style master | git apply -p0 -
git add -p && git commit --amend
```