### PR TITLE
fdo: Use WAYLAND_VERSION_* instead of CMake check

### DIFF
--- a/core/cog-config.h.in
+++ b/core/cog-config.h.in
@@ -16,7 +16,6 @@
 #define COG_VERSION_EXTRA "@COG_VERSION_EXTRA@"
 #cmakedefine COG_DEFAULT_APPID "@COG_DEFAULT_APPID@"
 #cmakedefine COG_DEFAULT_HOME_URI "@COG_DEFAULT_HOME_URI@"
-#cmakedefine01 WAYLAND_1_10_OR_GREATER
 
 /* FIXME: Perhaps make this a cmake define instead. */
 #define COG_DEFAULT_APPNAME "Cog"

--- a/platform/fdo/CMakeLists.txt
+++ b/platform/fdo/CMakeLists.txt
@@ -13,12 +13,7 @@ add_wayland_protocol(cogplatform-fdo CLIENT fullscreen-shell-unstable-v1)
 add_wayland_protocol(cogplatform-fdo CLIENT presentation-time)
 add_wayland_protocol(cogplatform-fdo CLIENT linux-dmabuf-unstable-v1)
 
-set(WAYLAND_1_10_OR_GREATER OFF)
 pkg_check_modules(WAYLAND IMPORTED_TARGET REQUIRED wayland-client)
-if (NOT (WAYLAND_VERSION VERSION_LESS 1.10))
-    set(WAYLAND_1_10_OR_GREATER ON)
-endif ()
-
 pkg_check_modules(WpeFDO IMPORTED_TARGET REQUIRED wpebackend-fdo-1.0>=1.3.1)
 pkg_check_modules(EGL IMPORTED_TARGET REQUIRED egl)
 pkg_check_modules(XkbCommon IMPORTED_TARGET REQUIRED xkbcommon)

--- a/platform/fdo/cog-platform-fdo.c
+++ b/platform/fdo/cog-platform-fdo.c
@@ -81,6 +81,13 @@
 # define HAVE_SHM_EXPORTED_BUFFER 0
 #endif
 
+#if defined(WAYLAND_VERSION_MAJOR) && defined(WAYLAND_VERSION_MINOR)
+# define WAYLAND_1_10_OR_GREATER ((WAYLAND_VERSION_MAJOR >= 2) || \
+                                  (WAYLAND_VERSION_MAJOR == 1 && WAYLAND_VERSION_MINOR >= 10))
+#else
+# define WAYLAND_1_10_OR_GREATER 0
+#endif
+
 #if COG_ENABLE_WESTON_DIRECT_DISPLAY
 #define VIDEO_BUFFER_FORMAT DRM_FORMAT_YUYV
 struct video_buffer {


### PR DESCRIPTION
Use the `WAYLAND_VERSION_{MAJOR,MINOR}` macros to check whether the FDO platform plug-in is being built against Wayland 1.10 or newer. This makes it unnecessary to check the version with CMake.

This also fixes a recent regression which caused `WAYLAND_1_10_OR_GREATER` to not be defined by CMake anymore.