### PR TITLE
CI: Publish docs on pushes to main branch

### DIFF
--- a/.github/workflows/ci-native.yml
+++ b/.github/workflows/ci-native.yml
@@ -76,3 +76,18 @@ jobs:
         with:
           name: docs
           path: ~/build/docs/html
+  publish:
+    if: ${{ github.ref == 'refs/heads/aperezdc/main' }}
+    needs: build
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Fetch Documentation
+        uses: actions/download-artifact@v2
+        with:
+          name: docs
+          path: html
+      - name: Deploy Documentation
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: html


### PR DESCRIPTION
Publishes the archived documentation artifacts after pushes to the main branch. Could be extended at some point for tags.