### PR TITLE
drm: enable the platform module by default

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -55,7 +55,7 @@ set(COG_DBUS_OWN_USER "" CACHE STRING
     "Additional user allowed to own the well-known name on the system bus")
 
 option(COG_PLATFORM_FDO "Build the FDO platform module" ON)
-option(COG_PLATFORM_DRM "Build the DRM platform module" OFF)
+option(COG_PLATFORM_DRM "Build the DRM platform module" ON)
 option(COG_PLATFORM_X11 "Build the DRM platform module" OFF)
 option(COG_BUILD_PROGRAMS "Build and install programs as well" ON)
 option(INSTALL_MAN_PAGES "Install the man(1) pages if COG_BUILD_PROGRAMS is enabled" ON)


### PR DESCRIPTION
The thing should be mature enough by now to be enabled by default.
Exception to this are different modifier issues that have to be
solved with different approaches around dmabuf management.