### PR TITLE
cog: Add support for loading a JSON content filter

### DIFF
--- a/data/cog.1
+++ b/data/cog.1
@@ -70,6 +70,9 @@ Platform plug-in to use.
 .TP
 .B \-\-web\-extensions\-dir=PATH
 Load Web Extensions from given directory.
+.TP
+.B \-F,\ \-\-content\-filter=PATH
+Load JSON file as a content filter.
 
 .SH ENVIRONMENT
 .PP


### PR DESCRIPTION
Add a new `-F`/`--content-filter` command line option to the `cog` launcher, which allows specifying the path to a JSON rule set which will be compiled and used as content filter.