### PR TITLE
fdo: Reintroduce checks on Wayland protocols

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -7,7 +7,7 @@ AlignConsecutiveMacros: true
 AlignConsecutiveAssignments: false
 AlignConsecutiveBitFields: true
 AlignConsecutiveDeclarations: false
-AlignEscapedNewlines: Right
+AlignEscapedNewlines: Left
 AlignTrailingComments: true
 AllowAllArgumentsOnNextLine: false
 AllowAllConstructorInitializersOnNextLine: false

--- a/platform/fdo/cog-platform-fdo.c
+++ b/platform/fdo/cog-platform-fdo.c
@@ -2092,18 +2092,71 @@ clear_wayland (void)
     wl_display_disconnect (wl_data.display);
 }
 
+// clang-format off
+#define SHELL_PROTOCOLS(m) \
+    m(xdg_wm_base)         \
+    m(wl_shell)            \
+    m(zwp_fullscreen_shell_v1)
+// clang-format on
+
+#define DECLARE_PROTOCOL_ENTRY(proto) gboolean found_##proto;
+struct check_supported_protocols {
+    SHELL_PROTOCOLS(DECLARE_PROTOCOL_ENTRY)
+};
+#undef DECLARE_PROTOCOL_ENTRY
+
+static void
+on_registry_global_is_supported_check(void *data,
+                                      struct wl_registry *registry,
+                                      uint32_t name,
+                                      const char *interface,
+                                      uint32_t version)
+{
+    struct check_supported_protocols *protocols = data;
+
+#define TRY_MATCH_PROTOCOL_ENTRY(proto)                   \
+    if (strcmp(interface, proto##_interface.name) == 0) { \
+        protocols->found_##proto = TRUE;                  \
+        return;                                           \
+    }
+
+    SHELL_PROTOCOLS(TRY_MATCH_PROTOCOL_ENTRY)
+
+#undef TRY_MATCH_PROTOCOL_ENTRY
+}
+
 static void *
 check_supported(void *data G_GNUC_UNUSED)
 {
     /*
-     * XXX: It would be neat to be able to determine if the compositor
-     *      supports the few protocols needed for operation, but that
-     *      would require protocol roundtrips.
+     * XXX: It would be neat to have some way of determining whether EGL is
+     *      usable without doing EGL initialization. Maybe an option is
+     *      checking whether the wl_drm protocol is present, but some GPU
+     *      drivers might expose other protocols (w.g. wl_viv for Vivante)
+     *      so that could result in needing to maintain the list updated.
+     *
+     *      For now the check assumes that EGL will work if the compositor
+     *      handles at least one of the shell protocols supported by Cog.
      */
     struct wl_display *display = wl_display_connect(NULL);
     if (display) {
+        struct check_supported_protocols protocols = {};
+        struct wl_registry *registry = wl_display_get_registry(display);
+        wl_registry_add_listener(registry,
+                                 &((const struct wl_registry_listener){
+                                     .global = on_registry_global_is_supported_check,
+                                 }),
+                                 &protocols);
+        wl_display_roundtrip(display);
+
+        gboolean ok = FALSE;
+#define CHECK_SHELL_PROTOCOL(proto) ok = ok || protocols.found_##proto;
+        SHELL_PROTOCOLS(CHECK_SHELL_PROTOCOL)
+#undef CHECK_SHELL_PROTOCOL
+
+        wl_registry_destroy(registry);
         wl_display_destroy(display);
-        return GINT_TO_POINTER(TRUE);
+        return GINT_TO_POINTER(ok);
     } else {
         return GINT_TO_POINTER(FALSE);
     }


### PR DESCRIPTION
Add code to do a cursory check on the Wayland protocols handled by the Wayland compositor in the `check_supported()` function. This makes sure that the FDO platform will be chosen if at least one of the shell protocols supported by the code are handled by the compositor.

Note that it is not needed to check for protocols from the base Wayland specification which every compositor is expected to implement (`wl_compositor`, `wl_shm`, `wl_seat`, etc.) because these will always be available.

As a related note, it would be neat to check that the EGL will be usable with the Wayland compositor, but there is no 100% reliable way without going through actual EGL initialization, so no check is added for this at the moment.