### PR TITLE
Depend on WPE WebKit 2.28, libwpe+WPEBackend-fdo 1.5

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -115,29 +115,10 @@ set(COGCORE_SOURCES
 
 pkg_check_modules(GIO IMPORTED_TARGET REQUIRED gio-2.0>=2.44)
 pkg_check_modules(SOUP IMPORTED_TARGET REQUIRED libsoup-2.4)
-
-# There is no need to explicitly check wpe-1.0 here because it's a
-# dependency already specified in the wpe-webkit.pc file.
-pkg_check_modules(WEB_ENGINE IMPORTED_TARGET REQUIRED wpe-webkit-1.0>=2.23.91)
-if ("${WEB_ENGINE_VERSION}" VERSION_GREATER "2.23")
-    add_definitions(-DCOG_BG_COLOR_API_SUPPORTED=1)
-else ()
-    add_definitions(-DCOG_BG_COLOR_API_SUPPORTED=0)
-endif ()
-if ("${WEB_ENGINE_VERSION}" VERSION_GREATER "2.27.3")
-    set(COG_IM_API_SUPPORTED ON)
-else ()
-    set(COG_IM_API_SUPPORTED OFF)
-endif ()
-if (COG_PLATFORM_FDO AND "${WEB_ENGINE_VERSION}" VERSION_GREATER "2.27.3")
-    set(COG_FDO_WIDGETS_SUPPORTED ON)
-else ()
-    set(COG_FDO_WIDGETS_SUPPORTED OFF)
-endif ()
+pkg_check_modules(WebKit IMPORTED_TARGET REQUIRED wpe-webkit-1.0>=2.28.0 wpe-1.0>=1.6.0)
 
 include(CheckCCompilerFlag)
 check_c_compiler_flag(-Wall HAS_WALL)
-
 
 if (COG_DBUS_SYSTEM_BUS)
     # Generate and install D-Bus policy configuration file.
@@ -159,7 +140,7 @@ set_target_properties(cogcore PROPERTIES
     VERSION ${COGCORE_VERSION}
     SOVERSION ${COGCORE_VERSION_MAJOR}
 )
-target_link_libraries(cogcore PkgConfig::WEB_ENGINE PkgConfig::SOUP)
+target_link_libraries(cogcore PkgConfig::WebKit PkgConfig::SOUP)
 target_compile_definitions(cogcore PRIVATE G_LOG_DOMAIN=\"Cog-Core\")
 if (HAS_WALL)
     target_compile_options(cogcore PUBLIC -Wall)

--- a/cog.c
+++ b/cog.c
@@ -12,12 +12,6 @@
 #include <string.h>
 #include "core/cog.h"
 
-#if defined(WPE_CHECK_VERSION) && WPE_CHECK_VERSION(1, 3, 0)
-# define HAVE_DEVICE_SCALING 1
-#else
-# define HAVE_DEVICE_SCALING 0
-#endif /* WPE_CHECK_VERSION */
-
 enum webprocess_fail_action {
     WEBPROCESS_FAIL_UNKNOWN = 0,
     WEBPROCESS_FAIL_ERROR_PAGE,
@@ -34,9 +28,7 @@ static struct {
     gboolean print_appid;
     gboolean doc_viewer;
     gdouble  scale_factor;
-#if HAVE_DEVICE_SCALING
     gdouble  device_scale_factor;
-#endif // HAVE_DEVICE_SCALING
     GStrv    dir_handlers;
     GStrv    arguments;
     char    *background_color;
@@ -52,9 +44,7 @@ static struct {
     gboolean ignore_tls_errors;
 } s_options = {
     .scale_factor = 1.0,
-#if HAVE_DEVICE_SCALING
     .device_scale_factor = 1.0,
-#endif // HAVE_DEVICE_SCALING
 };
 
 
@@ -69,11 +59,9 @@ static GOptionEntry s_cli_options[] =
     { "scale", '\0', 0, G_OPTION_ARG_DOUBLE, &s_options.scale_factor,
         "Zoom/Scaling factor applied to Web content (default: 1.0, no scaling)",
         "FACTOR" },
-#if HAVE_DEVICE_SCALING
     { "device-scale", '\0', 0, G_OPTION_ARG_DOUBLE, &s_options.device_scale_factor,
         "Output device scaling factor (default: 1.0, no scaling, 96 DPI)",
         "FACTOR" },
-#endif // HAVE_DEVICE_SCALING
     { "doc-viewer", '\0', 0, G_OPTION_ARG_NONE, &s_options.doc_viewer,
         "Document viewer mode: optimizes for local loading of Web content. "
         "This reduces memory usage at the cost of reducing caching of "
@@ -395,11 +383,8 @@ on_create_view (CogShell *shell, void *user_data G_GNUC_UNUSED)
 
     if (s_options.platform) {
         cog_platform_init_web_view (s_options.platform, web_view);
-
-#if COG_IM_API_SUPPORTED
         g_autoptr(WebKitInputMethodContext) im_context = cog_platform_create_im_context (s_options.platform);
         webkit_web_view_set_input_method_context (web_view, im_context);
-#endif
     }
 
     if (s_options.background_color != NULL) {

--- a/core/cog-platform.c
+++ b/core/cog-platform.c
@@ -127,12 +127,10 @@ cog_platform_init_web_view (CogPlatform   *platform,
 WebKitInputMethodContext*
 cog_platform_create_im_context (CogPlatform *platform)
 {
-#if COG_IM_API_SUPPORTED
     g_return_val_if_fail (platform != NULL, NULL);
 
     if (platform->create_im_context)
         return platform->create_im_context (platform);
-#endif
 
     return NULL;
 }

--- a/core/cog-webkit-utils.h
+++ b/core/cog-webkit-utils.h
@@ -19,19 +19,6 @@
 
 G_BEGIN_DECLS
 
-#if !WEBKIT_CHECK_VERSION(2, 23, 0)
-
-/* Define cleanup functions to enable using g_auto* with WebKit types. */
-
-G_DEFINE_AUTOPTR_CLEANUP_FUNC (WebKitWebContext, g_object_unref)
-G_DEFINE_AUTOPTR_CLEANUP_FUNC (WebKitWebView, g_object_unref)
-G_DEFINE_AUTOPTR_CLEANUP_FUNC (WebKitSettings, g_object_unref)
-G_DEFINE_AUTOPTR_CLEANUP_FUNC (WebKitURISchemeRequest, g_object_unref)
-G_DEFINE_AUTOPTR_CLEANUP_FUNC (WebKitWebsiteDataManager, g_object_unref)
-
-#endif /* WEBKIT_CHECK_VERSION */
-
-
 gboolean cog_handle_web_view_load_failed (WebKitWebView  *web_view,
                                           WebKitLoadEvent load_event,
                                           char           *failing_uri,

--- a/platform/drm/CMakeLists.txt
+++ b/platform/drm/CMakeLists.txt
@@ -1,7 +1,7 @@
 # libcogplatform-drm
 
 pkg_check_modules(EGL IMPORTED_TARGET REQUIRED egl)
-pkg_check_modules(WpeFDO IMPORTED_TARGET REQUIRED wpebackend-fdo-1.0>=1.3.1)
+pkg_check_modules(WpeFDO IMPORTED_TARGET REQUIRED wpebackend-fdo-1.0>=1.4.0)
 pkg_check_modules(LibDRM IMPORTED_TARGET REQUIRED libdrm>=2.4.71)
 pkg_check_modules(LibGBM IMPORTED_TARGET REQUIRED gbm>=13.0)
 pkg_check_modules(LibInput IMPORTED_TARGET REQUIRED libinput)
@@ -25,8 +25,8 @@ target_link_libraries(cogplatform-drm PRIVATE
     PkgConfig::LibGBM
     PkgConfig::LibInput
     PkgConfig::LibUdev
-    PkgConfig::WEB_ENGINE
     PkgConfig::WaylandServer
+    PkgConfig::WebKit
     PkgConfig::WpeFDO
 )
 

--- a/platform/drm/cog-platform-drm.c
+++ b/platform/drm/cog-platform-drm.c
@@ -30,12 +30,6 @@ typedef EGLDisplay (EGLAPIENTRYP PFNEGLGETPLATFORMDISPLAYEXTPROC) (EGLenum platf
 #define EGL_PLATFORM_GBM_KHR 0x31D7
 #endif
 
-#if defined(WPE_CHECK_VERSION)
-# define HAVE_DEVICE_SCALING WPE_CHECK_VERSION(1, 3, 0)
-#else
-# define HAVE_DEVICE_SCALING 0
-#endif
-
 #if defined(WPE_FDO_CHECK_VERSION)
 # define HAVE_SHM_EXPORTED_BUFFER WPE_FDO_CHECK_VERSION(1, 9, 0)
 #else
@@ -1620,8 +1614,6 @@ void
 cog_platform_plugin_init_web_view (CogPlatform   *platform,
                                    WebKitWebView *view)
 {
-#ifdef HAVE_DEVICE_SCALING
     wpe_view_backend_dispatch_set_device_scale_factor (wpe_view_data.backend,
                                                        drm_data.device_scale);
-#endif
 }

--- a/platform/fdo/CMakeLists.txt
+++ b/platform/fdo/CMakeLists.txt
@@ -1,6 +1,12 @@
 # libcogplatform-fdo
 
-add_library(cogplatform-fdo MODULE cog-platform-fdo.c)
+add_library(cogplatform-fdo MODULE
+    cog-im-context-fdo-v1.c
+    cog-im-context-fdo.c
+    cog-platform-fdo.c
+    cog-popup-menu-fdo.c
+    os-compatibility.c
+)
 set_target_properties(cogplatform-fdo PROPERTIES
     C_STANDARD 99
     LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}
@@ -8,21 +14,25 @@ set_target_properties(cogplatform-fdo PROPERTIES
 target_compile_definitions(cogplatform-fdo PRIVATE G_LOG_DOMAIN=\"Cog-FDO\")
 
 find_package(WaylandProtocols REQUIRED)
-add_wayland_protocol(cogplatform-fdo CLIENT xdg-shell)
 add_wayland_protocol(cogplatform-fdo CLIENT fullscreen-shell-unstable-v1)
-add_wayland_protocol(cogplatform-fdo CLIENT presentation-time)
 add_wayland_protocol(cogplatform-fdo CLIENT linux-dmabuf-unstable-v1)
+add_wayland_protocol(cogplatform-fdo CLIENT presentation-time)
+add_wayland_protocol(cogplatform-fdo CLIENT text-input-unstable-v1)
+add_wayland_protocol(cogplatform-fdo CLIENT text-input-unstable-v3)
+add_wayland_protocol(cogplatform-fdo CLIENT xdg-shell)
 
-pkg_check_modules(WAYLAND IMPORTED_TARGET REQUIRED wayland-client)
-pkg_check_modules(WpeFDO IMPORTED_TARGET REQUIRED wpebackend-fdo-1.0>=1.3.1)
+pkg_check_modules(Cairo IMPORTED_TARGET cairo)
 pkg_check_modules(EGL IMPORTED_TARGET REQUIRED egl)
+pkg_check_modules(WAYLAND IMPORTED_TARGET REQUIRED wayland-client)
+pkg_check_modules(WpeFDO IMPORTED_TARGET REQUIRED wpebackend-fdo-1.0>=1.6.0)
 pkg_check_modules(XkbCommon IMPORTED_TARGET REQUIRED xkbcommon)
 
 target_link_libraries(cogplatform-fdo PRIVATE
     cogcore
+    PkgConfig::Cairo
     PkgConfig::EGL
     PkgConfig::WAYLAND
-    PkgConfig::WEB_ENGINE
+    PkgConfig::WebKit
     PkgConfig::WpeFDO
 )
 
@@ -35,39 +45,6 @@ install(TARGETS cogplatform-fdo
     DESTINATION ${CMAKE_INSTALL_LIBDIR}
     COMPONENT "runtime"
 )
-
-# Input methods extension.
-if (COG_IM_API_SUPPORTED)
-    target_sources(cogplatform-fdo PRIVATE
-        cog-im-context-fdo.c
-        cog-im-context-fdo-v1.c
-    )
-    add_wayland_protocol(cogplatform-fdo CLIENT text-input-unstable-v1)
-    add_wayland_protocol(cogplatform-fdo CLIENT text-input-unstable-v3)
-    target_compile_options(cogcore PRIVATE -DCOG_IM_API_SUPPORTED=1)
-    if (COG_BUILD_PROGRAMS)
-        target_compile_options(cog PRIVATE -DCOG_IM_API_SUPPORTED=1)
-    endif ()
-    target_compile_definitions(cogplatform-fdo PRIVATE COG_IM_API_SUPPORTED=1)
-else ()
-    target_compile_options(cogcore PRIVATE -DCOG_IM_API_SUPPORTED=0)
-    if (COG_BUILD_PROGRAMS)
-        target_compile_options(cog PRIVATE -DCOG_IM_API_SUPPORTED=0)
-    endif ()
-    target_compile_definitions(cogplatform-fdo PRIVATE COG_IM_API_SUPPORTED=0)
-endif ()
-
-if (COG_FDO_WIDGETS_SUPPORTED)
-    pkg_check_modules(CAIRO IMPORTED_TARGET cairo)
-    target_link_libraries(cogplatform-fdo PRIVATE PkgConfig::CAIRO)
-    target_sources(cogplatform-fdo PRIVATE
-        cog-popup-menu-fdo.c
-        os-compatibility.c
-    )
-    target_compile_definitions(cogplatform-fdo PRIVATE COG_FDO_WIDGETS_SUPPORTED=1)
-else ()
-    target_compile_definitions(cogplatform-fdo PRIVATE COG_FDO_WIDGETS_SUPPORTED=0)
-endif ()
 
 if (COG_WESTON_DIRECT_DISPLAY)
 

--- a/platform/gtk4/CMakeLists.txt
+++ b/platform/gtk4/CMakeLists.txt
@@ -6,7 +6,7 @@ add_library(cogplatform-gtk4 MODULE
     cog-gtk-settings-cell-renderer-variant.c)
 target_link_libraries(cogplatform-gtk4 PRIVATE
     PkgConfig::COGPLATFORM_GTK4_DEPS
-    PkgConfig::WEB_ENGINE
+    PkgConfig::WebKit
 )
 set_target_properties(cogplatform-gtk4 PROPERTIES
     LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR})

--- a/platform/x11/CMakeLists.txt
+++ b/platform/x11/CMakeLists.txt
@@ -1,7 +1,7 @@
 # libcogplaform-x11
 
 pkg_check_modules(COGPLATFORM_X11_DEPS IMPORTED_TARGET
-    REQUIRED wpe-webkit-1.0>=2.24.0 wpebackend-fdo-1.0>=1.3.1 egl xcb xkbcommon-x11)
+    REQUIRED wpebackend-fdo-1.0>=1.6.0 egl xcb xkbcommon-x11)
 
 add_library(cogplatform-x11 MODULE cog-platform-x11.c)
 set_target_properties(cogplatform-x11 PROPERTIES
@@ -9,7 +9,10 @@ set_target_properties(cogplatform-x11 PROPERTIES
     LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}
 )
 target_compile_definitions(cogplatform-x11 PRIVATE G_LOG_DOMAIN=\"Cog-X11\")
-target_link_libraries(cogplatform-x11 PRIVATE cogcore PkgConfig::COGPLATFORM_X11_DEPS)
+target_link_libraries(cogplatform-x11 PRIVATE cogcore
+    PkgConfig::COGPLATFORM_X11_DEPS
+    PkgConfig::WebKit
+)
 
 install(TARGETS cogplatform-x11
     DESTINATION ${CMAKE_INSTALL_LIBDIR}

--- a/platform/x11/cog-platform-x11.c
+++ b/platform/x11/cog-platform-x11.c
@@ -44,12 +44,6 @@ typedef void (GL_APIENTRYP PFNGLEGLIMAGETARGETRENDERBUFFERSTORAGEOESPROC) (GLenu
 #define DEFAULT_WIDTH  1024
 #define DEFAULT_HEIGHT  768
 
-#if defined(WPE_CHECK_VERSION)
-# define HAVE_2D_AXIS_EVENT WPE_CHECK_VERSION(1, 5, 0) && WEBKIT_CHECK_VERSION(2, 27, 4)
-#else
-# define HAVE_2D_AXIS_EVENT 0
-#endif /* WPE_CHECK_VERSION */
-
 
 struct CogX11Display {
     Display *display;
@@ -249,7 +243,6 @@ xcb_handle_key_release (xcb_key_press_event_t *event)
 static void
 xcb_handle_axis (xcb_button_press_event_t *event, const int16_t axis_delta[2])
 {
-#if HAVE_2D_AXIS_EVENT
     struct wpe_input_axis_2d_event input_event = {
         .base = {
             .type = wpe_input_axis_event_type_mask_2d | wpe_input_axis_event_type_motion_smooth,
@@ -262,26 +255,6 @@ xcb_handle_axis (xcb_button_press_event_t *event, const int16_t axis_delta[2])
     };
 
     wpe_view_backend_dispatch_axis_event (s_window->wpe.backend, &input_event.base);
-#else
-    assert (axis_delta[0] ^ axis_delta[1]);
-
-    struct wpe_input_axis_event input_event = {
-        .type = wpe_input_axis_event_type_motion,
-        .time = event->time,
-        .x = s_display->xcb.pointer.x,
-        .y = s_display->xcb.pointer.y,
-    };
-
-    if (!!axis_delta[0]) {
-        input_event.axis = 1;
-        input_event.value = axis_delta[0];
-    } else {
-        input_event.axis = 0;
-        input_event.value = axis_delta[1];
-    }
-
-    wpe_view_backend_dispatch_axis_event (s_window->wpe.backend, &input_event);
-#endif
 }
 
 static void


### PR DESCRIPTION
Update the minimum required versions to the following, which are all more than one year old:

- WPE WebKit 2.27.3, the oldest development version of the 2.28 series   which already has most of the features used by Cog.
- libwpe and WPEBackend-fdo 1.5.0, with the same reasoning.

This allows removing a bunch of conditional code.

Fixes #241