### PR TITLE
Support building documentation using gi-docgen

### DIFF
--- a/.github/workflows/ci-cross.yml
+++ b/.github/workflows/ci-cross.yml
@@ -1,5 +1,5 @@
 ---
-name: CI
+name: "Build - ARM"
 on: [push]
 
 jobs:
@@ -15,12 +15,12 @@ jobs:
         run: |
           sudo apt update
           sudo apt install -y cmake ninja-build
-      - name: Toolchain Cache
+      - name: Cache
         uses: actions/cache@v2
         id: cache
         with:
           path: ~/toolchain
-          key: tc-${{ runner.os }}-${{ hashFiles('.github/toolchain.sh') }}
+          key: arm-${{ runner.os }}-${{ hashFiles('.github/toolchain.sh') }}
           restore-keys: tc-${{ runner.os }}-
       - name: Install Toolchain
         run: |-

--- a/.github/workflows/ci-native.yml
+++ b/.github/workflows/ci-native.yml
@@ -1,0 +1,78 @@
+---
+name: "Build - Native"
+on: [push]
+
+jobs:
+  build:
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Cache
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.cache/pip
+            ~/libwpe
+          key: native-${{ runner.os }}-${{ hashFiles('.github/workflows/ci-native.yml') }}
+          restore-keys: native-${{ runner.os }}-
+      - name: Install Debian Packages
+        run: |
+          sudo apt update
+          sudo apt install -y cmake ninja-build gobject-introspection \
+            libwpewebkit-1.0-dev libgles2-mesa-dev  libwpe-1.0-dev \
+            libgirepository1.0-dev gir1.2-glib-2.0 gir1.2-soup-2.4 \
+            libwayland-bin libwayland-dev wayland-protocols libepoxy-dev \
+            libdrm-dev libinput-dev libudev-dev libgbm-dev \
+            libxkbcommon-x11-dev libx11-xcb-dev
+      - name: Setup Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.8
+      - name: Install Python Packages
+        run: |
+          pip install --upgrade pip gi-docgen==2021.2 meson==0.49
+          printf '#! /bin/sh\nexec python -m gidocgen.gidocmain "$@"\n' \
+            > "$(which gi-docgen)"
+      - name: Fetch WPEBackend-fdo
+        run: |
+          if [[ -d ~/WPEBackend-fdo/.git ]] ; then
+            echo 'Updating WPEBackend-fdo clone...'
+            cd ~/WPEBackend-fdo/
+            git reset --hard
+            git clean -qxdff
+            git checkout -f master
+            git pull -q
+          else
+            echo 'Cloning WPEBackend-fdo afresh...'
+            rm -rf ~/WPEBackend-fdo/
+            git clone -q https://github.com/Igalia/WPEBackend-fdo ~/WPEBackend-fdo
+          fi
+      - name: Build and Install WPEBackend-fdo
+        env:
+          TERM: dumb
+        run: |
+          meson --prefix ~/prefix --libdir ~/prefix/lib \
+            ~/WPEBackend-fdo-build ~/WPEBackend-fdo
+          ninja -C ~/WPEBackend-fdo-build install
+      - name: Configure
+        run: |
+          export PKG_CONFIG_PATH=${HOME}/prefix/lib/pkgconfig/
+          mkdir ~/build/ && cd "$_"
+          cmake "${GITHUB_WORKSPACE}" \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DCOG_PLATFORM_FDO=ON \
+            -DCOG_PLATFORM_DRM=ON \
+            -DCOG_PLATFORM_X11=ON \
+            -DBUILD_DOCS=ON \
+            -GNinja
+      - name: Build
+        env:
+          TERM: dumb
+        run:
+          ninja -C ~/build/
+      - name: Archive Documentation
+        uses: actions/upload-artifact@v2
+        with:
+          name: docs
+          path: ~/build/docs/html

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -60,6 +60,7 @@ option(COG_PLATFORM_X11 "Build the DRM platform module" OFF)
 option(COG_BUILD_PROGRAMS "Build and install programs as well" ON)
 option(INSTALL_MAN_PAGES "Install the man(1) pages if COG_BUILD_PROGRAMS is enabled" ON)
 option(COG_WESTON_DIRECT_DISPLAY "Build direct display support for the FDO platform module" OFF)
+option(BUILD_DOCS "Build the documentation" OFF)
 
 set(COG_APPID "" CACHE STRING "Default GApplication unique identifier")
 set(COG_HOME_URI "" CACHE STRING "Default home URI")
@@ -150,7 +151,7 @@ if (COG_DBUS_SYSTEM_BUS)
     add_definitions(-DCOG_DBUS_OWN_USER=\"${COG_DBUS_OWN_USER}\")
 endif ()
 
-add_library(cogcore SHARED ${COGCORE_SOURCES})
+add_library(cogcore SHARED ${COGCORE_SOURCES} ${COGCORE_API_HEADERS})
 set_target_properties(cogcore PROPERTIES
     C_STANDARD 99
     VERSION ${COGCORE_VERSION}
@@ -201,11 +202,16 @@ install(FILES ${COGCORE_API_HEADERS}
     COMPONENT "development"
 )
 
+configure_file(core/cog-config.h.in cog-config.h @ONLY)
 configure_file(core/cogcore.pc.in cogcore.pc @ONLY)
 install(FILES ${CMAKE_CURRENT_BINARY_DIR}/cogcore.pc
     DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig
     COMPONENT "development"
 )
+
+if (BUILD_DOCS)
+    add_subdirectory(docs)
+endif ()
 
 add_subdirectory(platform/headless)
 if (COG_PLATFORM_FDO)
@@ -217,5 +223,3 @@ endif ()
 if (COG_PLATFORM_X11)
     add_subdirectory(platform/x11)
 endif ()
-
-configure_file(core/cog-config.h.in cog-config.h @ONLY)

--- a/cmake/FindGObjectIntrospection.cmake
+++ b/cmake/FindGObjectIntrospection.cmake
@@ -1,0 +1,66 @@
+# - Try to find gobject-introspection
+# Once done, this will define
+#
+#  INTROSPECTION_FOUND - system has gobject-introspection
+#  INTROSPECTION_SCANNER - the gobject-introspection scanner, g-ir-scanner
+#  INTROSPECTION_COMPILER - the gobject-introspection compiler, g-ir-compiler
+#  INTROSPECTION_GENERATE - the gobject-introspection generate, g-ir-generate
+#  INTROSPECTION_GIRDIR
+#  INTROSPECTION_TYPELIBDIR
+#  INTROSPECTION_CFLAGS
+#  INTROSPECTION_LIBS
+#
+# Copyright (C) 2010, Pino Toscano, <pino@kde.org>
+# Copyright (C) 2014 Igalia S.L.
+#
+# Redistribution and use is allowed according to the terms of the BSD license.
+
+macro(_GIR_GET_PKGCONFIG_VAR _outvar _varname _extra_args)
+    execute_process(
+        COMMAND ${PKG_CONFIG_EXECUTABLE} --variable=${_varname} ${_extra_args} gobject-introspection-1.0
+        OUTPUT_VARIABLE _result
+        RESULT_VARIABLE _null
+    )
+
+    if (_null)
+    else ()
+        string(REGEX REPLACE "[\r\n]" " " _result "${_result}")
+        string(REGEX REPLACE " +$" ""  _result "${_result}")
+        separate_arguments(_result)
+        set(${_outvar} ${_result} CACHE INTERNAL "")
+    endif ()
+endmacro(_GIR_GET_PKGCONFIG_VAR)
+
+find_package(PkgConfig QUIET)
+if (PKG_CONFIG_FOUND)
+    if (PACKAGE_FIND_VERSION_COUNT GREATER 0)
+        set(_gir_version_cmp ">=${PACKAGE_FIND_VERSION}")
+    endif ()
+    pkg_check_modules(_pc_gir gobject-introspection-1.0${_gir_version_cmp})
+    if (_pc_gir_FOUND)
+        set(INTROSPECTION_FOUND TRUE)
+        _gir_get_pkgconfig_var(INTROSPECTION_SCANNER "g_ir_scanner" "")
+        _gir_get_pkgconfig_var(INTROSPECTION_COMPILER "g_ir_compiler" "")
+        _gir_get_pkgconfig_var(INTROSPECTION_GENERATE "g_ir_generate" "")
+        _gir_get_pkgconfig_var(INTROSPECTION_GIRDIR "girdir" "")
+        _gir_get_pkgconfig_var(INTROSPECTION_TYPELIBDIR "typelibdir" "")
+        set(INTROSPECTION_VERSION "${_pc_gir_VERSION}")
+        if (${INTROSPECTION_VERSION} VERSION_GREATER_EQUAL "1.59.1")
+            set(INTROSPECTION_HAVE_SOURCES_TOP_DIRS YES)
+        endif ()
+        set(INTROSPECTION_CFLAGS "${_pc_gir_CFLAGS}")
+        set(INTROSPECTION_LIBS "${_pc_gir_LIBS}")
+    endif ()
+endif ()
+
+mark_as_advanced(
+    INTROSPECTION_SCANNER
+    INTROSPECTION_COMPILER
+    INTROSPECTION_GENERATE
+    INTROSPECTION_GIRDIR
+    INTROSPECTION_TYPELIBDIR
+    INTROSPECTION_CFLAGS
+    INTROSPECTION_LIBS
+    INTROSPECTION_VERSION
+    INTROSPECTION_HAVE_SOURCES_TOP_DIRS
+)

--- a/docs/CMakeLists.txt
+++ b/docs/CMakeLists.txt
@@ -1,0 +1,87 @@
+find_package(GObjectIntrospection REQUIRED)
+find_program(GI_DOCGEN
+    NAMES gi-docgen gi-docgen.py
+    HINTS "${CMAKE_SOURCE_DIR}/gi-docgen"
+    DOC "Path to the gi-docgen program"
+    REQUIRED
+)
+
+message(STATUS "Using g-ir-scanner: ${INTROSPECTION_SCANNER}")
+message(STATUS "Using gi-docgen: ${GI_DOCGEN}")
+
+configure_file(cog.toml.in cog.toml @ONLY)
+
+# TODO: Probably should be moved somewhere else, and use the API
+#       version string for other things, e.g. the library name.
+set(COGCORE_API_VERSION "${PROJECT_VERSION_MAJOR}.0")
+set(COGCORE_GIR_NAME "Cog-${COGCORE_API_VERSION}")
+set(COGCORE_GIR "${CMAKE_CURRENT_BINARY_DIR}/${COGCORE_GIR_NAME}.gir")
+
+function (get_target_doc_sources target varname)
+    set(result "")
+    get_property(sources TARGET ${target} PROPERTY SOURCES)
+    get_property(srcdir TARGET ${target} PROPERTY SOURCE_DIR)
+    foreach (src IN LISTS sources)
+        get_filename_component(src "${src}" REALPATH BASE_DIR "${srcdir}")
+        get_property(isobject SOURCE "${src}" PROPERTY EXTERNAL_OBJECT)
+        get_property(location SOURCE "${src}" PROPERTY LOCATION)
+        if (NOT isobject)
+            list(APPEND result "${location}")
+        endif ()
+    endforeach ()
+    set(${varname} ${result} PARENT_SCOPE)
+endfunction ()
+
+function (get_target_include_flags target varname)
+    set(result "")
+    get_property(dirs TARGET ${target} PROPERTY INCLUDE_DIRECTORIES)
+    foreach (dir IN LISTS dirs)
+        list(APPEND result "-I${dir}")
+    endforeach ()
+    set(${varname} ${result} PARENT_SCOPE)
+endfunction ()
+
+get_target_doc_sources(cogcore COGCORE_DOC_SOURCES)
+get_target_include_flags(cogcore COGCORE_DOC_IFLAGS)
+
+add_custom_command(
+    OUTPUT "${COGCORE_GIR}"
+    COMMENT "Generating ${COGCORE_GIR_NAME}.gir ..."
+    WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}"
+    DEPENDS ${COGCORE_DOC_SOURCES}
+    VERBATIM
+    COMMAND CC="${CMAKE_C_COMPILER}"
+        ${INTROSPECTION_SCANNER}
+        --output=${COGCORE_GIR}
+        --warn-all
+        --no-libtool
+        --library=$<TARGET_FILE_BASE_NAME:cogcore>
+        --library-path=$<TARGET_FILE_DIR:cogcore>
+        --nsversion=${COGCORE_API_VERSION}
+        --c-include=cog/cog.h
+        --namespace=Cog
+        --identifier-prefix=Cog
+        --symbol-prefix=cog
+        --pkg-export=cogcore
+        --pkg=wpe-webkit-1.0
+        --pkg=gobject-2.0
+        --pkg=gio-2.0
+        --pkg=glib-2.0
+        ${COGCORE_DOC_IFLAGS}
+        ${COGCORE_DOC_SOURCES}
+)
+
+add_custom_command(
+    OUTPUT html/index.html
+    WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}"
+    COMMENT "Generating documentation for ${COGCORE_GIR_NAME} ..."
+    DEPENDS cog.toml ${COGCORE_GIR}
+    VERBATIM
+    COMMAND "${GI_DOCGEN}" generate --quiet --no-namespace-dir
+        --content-dir ${CMAKE_CURRENT_SOURCE_DIR}
+        --output-dir ${CMAKE_CURRENT_BINARY_DIR}/html
+        --config ${CMAKE_CURRENT_BINARY_DIR}/cog.toml
+        ${COGCORE_GIR}
+)
+
+add_custom_target(doc ALL DEPENDS html/index.html)

--- a/docs/cog.toml.in
+++ b/docs/cog.toml.in
@@ -1,0 +1,38 @@
+[library]
+description = "The Cog core library"
+license = "MIT"
+authors = "The WPE WebKit team"
+version = "@PROJECT_VERSION@"
+browse_url = "https://github.com/Igalia/cog"
+repository_url = "https://github.com/Igalia/cog"
+website_url = "https://wpewebkit.org"
+dependencies = ["GObject-2.0", "Gio-2.0", "Soup-2.4"]
+devhelp = true
+search_index = true
+
+[dependencies."GObject-2.0"]
+name = "GObject"
+description = "The base type system library"
+docs_url = "https://developer.gnome.org/gobject/stable"
+
+[dependencies."Gio-2.0"]
+name = "Gio"
+description = "The GLib input/output library"
+docs_url = "https://developer.gnome.org/gio/stable"
+
+[dependencies."Soup-2.4"]
+name = "Soup"
+description = "The Soup networking library"
+docs_url = "https://developer.gnome.org/libsoup/stable"
+
+[theme]
+name = "basic"
+show_index_summary = true
+show_class_hierarchy = true
+
+[source-location]
+base_url = "https://github.com/Igalia/cog/blob/master/"
+
+[extra]
+content_files = []
+content_images = []


### PR DESCRIPTION
Add support for building documentation for the `cogcore` library using [gi-docgen](https://gitlab.gnome.org/ebassi/gi-docgen), and the corresponding CI steps to build and archive the documentation as an artifact. In the future we could also setup automatic deployment of the generated content to `wpewebkit.org` or to GitHub pages when a push to the main branch happens and/or a tag is created.

A preview (not kept updated) can be found at https://fugu.perezdecastro.org/Cog-0.0/

For now there is not a lot documented, but at least we need to start somewhere 😄 