### PR TITLE
CI: Bump to gi-docgen 2021.6

### DIFF
--- a/.github/workflows/ci-native.yml
+++ b/.github/workflows/ci-native.yml
@@ -31,9 +31,7 @@ jobs:
           python-version: 3.8
       - name: Install Python Packages
         run: |
-          pip install --upgrade pip gi-docgen==2021.2 meson==0.49
-          printf '#! /bin/sh\nexec python -m gidocgen.gidocmain "$@"\n' \
-            > "$(which gi-docgen)"
+          pip install --upgrade pip gi-docgen==2021.6 meson==0.49
       - name: Fetch WPEBackend-fdo
         run: |
           if [[ -d ~/WPEBackend-fdo/.git ]] ; then


### PR DESCRIPTION
The generated output has been improved, and also an upstream fix makes the wrapper script unneeded.