### PR TITLE
CI: Always use clang-format version 11

### DIFF
--- a/.github/workflows/codestyle.yml
+++ b/.github/workflows/codestyle.yml
@@ -6,14 +6,18 @@ jobs:
   check:
     runs-on: ubuntu-20.04
     steps:
-      - name: Install Tools
-        run: |
-          sudo apt update
-          sudo apt install -y clang-format diffutils
       - name: Checkout Head
         uses: actions/checkout@v2
         with:
           path: head
+      - name: Install Tools
+        run: |
+          curl -sL https://apt.llvm.org/llvm-snapshot.gpg.key | \
+            sudo apt-key add -
+          sudo add-apt-repository \
+            'deb http://apt.llvm.org/focal/ llvm-toolchain-focal-11 main'
+          sudo apt update
+          sudo apt install -y clang-format-11 diffutils
       - name: Checkout Base
         uses: actions/checkout@v2
         with:

--- a/data/check-style
+++ b/data/check-style
@@ -52,6 +52,8 @@ declare -r BASE HEAD
 
 declare -ra clang_format_diff_candidates=(
     # Search in $PATH (Ubuntu, Debian, maybe others)
+    clang-format-diff-11
+    clang-format-diff-11.py
     clang-format-diff
     clang-format-diff.py
     # Arch Linux, Fedora.
@@ -74,7 +76,7 @@ find_program ()
 }
 
 clang_format_diff=$(find_program "${clang_format_diff_candidates[@]}")
-clang_format=$(find_program clang-format)
+clang_format=$(find_program clang-format-11 clang-format)
 declare -r clang_format_diff clang_format
 
 if [[ ! -x ${clang_format_diff} ]] ; then
@@ -94,7 +96,7 @@ fi
 #
 #   clang-format version X.Y.Z
 #
-declare -r clang_format_min_version=10
+declare -r clang_format_min_version=11
 
 clang_format_version=$("${clang_format}" --version)
 if [[ ${clang_format_version} =~ ^clang-format[[:space:]]+version[[:space:]]+([[:digit:]]+)\. ]] ; then

--- a/data/check-style
+++ b/data/check-style
@@ -99,7 +99,7 @@ fi
 declare -r clang_format_min_version=11
 
 clang_format_version=$("${clang_format}" --version)
-if [[ ${clang_format_version} =~ ^clang-format[[:space:]]+version[[:space:]]+([[:digit:]]+)\. ]] ; then
+if [[ ${clang_format_version} =~ clang-format[[:space:]]+version[[:space:]]+([[:digit:]]+)\. ]] ; then
     clang_format_version=${BASH_REMATCH[1]}
     if [[ ${clang_format_version} -lt ${clang_format_min_version} ]] ; then
         echo "$0: clang-format ${clang_format_min_version}+ is needed, ${clang_format_version} detected" 1>&2


### PR DESCRIPTION
This is needed to make the code style checker work as intended (see #300 for an example failure).