### PR TITLE
drm: Implement output rotation

### DIFF
--- a/platform/drm/CMakeLists.txt
+++ b/platform/drm/CMakeLists.txt
@@ -17,7 +17,6 @@ set_target_properties(cogplatform-drm PROPERTIES
     C_STANDARD 99
     LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/modules
 )
-target_compile_definitions(cogplatform-drm PRIVATE G_LOG_DOMAIN=\"Cog-DRM\")
 target_link_libraries(cogplatform-drm PRIVATE
     cogcore
     PkgConfig::EGL
@@ -28,6 +27,14 @@ target_link_libraries(cogplatform-drm PRIVATE
     PkgConfig::WaylandServer
     PkgConfig::WebKit
     PkgConfig::WpeFDO
+)
+
+string(REGEX MATCH "^([0-9]+)\.([0-9]+)\.([0-9]+)" _ "${LibInput_VERSION}")
+target_compile_definitions(cogplatform-drm PRIVATE
+    G_LOG_DOMAIN=\"Cog-DRM\"
+    LIBINPUT_VER_MAJOR=${CMAKE_MATCH_1}
+    LIBINPUT_VER_MINOR=${CMAKE_MATCH_2}
+    LIBINPUT_VER_MICRO=${CMAKE_MATCH_3}
 )
 
 install(TARGETS cogplatform-drm

--- a/platform/drm/cog-platform-drm.c
+++ b/platform/drm/cog-platform-drm.c
@@ -21,6 +21,11 @@
 
 #include "../common/egl-proc-address.h"
 
+#ifndef LIBINPUT_CHECK_VERSION
+#    define LIBINPUT_CHECK_VERSION(a, b, c)                                                         \
+        ((LIBINPUT_VER_MAJOR > (a)) || (LIBINPUT_VER_MAJOR == (a) && (LIBINPUT_VER_MINOR > (b))) || \
+         (LIBINPUT_VER_MAJOR == (a) && (LIBINPUT_VER_MINOR == (b)) && (LIBINPUT_VER_MICRO >= (c))))
+#endif /* !LIBINPUT_CHECK_VERSION */
 
 #if !defined(EGL_EXT_platform_base)
 typedef EGLDisplay (EGLAPIENTRYP PFNEGLGETPLATFORMDISPLAYEXTPROC) (EGLenum platform, void *native_display, const EGLint *attrib_list);
@@ -1219,26 +1224,111 @@ input_process_events (void)
 
         enum libinput_event_type event_type = libinput_event_get_type (event);
         switch (event_type) {
-            case LIBINPUT_EVENT_KEYBOARD_KEY:
-                input_handle_key_event (libinput_event_get_keyboard_event (event));
-                break;
-            case LIBINPUT_EVENT_TOUCH_DOWN:
-            case LIBINPUT_EVENT_TOUCH_UP:
-            case LIBINPUT_EVENT_TOUCH_MOTION:
-            case LIBINPUT_EVENT_TOUCH_FRAME:
-                input_handle_touch_event(event_type, libinput_event_get_touch_event(event));
-                break;
-            case LIBINPUT_EVENT_POINTER_MOTION:
-                input_handle_pointer_motion_event(libinput_event_get_pointer_event(event), false);
-                break;
-            case LIBINPUT_EVENT_POINTER_MOTION_ABSOLUTE:
-                input_handle_pointer_motion_event(libinput_event_get_pointer_event(event), true);
-                break;
-            case LIBINPUT_EVENT_POINTER_BUTTON:
-                input_handle_pointer_button_event(libinput_event_get_pointer_event(event));
-                break;
-            default:
-                break;
+        case LIBINPUT_EVENT_NONE:
+            return;
+
+        case LIBINPUT_EVENT_DEVICE_ADDED:
+        case LIBINPUT_EVENT_DEVICE_REMOVED:
+            break;
+
+        case LIBINPUT_EVENT_KEYBOARD_KEY:
+            input_handle_key_event(libinput_event_get_keyboard_event(event));
+            break;
+
+        case LIBINPUT_EVENT_TOUCH_CANCEL:
+            break;
+        case LIBINPUT_EVENT_TOUCH_DOWN:
+        case LIBINPUT_EVENT_TOUCH_UP:
+        case LIBINPUT_EVENT_TOUCH_MOTION:
+        case LIBINPUT_EVENT_TOUCH_FRAME:
+            input_handle_touch_event(event_type, libinput_event_get_touch_event(event));
+            break;
+
+        case LIBINPUT_EVENT_POINTER_MOTION:
+            input_handle_pointer_motion_event(libinput_event_get_pointer_event(event), false);
+            break;
+        case LIBINPUT_EVENT_POINTER_MOTION_ABSOLUTE:
+            input_handle_pointer_motion_event(libinput_event_get_pointer_event(event), true);
+            break;
+
+        case LIBINPUT_EVENT_POINTER_BUTTON:
+            input_handle_pointer_button_event(libinput_event_get_pointer_event(event));
+            break;
+
+        case LIBINPUT_EVENT_GESTURE_SWIPE_BEGIN:
+        case LIBINPUT_EVENT_GESTURE_SWIPE_UPDATE:
+        case LIBINPUT_EVENT_GESTURE_SWIPE_END:
+            g_debug("%s: GESTURE_SWIPE_{BEGIN,UPDATE,END} unimplemented", __func__);
+            break;
+
+        case LIBINPUT_EVENT_GESTURE_PINCH_BEGIN:
+        case LIBINPUT_EVENT_GESTURE_PINCH_UPDATE:
+        case LIBINPUT_EVENT_GESTURE_PINCH_END:
+            g_debug("%s: GESTURE_PINCH_{BEGIN,UPDATE,END} unimplemented", __func__);
+            break;
+
+#if LIBINPUT_CHECK_VERSION(1, 2, 0)
+        case LIBINPUT_EVENT_TABLET_TOOL_AXIS:
+            g_debug("%s: TABLET_TOOL_AXIS unimplemented", __func__);
+            break;
+        case LIBINPUT_EVENT_TABLET_TOOL_PROXIMITY:
+            g_debug("%s: TABLET_TOOL_PROXIMITY unimplemented", __func__);
+            break;
+        case LIBINPUT_EVENT_TABLET_TOOL_TIP:
+            g_debug("%s: TABLET_TOOL_TIP unimplemented", __func__);
+            break;
+        case LIBINPUT_EVENT_TABLET_TOOL_BUTTON:
+            g_debug("%s: TABLET_TOOL_BUTTON unimplemented", __func__);
+            break;
+#endif /* LIBINPUT_CHECK_VERSION(1, 2, 0) */
+
+#if LIBINPUT_CHECK_VERSION(1, 3, 0)
+        case LIBINPUT_EVENT_TABLET_PAD_BUTTON:
+            g_debug("%s: TABLET_PAD_BUTTON unimplemented", __func__);
+            break;
+        case LIBINPUT_EVENT_TABLET_PAD_RING:
+            g_debug("%s: TABLET_PAD_RING unimplemented", __func__);
+            break;
+        case LIBINPUT_EVENT_TABLET_PAD_STRIP:
+            g_debug("%s: TABLET_PAD_STRIP unimplemented", __func__);
+            break;
+#endif /* LIBINPUT_CHECK_VERSION(1, 3, 0) */
+
+#if LIBINPUT_CHECK_VERSION(1, 7, 0)
+        case LIBINPUT_EVENT_SWITCH_TOGGLE:
+            g_debug("%s: SWITCH_TOGGLE unimplemented", __func__);
+            break;
+#endif /* LIBINPUT_CHECK_VERSION(1, 7, 0) */
+
+#if LIBINPUT_CHECK_VERSION(1, 15, 0)
+        case LIBINPUT_EVENT_TABLET_PAD_KEY:
+            g_debug("%s: TABLET_PAD_KEY unimplemented", __func__);
+            break;
+#endif /* LIBINPUT_CHECK_VERSION(1, 15, 0) */
+
+#if LIBINPUT_CHECK_VERSION(1, 19, 0)
+        case LIBINPUT_EVENT_POINTER_AXIS:
+            /* Deprecated, use _SCROLL_{WHEEL,FINGER,CONTINUOUS} below. */
+            break;
+        case LIBINPUT_EVENT_POINTER_SCROLL_WHEEL:
+            g_debug("%s: POINTER_SCROLL_WHEEL unimplemented", __func__);
+            break;
+        case LIBINPUT_EVENT_POINTER_SCROLL_FINGER:
+            g_debug("%s: POINTER_SCROLL_FINGER unimplemented", __func__);
+            break;
+        case LIBINPUT_EVENT_POINTER_SCROLL_CONTINUOUS:
+            g_debug("%s: POINTER_SCROLL_CONTINUOUS unimplemented", __func__);
+            break;
+
+        case LIBINPUT_EVENT_GESTURE_HOLD_BEGIN:
+        case LIBINPUT_EVENT_GESTURE_HOLD_END:
+            g_debug("%s: GESTURE_HOLD_{BEGIN,END} unimplemented", __func__);
+            break;
+#else
+        case LIBINPUT_EVENT_POINTER_AXIS:
+            g_debug("%s: POINTER_AXIS unimplemented", __func__);
+            break;
+#endif /* LIBINPUT_CHECK_VERSION(1, 19, 0) */
         }
 
         libinput_event_destroy (event);

--- a/platform/drm/cog-platform-drm.c
+++ b/platform/drm/cog-platform-drm.c
@@ -50,7 +50,18 @@ struct _CogDrmPlatformClass {
 
 struct _CogDrmPlatform {
     CogPlatform parent;
+
+    uint32_t rotation;  /* Counter-clockwise degrees. */
+    bool rotation_set;
 };
+
+enum {
+    PROP_0,
+    PROP_ROTATION,
+    N_PROPERTIES,
+};
+
+static GParamSpec *s_properties[N_PROPERTIES] = { NULL, };
 
 G_DECLARE_FINAL_TYPE(CogDrmPlatform, cog_drm_platform, COG, DRM_PLATFORM, CogPlatform)
 
@@ -75,6 +86,14 @@ struct buffer_object {
     } export;
 };
 
+enum {
+    ROTATE_VALUE_INDEX_0,
+    ROTATE_VALUE_INDEX_90,
+    ROTATE_VALUE_INDEX_180,
+    ROTATE_VALUE_INDEX_270,
+    ROTATE_N_VALUES,
+};
+
 static struct {
     int fd;
     drmModeRes *base_resources;
@@ -92,6 +111,8 @@ static struct {
     struct {
         drmModePlane *obj;
         uint32_t obj_id;
+        uint32_t rotation_prop_id;
+        uint64_t rotation_values[ROTATE_N_VALUES];
     } plane;
 
     struct {
@@ -526,25 +547,56 @@ init_drm(void)
 
         drm_data.plane.obj = plane;
         drm_data.plane.obj_id = plane_id;
+        drm_data.plane.rotation_prop_id = 0;
         bool is_primary = false;
 
         drmModeObjectProperties *plane_props = drmModeObjectGetProperties (drm_data.fd, plane_id, DRM_MODE_OBJECT_PLANE);
 
         for (int j = 0; j < plane_props->count_props; ++j) {
             drmModePropertyRes *prop = drmModeGetProperty (drm_data.fd, plane_props->props[j]);
-            is_primary = !g_strcmp0 (prop->name, "type")
-                              && plane_props->prop_values[j] == DRM_PLANE_TYPE_PRIMARY;
-            drmModeFreeProperty (prop);
+            if (!g_strcmp0(prop->name, "type")) {
+                is_primary = plane_props->prop_values[j] == DRM_PLANE_TYPE_PRIMARY;
+            } else if (!g_strcmp0(prop->name, "rotation")) {
+                drm_data.plane.rotation_prop_id = prop->prop_id;
+                /*
+                 * Map bitmask enum value names (which are standard) to their values
+                 * (which are not, and may change from one driver/device to another).
+                 */
+                static const char *value_names[ROTATE_N_VALUES] = {
+                    [ROTATE_VALUE_INDEX_0] = "rotate-0",
+                    [ROTATE_VALUE_INDEX_90] = "rotate-90",
+                    [ROTATE_VALUE_INDEX_180] = "rotate-180",
+                    [ROTATE_VALUE_INDEX_270] = "rotate-270",
+                };
+                for (unsigned m = 0; m < ROTATE_N_VALUES; m++) {
+                    drm_data.plane.rotation_values[m] = UINT64_MAX;
+                    for (unsigned n = 0; n < prop->count_enums; n++)  {
+                        if (!strcmp(value_names[m], prop->enums[n].name)) {
+                            /* The value is the bit index of the bitmask: shift it. */
+                            drm_data.plane.rotation_values[m] = (1 << prop->enums[n].value);
+                            break;
+                        }
+                    }
+                }
+            }
 
-            if (is_primary)
-                break;
+            drmModeFreeProperty(prop);
         }
 
-        drmModeFreeObjectProperties (plane_props);
+        drmModeFreeObjectProperties(plane_props);
 
         if (is_primary)
             break;
     }
+
+    g_debug("%s: using primary plane id %" PRIu32 ", rotation prop id %" PRIu32
+            " {rotate-0 = %#" PRIx64 ", rotate-90 = %#" PRIx64
+            ", rotate-180 = %#" PRIx64 ", rotate-270 = %#" PRIx64 "}",
+            __func__, drm_data.plane.obj_id, drm_data.plane.rotation_prop_id,
+            drm_data.plane.rotation_values[0],
+            drm_data.plane.rotation_values[1],
+            drm_data.plane.rotation_values[2],
+            drm_data.plane.rotation_values[3]);
 
     drm_data.connector_props.props = drmModeObjectGetProperties (drm_data.fd,
                                                                  drm_data.connector.obj_id,
@@ -877,8 +929,20 @@ add_plane_property (drmModeAtomicReq *req, uint32_t obj_id, const char *name, ui
                          req, obj_id, name, value);
 }
 
+static inline uint32_t
+to_drm_rotation(uint32_t cw_degrees)
+{
+    switch (cw_degrees % 360) {
+        case 0:   return drm_data.plane.rotation_values[ROTATE_VALUE_INDEX_0];
+        case 90:  return drm_data.plane.rotation_values[ROTATE_VALUE_INDEX_90];
+        case 180: return drm_data.plane.rotation_values[ROTATE_VALUE_INDEX_180];
+        case 270: return drm_data.plane.rotation_values[ROTATE_VALUE_INDEX_270];
+        default:  return UINT32_MAX;
+    }
+}
+
 static int
-drm_commit_buffer_nonatomic (struct buffer_object *buffer)
+drm_commit_buffer_nonatomic(CogDrmPlatform *platform, struct buffer_object *buffer)
 {
     if (!drm_data.mode_set) {
         int ret = drmModeSetCrtc (drm_data.fd, drm_data.crtc.obj_id, buffer->fb_id, 0, 0,
@@ -889,12 +953,24 @@ drm_commit_buffer_nonatomic (struct buffer_object *buffer)
         drm_data.mode_set = true;
     }
 
+    if (drm_data.plane.rotation_prop_id && !platform->rotation_set) {
+        if (drmModeObjectSetProperty(drm_data.fd, drm_data.plane.obj_id,
+                                     DRM_MODE_OBJECT_PLANE,
+                                     drm_data.plane.rotation_prop_id,
+                                     to_drm_rotation(platform->rotation))) {
+            g_warning("Could not set rotation '%" PRIu32 "' (%s)",
+                      platform->rotation, strerror(errno));
+            return -1;
+        }
+        platform->rotation_set = true;
+    }
+
     return drmModePageFlip (drm_data.fd, drm_data.crtc.obj_id, buffer->fb_id,
                             DRM_MODE_PAGE_FLIP_EVENT, buffer);
 }
 
 static int
-drm_commit_buffer_atomic (struct buffer_object *buffer)
+drm_commit_buffer_atomic(CogDrmPlatform *platform, struct buffer_object *buffer)
 {
     int ret = 0;
     uint32_t flags = DRM_MODE_PAGE_FLIP_EVENT | DRM_MODE_ATOMIC_NONBLOCK;
@@ -920,6 +996,12 @@ drm_commit_buffer_atomic (struct buffer_object *buffer)
         }
 
         drm_data.mode_set = true;
+    }
+
+    if (drm_data.plane.rotation_prop_id && !platform->rotation_set) {
+        ret |= add_plane_property(req, drm_data.plane.obj_id,
+                                  "rotation", to_drm_rotation(platform->rotation));
+        platform->rotation_set = true;
     }
 
     ret |= add_plane_property (req, drm_data.plane.obj_id,
@@ -958,13 +1040,13 @@ drm_commit_buffer_atomic (struct buffer_object *buffer)
 }
 
 static void
-drm_commit_buffer (struct buffer_object *buffer)
+drm_commit_buffer(CogDrmPlatform *platform, struct buffer_object *buffer)
 {
     int ret;
     if (drm_data.atomic_modesetting)
-        ret = drm_commit_buffer_atomic (buffer);
+        ret = drm_commit_buffer_atomic(platform, buffer);
     else
-        ret = drm_commit_buffer_nonatomic (buffer);
+        ret = drm_commit_buffer_nonatomic(platform, buffer);
 
     if (ret)
         g_warning ("failed to schedule a page flip: %s", strerror (errno));
@@ -1637,10 +1719,11 @@ init_glib (void)
 static void
 on_export_buffer_resource (void *data, struct wl_resource *buffer_resource)
 {
+    CogDrmPlatform *platform = data;
     struct buffer_object *buffer = drm_buffer_for_resource (buffer_resource);
     if (buffer) {
         buffer->export.resource = buffer_resource;
-        drm_commit_buffer (buffer);
+        drm_commit_buffer(platform, buffer);
         return;
     }
 
@@ -1658,17 +1741,18 @@ on_export_buffer_resource (void *data, struct wl_resource *buffer_resource)
     buffer = drm_create_buffer_for_bo (bo, buffer_resource, width, height, format);
     if (buffer) {
         buffer->export.resource = buffer_resource;
-        drm_commit_buffer (buffer);
+        drm_commit_buffer(platform, buffer);
     }
 }
 
 static void
 on_export_dmabuf_resource (void *data, struct wpe_view_backend_exportable_fdo_dmabuf_resource *dmabuf_resource)
 {
+    CogDrmPlatform *platform = data;
     struct buffer_object *buffer = drm_buffer_for_resource (dmabuf_resource->buffer_resource);
     if (buffer) {
         buffer->export.resource = dmabuf_resource->buffer_resource;
-        drm_commit_buffer (buffer);
+        drm_commit_buffer(platform, buffer);
         return;
     }
 
@@ -1697,7 +1781,7 @@ on_export_dmabuf_resource (void *data, struct wpe_view_backend_exportable_fdo_dm
                                        dmabuf_resource->format);
     if (buffer) {
         buffer->export.resource = dmabuf_resource->buffer_resource;
-        drm_commit_buffer (buffer);
+        drm_commit_buffer(platform, buffer);
     }
 }
 
@@ -1705,6 +1789,7 @@ on_export_dmabuf_resource (void *data, struct wpe_view_backend_exportable_fdo_dm
 static void
 on_export_shm_buffer (void* data, struct wpe_fdo_shm_exported_buffer *exported_buffer)
 {
+    CogDrmPlatform *platform = data;
     struct wl_resource *exported_resource = wpe_fdo_shm_exported_buffer_get_resource (exported_buffer);
     struct wl_shm_buffer *exported_shm_buffer = wpe_fdo_shm_exported_buffer_get_shm_buffer (exported_buffer);
 
@@ -1713,7 +1798,7 @@ on_export_shm_buffer (void* data, struct wpe_fdo_shm_exported_buffer *exported_b
         drm_copy_shm_buffer_into_bo (exported_shm_buffer, buffer->bo);
 
         buffer->export.shm_buffer = exported_buffer;
-        drm_commit_buffer (buffer);
+        drm_commit_buffer(platform, buffer);
         return;
     }
 
@@ -1722,7 +1807,7 @@ on_export_shm_buffer (void* data, struct wpe_fdo_shm_exported_buffer *exported_b
         drm_copy_shm_buffer_into_bo (exported_shm_buffer, buffer->bo);
 
         buffer->export.shm_buffer = exported_buffer;
-        drm_commit_buffer (buffer);
+        drm_commit_buffer(platform, buffer);
     }
 }
 #endif
@@ -1837,7 +1922,7 @@ cog_drm_platform_get_view_backend(CogPlatform *platform, WebKitWebView *related_
     };
 
     wpe_host_data.exportable = wpe_view_backend_exportable_fdo_create (&exportable_client,
-                                                                       NULL,
+                                                                       platform,
                                                                        drm_data.width / drm_data.device_scale,
                                                                        drm_data.height / drm_data.device_scale);
     g_assert (wpe_host_data.exportable);
@@ -1862,14 +1947,79 @@ cog_drm_platform_init_web_view(CogPlatform *platform, WebKitWebView *view)
 }
 
 static void
+cog_drm_platform_set_property(GObject      *object,
+                              unsigned      prop_id,
+                              const GValue *value,
+                              GParamSpec   *pspec)
+{
+    CogDrmPlatform *self = COG_DRM_PLATFORM(object);
+    switch (prop_id) {
+        case PROP_ROTATION: {
+            uint32_t rotation = g_value_get_uint(value);
+            if (rotation == self->rotation)
+                return;
+            switch (rotation) {
+                case 0: case 90: case 180: case 270:
+                    break;
+                default:
+                    g_warning("Unsupported rotation value '%" PRIu32 "'", rotation);
+                    return;
+            }
+            self->rotation = rotation;
+            self->rotation_set = false;
+            break;
+        }
+        default:
+            G_OBJECT_WARN_INVALID_PROPERTY_ID(object, prop_id, pspec);
+    }
+}
+
+static void
+cog_drm_platform_get_property(GObject    *object,
+                              unsigned    prop_id,
+                              GValue     *value,
+                              GParamSpec *pspec)
+{
+    CogDrmPlatform *self = COG_DRM_PLATFORM(object);
+    switch (prop_id) {
+        case PROP_ROTATION:
+            g_value_set_uint(value, self->rotation);
+            break;
+        default:
+            G_OBJECT_WARN_INVALID_PROPERTY_ID(object, prop_id, pspec);
+    }
+}
+
+static void
 cog_drm_platform_class_init(CogDrmPlatformClass *klass)
 {
+    GObjectClass *object_class = G_OBJECT_CLASS(klass);
+    object_class->get_property = cog_drm_platform_get_property;
+    object_class->set_property = cog_drm_platform_set_property;
+
     CogPlatformClass *platform_class = COG_PLATFORM_CLASS(klass);
     platform_class->is_supported = cog_drm_platform_is_supported;
     platform_class->setup = cog_drm_platform_setup;
     platform_class->teardown = cog_drm_platform_teardown;
     platform_class->get_view_backend = cog_drm_platform_get_view_backend;
     platform_class->init_web_view = cog_drm_platform_init_web_view;
+
+    /* TODO: Move into CogDrmShell once we have such a thing. */
+
+    /**
+     * CogDrmPlatform:rotation:
+     *
+     * Clockwise rotation applied to outputs, in degrees.
+     * Only multiples of 90 degrees are guaranteed to work.
+     */
+    s_properties[PROP_ROTATION] =
+        g_param_spec_uint("rotation",
+                          "Output rotation",
+                          "Amount of clockwise rotation in degrees applied to the output",
+                          0, 359, 0,
+                          G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS);
+
+    g_object_class_install_properties(object_class, N_PROPERTIES, s_properties);
 }
 
 static void

--- a/platform/drm/cog-platform-drm.c
+++ b/platform/drm/cog-platform-drm.c
@@ -1212,6 +1212,26 @@ input_handle_pointer_button_event (struct libinput_event_pointer *pointer_event)
 }
 
 static void
+input_handle_device_added(struct libinput_device *device)
+{
+    g_debug("Input device %p added: %s (%04x:%04x)",
+            device,
+            libinput_device_get_name(device),
+            libinput_device_get_id_vendor(device),
+            libinput_device_get_id_product(device));
+}
+
+static void
+input_handle_device_removed(struct libinput_device *device)
+{
+    g_debug("Input device %p removed: %s (%04x:%04x)",
+            device,
+            libinput_device_get_name(device),
+            libinput_device_get_id_vendor(device),
+            libinput_device_get_id_product(device));
+}
+
+static void
 input_process_events (void)
 {
     g_assert (input_data.libinput);
@@ -1228,7 +1248,10 @@ input_process_events (void)
             return;
 
         case LIBINPUT_EVENT_DEVICE_ADDED:
+            input_handle_device_added(libinput_event_get_device(event));
+            break;
         case LIBINPUT_EVENT_DEVICE_REMOVED:
+            input_handle_device_removed(libinput_event_get_device(event));
             break;
 
         case LIBINPUT_EVENT_KEYBOARD_KEY:

--- a/platform/drm/cog-platform-drm.c
+++ b/platform/drm/cog-platform-drm.c
@@ -124,6 +124,7 @@ static struct {
     double device_scale;
 
     bool atomic_modesetting;
+    bool universal_planes;
     bool mode_set;
     struct wl_list buffer_list;
     struct buffer_object *committed_buffer;
@@ -412,6 +413,8 @@ init_drm(void)
     if (!drm_data.base_resources)
         return FALSE;
 
+    drm_data.universal_planes = drmSetClientCap(drm_data.fd, DRM_CLIENT_CAP_UNIVERSAL_PLANES, 1) == 0;
+
     if (drm_data.atomic_modesetting) {
         int ret = drmSetClientCap (drm_data.fd, DRM_CLIENT_CAP_ATOMIC, 1);
         if (ret) {
@@ -662,9 +665,8 @@ clear_cursor (void) {
 static gboolean
 init_cursor (void)
 {
-    bool cursor_supported = drmSetClientCap(drm_data.fd, DRM_CLIENT_CAP_UNIVERSAL_PLANES, 1) == 0;
-    if (!cursor_supported) {
-        g_warning("cursor not supported");
+    if (!drm_data.universal_planes) {
+        g_warning("cursor not supported: no universal planes");
         return FALSE;
     }
 

--- a/platform/drm/cog-platform-drm.c
+++ b/platform/drm/cog-platform-drm.c
@@ -51,6 +51,7 @@ struct _CogDrmPlatformClass {
 struct _CogDrmPlatform {
     CogPlatform parent;
     unsigned rotation;  /* Number of counter-clockwise 90 degree increments. */
+    GList *rotatable_input_devices;
 };
 
 enum {
@@ -1410,6 +1411,51 @@ input_handle_pointer_axis_event(struct libinput_event_pointer *pointer_event)
 }
 #endif /* !LIBINPUT_CHECK_VERSION(1, 19, 0) */
 
+static bool
+input_device_needs_config(struct libinput_device *device)
+{
+    static const enum libinput_device_capability device_caps[] = {
+        LIBINPUT_DEVICE_CAP_GESTURE,
+        LIBINPUT_DEVICE_CAP_POINTER,
+        LIBINPUT_DEVICE_CAP_TABLET_PAD,
+        LIBINPUT_DEVICE_CAP_TABLET_TOOL,
+        LIBINPUT_DEVICE_CAP_TOUCH,
+    };
+
+    for (unsigned i = 0; i < G_N_ELEMENTS(device_caps); i++)
+        if (libinput_device_has_capability(device, device_caps[i]))
+            return !!libinput_device_config_rotation_is_available(device);
+
+    return false;
+}
+
+static void
+input_configure_device(struct libinput_device *device, CogDrmPlatform *platform)
+{
+    enum libinput_config_status status =
+         libinput_device_config_rotation_set_angle(device, platform->rotation * 90);
+
+    const char *name = libinput_device_get_name(device);
+    const int id_vendor = libinput_device_get_id_vendor(device);
+    const int id_product = libinput_device_get_id_product(device);
+
+    switch (status) {
+    case LIBINPUT_CONFIG_STATUS_SUCCESS:
+        g_debug("%s: Rotation set for %s (%04x:%04x)",
+                __func__, name, id_vendor, id_product);
+        break;
+
+    case LIBINPUT_CONFIG_STATUS_UNSUPPORTED:
+        g_debug("%s: Rotation unsupported for %s (%04x:%04x)",
+                __func__, name, id_vendor, id_product);
+        break;
+    case LIBINPUT_CONFIG_STATUS_INVALID:
+        g_debug("%s: Rotation %u invalid for %s (%04x:%04x)",
+                __func__, platform->rotation * 90, name, id_vendor, id_product);
+        break;
+    }
+}
+
 static void
 input_handle_device_added(struct libinput_device *device)
 {
@@ -1418,6 +1464,14 @@ input_handle_device_added(struct libinput_device *device)
             libinput_device_get_name(device),
             libinput_device_get_id_vendor(device),
             libinput_device_get_id_product(device));
+
+    if (input_device_needs_config(device)) {
+        CogDrmPlatform *platform = libinput_get_user_data(libinput_device_get_context(device));
+        platform->rotatable_input_devices =
+            g_list_append(platform->rotatable_input_devices,
+                          libinput_device_ref(device));
+        input_configure_device(device, platform);
+    }
 }
 
 static void
@@ -1428,6 +1482,14 @@ input_handle_device_removed(struct libinput_device *device)
             libinput_device_get_name(device),
             libinput_device_get_id_vendor(device),
             libinput_device_get_id_product(device));
+
+    CogDrmPlatform *platform = libinput_get_user_data(libinput_device_get_context(device));
+    GList *item = g_list_find(platform->rotatable_input_devices, device);
+    if (item) {
+        platform->rotatable_input_devices =
+            g_list_remove_link(platform->rotatable_input_devices, item);
+        g_list_free_full(item, (GDestroyNotify) libinput_device_unref);
+    }
 }
 
 static void
@@ -1568,14 +1630,19 @@ input_interface_close_restricted (int fd, void *user_data)
 }
 
 static void
-clear_input (void)
+clear_input(CogDrmPlatform *platform)
 {
+    if (platform->rotatable_input_devices) {
+        g_list_free_full(platform->rotatable_input_devices,
+                         (GDestroyNotify) libinput_device_unref);
+        platform->rotatable_input_devices = NULL;
+    }
     g_clear_pointer (&input_data.libinput, libinput_unref);
     g_clear_pointer (&input_data.udev, udev_unref);
 }
 
 static gboolean
-init_input (void)
+init_input(CogDrmPlatform *platform)
 {
     static struct libinput_interface interface = {
         .open_restricted = input_interface_open_restricted,
@@ -1586,9 +1653,9 @@ init_input (void)
     if (!input_data.udev)
         return FALSE;
 
-    input_data.libinput = libinput_udev_create_context (&interface,
-                                                        NULL,
-                                                        input_data.udev);
+    input_data.libinput = libinput_udev_create_context(&interface,
+                                                       platform,
+                                                       input_data.udev);
     if (!input_data.libinput)
         return FALSE;
 
@@ -1910,7 +1977,7 @@ cog_drm_platform_setup(CogPlatform *platform, CogShell *shell, const char *param
         return FALSE;
     }
 
-    if (!init_input ()) {
+    if (!init_input(COG_DRM_PLATFORM(platform))) {
         g_set_error_literal (error,
                              COG_PLATFORM_WPE_ERROR,
                              COG_PLATFORM_WPE_ERROR_INIT,
@@ -1939,7 +2006,7 @@ cog_drm_platform_teardown(CogPlatform *platform)
     clear_buffers ();
 
     clear_glib ();
-    clear_input ();
+    clear_input(COG_DRM_PLATFORM(platform));
     clear_egl ();
     clear_gbm ();
     clear_cursor ();
@@ -2025,6 +2092,11 @@ cog_drm_platform_set_property(GObject      *object,
                         "to %" PRIu32 "x%" PRIu32 "@%.2fx.", __func__,
                         prev_width, prev_height, drm_data.device_scale,
                         width, height, drm_data.device_scale);
+
+                if (self->rotatable_input_devices)
+                    g_list_foreach(self->rotatable_input_devices,
+                                   (GFunc) input_configure_device,
+                                   self);
             } else {
                 g_debug("%s: Effective resolution unchanged at "
                         "%" PRIu32 "x%" PRIu32 "@%.2f.", __func__,


### PR DESCRIPTION
Does what it says on the tin. There are a few things which are needed:

- [x] Fetching the values for the `rotate-<N>` DRM plane properties.
- [x] Configuring the `rotation` property when mode setting.
- [ ] Transforming input coordinates, [libinput_device_config_rotation_set_angle()](https://wayland.freedesktop.org/libinput/doc/latest/api/group__config.html#ga136b2f7753235c5d2a9fb2762a040eef) should be enough.
- [x] Exposing a setting somewhere, to allow configuring at run time.
- [x] Exposing an option in the `cog` launcher.

Closes #205 

----

Currently this is posted as a draft for early feedback, as this needs still some work before I am completely satisfied with it 😄 