### PR TITLE
drm: Correctly set CMake target options

### DIFF
--- a/platform/drm/CMakeLists.txt
+++ b/platform/drm/CMakeLists.txt
@@ -13,7 +13,7 @@ add_library(cogplatform-drm MODULE
     kms.c
     cursor-drm.c
 )
-set_target_properties(cogplatform-fdo PROPERTIES
+set_target_properties(cogplatform-drm PROPERTIES
     C_STANDARD 99
     LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}
 )


### PR DESCRIPTION
Fix a typo in the call to `set_target_properties()`, which makes `libcogplatform-drm.so` be built into the expected location, and also correctly sets it to be compiled as C99.