### PR TITLE
core: Avoid re-declaring CogRequestHandler

### DIFF
--- a/core/cog-launcher.h
+++ b/core/cog-launcher.h
@@ -14,19 +14,16 @@
 #endif
 
 #include "cog-config.h"
+#include "cog-request-handler.h"
 #include "cog-shell.h"
-#include "cog-webkit-utils.h"
 
 G_BEGIN_DECLS
 
-typedef struct _CogRequestHandler CogRequestHandler;
+#define COG_TYPE_LAUNCHER (cog_launcher_get_type())
 
-#define COG_TYPE_LAUNCHER (cog_launcher_get_type ())
+G_DECLARE_FINAL_TYPE(CogLauncher, cog_launcher, COG, LAUNCHER, GApplication)
 
-G_DECLARE_FINAL_TYPE (CogLauncher, cog_launcher, COG, LAUNCHER, GApplication)
-
-struct _CogLauncherClass
-{
+struct _CogLauncherClass {
     GApplicationClass parent_class;
 };
 


### PR DESCRIPTION
Change `cog-launcher.h` to not re-declare `CogRequestHandler`, and instead include the header needed to bring its definition into scope. While at it, keep the style-checker happy.

Closes #261