### PR TITLE
README: Update status badges

### DIFF
--- a/.github/workflows/codestyle.yml
+++ b/.github/workflows/codestyle.yml
@@ -17,7 +17,7 @@ jobs:
           sudo add-apt-repository \
             'deb http://apt.llvm.org/focal/ llvm-toolchain-focal-11 main'
           sudo apt update
-          sudo apt install -y clang-format-11
+          sudo apt install -y clang-format-11 diffutils
       - name: Checkout Base
         uses: actions/checkout@v2
         with:
@@ -26,8 +26,7 @@ jobs:
       - name: Check
         run: |
           cd "${GITHUB_WORKSPACE}"
-          git diff --no-color --no-index -U0 --histogram --exit-code \
-            --no-index -- base head > checkouts.diff || rc=$?
+          diff -NaurU0 base head > checkouts.diff || rc=$?
           if [[ $rc -eq 1 ]] ; then
             cd head
             data/check-style -d -o../code-style.diff < ../checkouts.diff

--- a/README.md
+++ b/README.md
@@ -3,7 +3,9 @@ Cog
 
 ![Cog (boat)](data/cog.png)
 
-[![Build Status](https://travis-ci.com/Igalia/cog.svg?branch=master)](https://travis-ci.com/Igalia/cog)
+[![Build - Native](https://github.com/Igalia/cog/actions/workflows/ci-native.yml/badge.svg)](https://github.com/Igalia/cog/actions/workflows/ci-native.yml)
+[![Build - ARM](https://github.com/Igalia/cog/actions/workflows/ci-cross.yml/badge.svg)](https://github.com/Igalia/cog/actions/workflows/ci-cross.yml)
+[![Code Style](https://github.com/Igalia/cog/actions/workflows/codestyle.yml/badge.svg)](https://github.com/Igalia/cog/actions/workflows/codestyle.yml)
 
 Cog is a small single “window” launcher for the [WebKit WPE
 port](https://trac.webkit.org/wiki/WPE). It is small, provides no user

--- a/data/check-style
+++ b/data/check-style
@@ -119,7 +119,7 @@ declare -a input_cmd
 if ${diff_input} ; then
     input_cmd=(cat)
 else
-    input_cmd=(git diff --no-color -U0 --histogram "${BASE}...${HEAD}")
+    input_cmd=(git diff --no-color -U0 "${BASE}...${HEAD}")
 fi
 
 "${input_cmd[@]}" \


### PR DESCRIPTION
Change the obsolete Travis-CI badge to the ones provided by the new GitHub Actions workflows.