### PR TITLE
CI: Fetch Git history to use data/check-style

### DIFF
--- a/.github/workflows/codestyle.yml
+++ b/.github/workflows/codestyle.yml
@@ -8,8 +8,10 @@ jobs:
     steps:
       - name: Checkout Head
         uses: actions/checkout@v2
-        with:
-          path: head
+      - name: Fetch Git History
+        run: |
+          git fetch --no-tags --prune --depth=1 \
+            origin +refs/heads/master:refs/remotes/origin/master
       - name: Install Tools
         run: |
           curl -sL https://apt.llvm.org/llvm-snapshot.gpg.key | \
@@ -18,21 +20,9 @@ jobs:
             'deb http://apt.llvm.org/focal/ llvm-toolchain-focal-11 main'
           sudo apt update
           sudo apt install -y clang-format-11 diffutils
-      - name: Checkout Base
-        uses: actions/checkout@v2
-        with:
-          ref: ${{ github.base_ref }}
-          path: base
       - name: Check
         run: |
-          cd "${GITHUB_WORKSPACE}"
-          diff -NaurU0 base head > checkouts.diff || rc=$?
-          if [[ $rc -eq 1 ]] ; then
-            cd head
-            data/check-style -d -o../code-style.diff < ../checkouts.diff
-          else
-            exit $rc
-          fi
+          data/check-style -ocode-style.diff origin/master
       - name: Archive Diff
         uses: actions/upload-artifact@v2
         if: failure()

--- a/data/check-style
+++ b/data/check-style
@@ -112,7 +112,9 @@ fi
 
 if [[ -z ${FILE} ]] ; then
     FILE=$(mktemp)
-    trap "rm -f '${FILE}'" EXIT
+    trap 'rm -f "${FILE}"' EXIT
+else
+    trap '[[ -s ${FILE} ]] || rm -f "${FILE}"' EXIT
 fi
 
 declare -a input_cmd

--- a/data/check-style
+++ b/data/check-style
@@ -3,7 +3,7 @@ set -eu -o pipefail
 
 FILE=
 BASE=
-HEAD=
+HEAD=HEAD
 
 declare -a args=()
 diff_input=false
@@ -119,7 +119,7 @@ declare -a input_cmd
 if ${diff_input} ; then
     input_cmd=(cat)
 else
-    input_cmd=(git diff --no-color -U0 "${BASE}...${HEAD}")
+    input_cmd=(git diff --no-color -U0 "${BASE}" "${HEAD}")
 fi
 
 "${input_cmd[@]}" \


### PR DESCRIPTION
Arrange to fetch the Git history needed to make `git diff` work from a pull request checkout, so the data/check-style can be invoked directly instead of relying on an external diff tool. This makes the CI code style checks run the same command that a developer would use locally, thus avoiding the situation in which the CI would complain that there are code style issues that were not reported in a local run.