### PR TITLE
core: Use wl platform module as fallback for fdo

### DIFF
--- a/core/cog-modules.c
+++ b/core/cog-modules.c
@@ -86,6 +86,11 @@ cog_modules_get_preferred(GIOExtensionPoint *extension_point, const char *prefer
 
     ensure_extension_points();
 
+    if (extension_point == COG_MODULES_PLATFORM && g_strcmp0(preferred_module, "fdo") == 0) {
+        g_warning("Platform module name 'fdo' is deprecated, please use 'wl' instead.");
+        preferred_module = "wl";
+    }
+
     GIOExtension *extension, *chosen = NULL;
     if (preferred_module) {
         extension = g_io_extension_point_get_extension_by_name(extension_point, preferred_module);


### PR DESCRIPTION
If the `fdo` platform module is explicitly requested, fall back to `wl`, which is its new name. This is needed to ensure backwards compatibility and might be removed at some point in the future,  therefore a warning is also printed to let users know about this.

----

This is a follow-up to #351