### PR TITLE
codestyle: Use Git's diff on CI with same options

### DIFF
--- a/.github/workflows/codestyle.yml
+++ b/.github/workflows/codestyle.yml
@@ -17,7 +17,7 @@ jobs:
           sudo add-apt-repository \
             'deb http://apt.llvm.org/focal/ llvm-toolchain-focal-11 main'
           sudo apt update
-          sudo apt install -y clang-format-11 diffutils
+          sudo apt install -y clang-format-11
       - name: Checkout Base
         uses: actions/checkout@v2
         with:
@@ -26,7 +26,8 @@ jobs:
       - name: Check
         run: |
           cd "${GITHUB_WORKSPACE}"
-          diff -NaurU0 base head > checkouts.diff || rc=$?
+          git diff --no-color --no-index -U0 --histogram --exit-code \
+            --no-index -- base head > checkouts.diff || rc=$?
           if [[ $rc -eq 1 ]] ; then
             cd head
             data/check-style -d -o../code-style.diff < ../checkouts.diff

--- a/data/check-style
+++ b/data/check-style
@@ -119,7 +119,7 @@ declare -a input_cmd
 if ${diff_input} ; then
     input_cmd=(cat)
 else
-    input_cmd=(git diff --no-color -U0 "${BASE}...${HEAD}")
+    input_cmd=(git diff --no-color -U0 --histogram "${BASE}...${HEAD}")
 fi
 
 "${input_cmd[@]}" \


### PR DESCRIPTION
Make CI code style checks use as input the same diff that would have been generated locally when running `data/check-style` to avoid situations in which running the script on a developer's machine would report no mistakes but the CI would insist that there are still some code style issues.