### PR TITLE
CMake: install D-Bus policy configuration to CMAKE_INSTALL_DATADIR

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -125,7 +125,7 @@ if (COG_DBUS_SYSTEM_BUS)
     configure_file(dbus/policy.conf.in ${COG_DEFAULT_APPID}.conf @ONLY)
     install(
         FILES ${CMAKE_CURRENT_BINARY_DIR}/${COG_DEFAULT_APPID}.conf
-        DESTINATION ${CMAKE_INSTALL_SYSCONFDIR}/dbus-1/system.d
+        DESTINATION ${CMAKE_INSTALL_DATADIR}/dbus-1/system.d
         COMPONENT "runtime"
     )
 


### PR DESCRIPTION
The D-Bus system bus policy config should reside in `CMAKE_INSTALL_DATADIR` rather than in `CMAKE_INSTALL_SYSCONFDIR`.

See:

  https://gitlab.freedesktop.org/dbus/dbus/-/blob/ef55a3db0d8f17848f8a579092fb05900cc076f5/bus/CMakeLists.txt#L117