### PR TITLE
cog: Fix build for WebKit versions inferior to 2.32

### DIFF
--- a/cog.c
+++ b/cog.c
@@ -263,7 +263,11 @@ on_handle_local_options (GApplication *application,
                                                          s_options.web_extensions_dir);
     }
 
+#if WEBKIT_CHECK_VERSION(2, 32, 0)
     webkit_website_data_manager_set_tls_errors_policy(
+#else
+    webkit_web_context_set_tls_errors_policy(
+#endif
         webkit_web_context_get_website_data_manager(cog_shell_get_web_context(shell)),
         s_options.ignore_tls_errors ? WEBKIT_TLS_ERRORS_POLICY_IGNORE : WEBKIT_TLS_ERRORS_POLICY_FAIL);
 


### PR DESCRIPTION
webkit_web_context_set_tls_errors_policy() was introduced in 2.32,
can't be used for older versions...