### PR TITLE
drm: Implement an OpenGL ES renderer with rotation support

### DIFF
--- a/launcher/cog-launcher.c
+++ b/launcher/cog-launcher.c
@@ -37,6 +37,7 @@ static struct {
     };
     GStrv arguments;
     char *background_color;
+    char *platform_params;
     union {
         char *platform_name;
     };
@@ -219,7 +220,7 @@ platform_setup(CogLauncher *self)
     }
     g_clear_pointer(&s_options.platform_name, g_free);
 
-    if (!cog_platform_setup(platform, self->shell, "", &error)) {
+    if (!cog_platform_setup(platform, self->shell, s_options.platform_params ?: "", &error)) {
         g_warning("Platform setup failed: %s", error->message);
         return FALSE;
     }
@@ -1000,6 +1001,8 @@ static GOptionEntry s_cli_options[] = {
     {"bg-color", 'b', 0, G_OPTION_ARG_STRING, &s_options.background_color,
      "Background color, as a CSS name or in #RRGGBBAA hex syntax (default: white)", "BG_COLOR"},
     {"platform", 'P', 0, G_OPTION_ARG_STRING, &s_options.platform_name, "Platform plug-in to use.", "NAME"},
+    {"platform-params", 'O', 0, G_OPTION_ARG_STRING, &s_options.platform_params,
+     "Comma separated list of platform parameters.", "PARAMS"},
     {"web-extensions-dir", '\0', 0, G_OPTION_ARG_STRING, &s_options.web_extensions_dir,
      "Load Web Extensions from given directory.", "PATH"},
     {"ignore-tls-errors", '\0', 0, G_OPTION_ARG_NONE, &s_options.ignore_tls_errors,

--- a/platform/common/cog-gl-utils.c
+++ b/platform/common/cog-gl-utils.c
@@ -1,0 +1,80 @@
+/*
+ * cog-gl-utils.c
+ * Copyright (C) 2021 Igalia S.L.
+ *
+ * Distributed under terms of the MIT license.
+ */
+
+#include "cog-gl-utils.h"
+
+#include "../../core/cog.h"
+
+void
+cog_gl_shader_id_destroy(CogGLShaderId *shader_id)
+{
+    if (shader_id && *shader_id) {
+        glDeleteShader(*shader_id);
+        *shader_id = 0;
+    }
+}
+
+CogGLShaderId
+cog_gl_shader_id_steal(CogGLShaderId *shader_id)
+{
+    g_assert(shader_id);
+    CogGLShaderId result = *shader_id;
+    *shader_id = 0;
+    return result;
+}
+
+CogGLShaderId
+cog_gl_load_shader(const char *source, GLenum kind, GError **error)
+{
+    g_assert(source != NULL);
+    g_assert(kind == GL_VERTEX_SHADER || kind == GL_FRAGMENT_SHADER);
+
+    g_auto(CogGLShaderId) shader = glCreateShader(kind);
+    glShaderSource(shader, 1, &source, NULL);
+
+    GLenum err;
+    if ((err = glGetError()) != GL_NO_ERROR) {
+        g_set_error_literal(error, COG_PLATFORM_EGL_ERROR, err, "Cannot set shader source");
+        return 0;
+    }
+
+    glCompileShader(shader);
+    if ((err = glGetError()) != GL_NO_ERROR) {
+        g_set_error_literal(error, COG_PLATFORM_EGL_ERROR, err, "Cannot compile shader");
+        return 0;
+    }
+
+    GLint shaderCompiled = GL_FALSE;
+    glGetShaderiv(shader, GL_COMPILE_STATUS, &shaderCompiled);
+    if (shaderCompiled == GL_TRUE)
+        return cog_gl_shader_id_steal(&shader);
+
+    GLint log_length = 0;
+    glGetShaderiv(shader, GL_INFO_LOG_LENGTH, &log_length);
+    g_autofree char *log = g_new0(char, log_length + 1);
+    glGetShaderInfoLog(shader, log_length, NULL, log);
+    g_set_error(error, COG_PLATFORM_EGL_ERROR, 0, "Shader compilation: %s", log);
+    return 0;
+}
+
+bool
+cog_gl_link_program(GLuint program, GError **error)
+{
+    glLinkProgram(program);
+
+    GLint status = 0;
+    glGetProgramiv(program, GL_LINK_STATUS, &status);
+    if (status)
+        return true;
+
+    GLint log_length = 0;
+    glGetProgramiv(program, GL_INFO_LOG_LENGTH, &log_length);
+    g_autofree char *log = g_new0(char, log_length + 1);
+    glGetProgramInfoLog(program, log_length, NULL, log);
+    g_set_error(error, COG_PLATFORM_EGL_ERROR, 0, "Shader linking: %s", log);
+    return false;
+}

--- a/platform/common/cog-gl-utils.h
+++ b/platform/common/cog-gl-utils.h
@@ -1,0 +1,26 @@
+/*
+ * cog-gl-utils.h
+ * Copyright (C) 2021 Igalia S.L.
+ *
+ * Distributed under terms of the MIT license.
+ */
+
+#pragma once
+
+#include <epoxy/gl.h>
+#include <glib.h>
+
+G_BEGIN_DECLS
+
+typedef GLuint CogGLShaderId;
+
+void cog_gl_shader_id_destroy(CogGLShaderId *shader_id);
+G_DEFINE_AUTO_CLEANUP_CLEAR_FUNC(CogGLShaderId, cog_gl_shader_id_destroy)
+
+CogGLShaderId cog_gl_shader_id_steal(CogGLShaderId *shader_id) G_GNUC_WARN_UNUSED_RESULT;
+
+CogGLShaderId cog_gl_load_shader(const char *source, GLenum kind, GError **) G_GNUC_WARN_UNUSED_RESULT;
+
+bool cog_gl_link_program(GLuint program, GError **);
+
+G_END_DECLS

--- a/platform/drm/CMakeLists.txt
+++ b/platform/drm/CMakeLists.txt
@@ -10,6 +10,8 @@ pkg_check_modules(WaylandServer IMPORTED_TARGET REQUIRED wayland-server)
 
 add_library(cogplatform-drm MODULE
     cog-platform-drm.c
+    cog-drm-renderer.c
+    cog-drm-modeset-renderer.c
     kms.c
     cursor-drm.c
 )

--- a/platform/drm/CMakeLists.txt
+++ b/platform/drm/CMakeLists.txt
@@ -9,6 +9,7 @@ pkg_check_modules(LibUdev IMPORTED_TARGET REQUIRED libudev)
 pkg_check_modules(WaylandServer IMPORTED_TARGET REQUIRED wayland-server)
 
 add_library(cogplatform-drm MODULE
+    ../common/cog-gl-utils.c
     cog-platform-drm.c
     cog-drm-renderer.c
     cog-drm-gles-renderer.c

--- a/platform/drm/CMakeLists.txt
+++ b/platform/drm/CMakeLists.txt
@@ -1,6 +1,6 @@
 # libcogplatform-drm
 
-pkg_check_modules(EGL IMPORTED_TARGET REQUIRED egl)
+pkg_check_modules(Epoxy IMPORTED_TARGET REQUIRED epoxy)
 pkg_check_modules(WpeFDO IMPORTED_TARGET REQUIRED wpebackend-fdo-1.0>=1.4.0)
 pkg_check_modules(LibDRM IMPORTED_TARGET REQUIRED libdrm>=2.4.71)
 pkg_check_modules(LibGBM IMPORTED_TARGET REQUIRED gbm>=13.0)
@@ -19,7 +19,7 @@ set_target_properties(cogplatform-drm PROPERTIES
 )
 target_link_libraries(cogplatform-drm PRIVATE
     cogcore
-    PkgConfig::EGL
+    PkgConfig::Epoxy
     PkgConfig::LibDRM
     PkgConfig::LibGBM
     PkgConfig::LibInput

--- a/platform/drm/CMakeLists.txt
+++ b/platform/drm/CMakeLists.txt
@@ -11,6 +11,7 @@ pkg_check_modules(WaylandServer IMPORTED_TARGET REQUIRED wayland-server)
 add_library(cogplatform-drm MODULE
     cog-platform-drm.c
     cog-drm-renderer.c
+    cog-drm-gles-renderer.c
     cog-drm-modeset-renderer.c
     kms.c
     cursor-drm.c

--- a/platform/drm/cog-drm-gles-renderer.c
+++ b/platform/drm/cog-drm-gles-renderer.c
@@ -5,16 +5,77 @@
  * Distributed under terms of the MIT license.
  */
 
+#include "../../core/cog.h"
+#include "../common/cog-gl-utils.h"
 #include "cog-drm-renderer.h"
+#include <drm_fourcc.h>
+#include <drm_mode.h>
 #include <epoxy/gl.h>
+#include <errno.h>
+#include <gbm.h>
+#include <glib-unix.h>
 #include <wayland-util.h>
 #include <wpe/fdo-egl.h>
 #include <wpe/fdo.h>
+#include <xf86drm.h>
+#include <xf86drmMode.h>
+
+G_DEFINE_AUTOPTR_CLEANUP_FUNC(drmModePlane, drmModeFreePlane)
 
 typedef struct {
     CogDrmRenderer base;
 
+    struct gbm_device  *gbm_device;
+    struct gbm_surface *gbm_surface;
+    struct gbm_bo      *current_bo;
+    struct gbm_bo      *next_bo;
+    uint32_t            gbm_format;
+
+    /*
+     * Logical view size without transformations applied, which is needed to
+     * change the transformed size (i.e. rotated) of the view after the view
+     * backend has been instantiated. Note that physical output size is
+     * always determinted from the chosen DRM/KMS mode.
+     */
+    uint32_t width, height;
+
+    CogDrmRendererRotation rotation;
+
+    EGLDisplay egl_display;
+    EGLConfig  egl_config;
+    EGLContext egl_context;
+    EGLSurface egl_surface;
+
+    /*
+     * The renderer wraps frames provided by wpebackend-fdo into a texture,
+     * then paints a quad which samples said texture. A simple GLSL shader
+     * program uses the "position" attribute to fetch the coordinates of
+     * the quad, and the "texture" attribute the UV mapping coordinates for
+     * the texture. Rotation is achieved by changing the UV mapping. The
+     * "texture" uniform is used to reference the texture unit where the
+     * frame textures get loaded.
+     */
+    GLuint gl_program;
+    GLuint gl_texture;
+    GLint  gl_attrib_position;
+    GLint  gl_attrib_texture;
+    GLint  gl_uniform_texture;
+
     struct wpe_view_backend_exportable_fdo *exportable;
+
+    drmEventContext drm_context;
+    unsigned        drm_fd_source;
+    uint32_t        crtc_id;
+    uint32_t        connector_id;
+    uint32_t        plane_id;
+    drmModeModeInfo mode;
+    bool            mode_set;
+    bool            atomic_modesetting;
+
+    struct {
+        drmModeObjectProperties *props;
+        drmModePropertyRes     **props_info;
+    } connector_props, crtc_props, plane_props;
 } CogDrmGlesRenderer;
 
 static void
@@ -22,48 +83,502 @@ cog_drm_gles_renderer_handle_egl_image(void *data, struct wpe_fdo_egl_exported_i
 {
     CogDrmGlesRenderer *self = data;
 
-    /* TODO: Actually do display the image. */
+    if (!eglMakeCurrent(self->egl_display, self->egl_surface, self->egl_surface, self->egl_context)) {
+        g_critical("%s: Cannot activate EGL context for rendering (%#04x)", __func__, eglGetError());
+        return;
+    }
+
+    glViewport(0, 0, self->mode.hdisplay, self->mode.vdisplay);
+    glClearColor(0, 0, 0, 0);
+    glClear(GL_COLOR_BUFFER_BIT);
+
+    glUseProgram(self->gl_program);
+    glActiveTexture(GL_TEXTURE0);
+    glBindTexture(GL_TEXTURE_2D, self->gl_texture);
+    glEGLImageTargetTexture2DOES(GL_TEXTURE_2D, wpe_fdo_egl_exported_image_get_egl_image(image));
+    glUniform1i(self->gl_uniform_texture, 0);
+
+    /* clang-format off */
+    static const float position_coords[4][2] = {
+        { -1,  1 }, { 1,  1 },
+        { -1, -1 }, { 1, -1 },
+    };
+    static const float texture_coords[4][4][2] = {
+        [COG_DRM_RENDERER_ROTATION_0] = {
+            { 0, 0 }, { 1, 0 },
+            { 0, 1 }, { 1, 1 },
+        },
+        [COG_DRM_RENDERER_ROTATION_90] = {
+            { 1, 0 }, { 1, 1 },
+            { 0, 0 }, { 0, 1 },
+        },
+        [COG_DRM_RENDERER_ROTATION_180] = {
+            { 1, 1 }, { 0, 1 },
+            { 1, 0 }, { 0, 0 },
+        },
+        [COG_DRM_RENDERER_ROTATION_270] = {
+            { 0, 1 }, { 0, 0 },
+            { 1, 1 }, { 1, 0 },
+        },
+    };
+    /* clang-format on */
+
+    glVertexAttribPointer(self->gl_attrib_position, 2, GL_FLOAT, GL_FALSE, 0, position_coords);
+    glVertexAttribPointer(self->gl_attrib_texture, 2, GL_FLOAT, GL_FALSE, 0, texture_coords[self->rotation]);
+
+    glEnableVertexAttribArray(self->gl_attrib_position);
+    glEnableVertexAttribArray(self->gl_attrib_texture);
+
+    glDrawArrays(GL_TRIANGLE_STRIP, 0, 4);
+
+    glDisableVertexAttribArray(self->gl_attrib_position);
+    glDisableVertexAttribArray(self->gl_attrib_texture);
+
+    if (G_UNLIKELY(!eglSwapBuffers(self->egl_display, self->egl_surface))) {
+        g_critical("%s: eglSwapBuffers failed (%#04x)", __func__, eglGetError());
+        return;
+    }
+
     wpe_view_backend_exportable_fdo_egl_dispatch_release_exported_image(self->exportable, image);
 
+    int drm_fd = gbm_device_get_fd(self->gbm_device);
+
+    struct gbm_bo *bo = gbm_surface_lock_front_buffer(self->gbm_surface);
+
+    uint32_t handles[4], strides[4], offsets[4];
+    uint64_t modifiers[4];
+
+    for (unsigned i = 0; i < gbm_bo_get_plane_count(bo); i++) {
+        handles[i] = gbm_bo_get_handle_for_plane(bo, i).u32;
+        strides[i] = gbm_bo_get_stride_for_plane(bo, i);
+        offsets[i] = gbm_bo_get_offset(bo, i);
+        modifiers[i] = gbm_bo_get_modifier(bo);
+    }
+
+    /*
+     * Allocating a BO with most drivers typically does NOT query the DRM/KMS
+     * subsystem to know which modifiers are appropriate for an output, which
+     * means the modifiers reported by libgbm might result in a failed frame
+     * buffer allocation. Retrying without modifiers can work in many cases.
+     *
+     * For more on this topic, see https://lkml.org/lkml/2020/7/1/1118
+     */
+    uint32_t fb_id = 0;
+    uint32_t flags = (modifiers[0] && modifiers[0] != DRM_FORMAT_MOD_INVALID) ? DRM_MODE_FB_MODIFIERS : 0;
+    int ret = drmModeAddFB2WithModifiers(drm_fd, self->mode.hdisplay, self->mode.vdisplay, self->gbm_format, handles,
+                                         strides, offsets, modifiers, &fb_id, flags);
+    if (ret) {
+        handles[0] = gbm_bo_get_handle(bo).u32;
+        handles[1] = handles[2] = handles[3] = 0;
+        strides[0] = gbm_bo_get_stride(bo);
+        strides[1] = strides[2] = strides[3] = 0;
+        offsets[0] = offsets[1] = offsets[2] = offsets[3] = 0;
+        ret = drmModeAddFB2(drm_fd, self->mode.hdisplay, self->mode.vdisplay, self->gbm_format, handles, strides,
+                            offsets, &fb_id, 0);
+    }
+    if (ret) {
+        g_warning("%s: Cannot create framebuffer (%s)", __func__, g_strerror(errno));
+        gbm_surface_release_buffer(self->gbm_surface, bo);
+        return;
+    }
+    gbm_bo_set_user_data(bo, GINT_TO_POINTER(fb_id), NULL);
+
+    if (G_UNLIKELY(!self->mode_set)) {
+        int ret = drmModeSetCrtc(drm_fd, self->crtc_id, fb_id, 0, 0, &self->connector_id, 1, &self->mode);
+        if (ret) {
+            g_warning("%s: Cannot set mode (%s)", __func__, g_strerror(errno));
+            return;
+        }
+        self->mode_set = true;
+    }
+
+    self->next_bo = bo;
+
+    if (drmModePageFlip(drm_fd, self->crtc_id, fb_id, DRM_MODE_PAGE_FLIP_EVENT, self)) {
+        g_warning("%s: Cannot schedule page flip (%s)", __func__, g_strerror(errno));
+        return;
+    }
+}
+
+static void
+cog_drm_gles_renderer_handle_page_flip(int fd, unsigned frame, unsigned sec, unsigned usec, void *data)
+{
+    CogDrmGlesRenderer *self = data;
+
+    if (self->current_bo) {
+        uint32_t fb_id = GPOINTER_TO_INT(gbm_bo_get_user_data(self->current_bo));
+        drmModeRmFB(gbm_device_get_fd(self->gbm_device), fb_id);
+        gbm_surface_release_buffer(self->gbm_surface, self->current_bo);
+    }
+    self->current_bo = g_steal_pointer(&self->next_bo);
+
     wpe_view_backend_exportable_fdo_dispatch_frame_complete(self->exportable);
+}
+
+static bool
+cog_drm_gles_renderer_initialize_shaders(CogDrmGlesRenderer *self, GError **error)
+{
+    static const char vertex_shader_source[] = "attribute vec2 position;\n"
+                                               "attribute vec2 texture;\n"
+                                               "varying vec2 v_texture;\n"
+                                               "void main() {\n"
+                                               "  v_texture = texture;\n"
+                                               "  gl_Position = vec4(position, 0, 1);\n"
+                                               "}\n";
+    static const char fragment_shader_source[] = "precision mediump float;\n"
+                                                 "uniform sampler2D u_texture;\n"
+                                                 "varying vec2 v_texture;\n"
+                                                 "void main() {\n"
+                                                 "  gl_FragColor = texture2D(u_texture, v_texture);\n"
+                                                 "}\n";
+
+    g_auto(CogGLShaderId) vertex_shader = cog_gl_load_shader(vertex_shader_source, GL_VERTEX_SHADER, error);
+    if (!vertex_shader)
+        return false;
+
+    g_auto(CogGLShaderId) fragment_shader = cog_gl_load_shader(fragment_shader_source, GL_FRAGMENT_SHADER, error);
+    if (!fragment_shader)
+        return false;
+
+    if (!(self->gl_program = glCreateProgram())) {
+        g_set_error_literal(error, COG_PLATFORM_EGL_ERROR, glGetError(), "Cannot create shader program");
+        return false;
+    }
+
+    glAttachShader(self->gl_program, vertex_shader);
+    glAttachShader(self->gl_program, fragment_shader);
+    glBindAttribLocation(self->gl_program, 0, "position");
+    glBindAttribLocation(self->gl_program, 1, "texture");
+
+    if (!cog_gl_link_program(self->gl_program, error)) {
+        glDeleteProgram(self->gl_program);
+        self->gl_program = 0;
+        return false;
+    }
+
+    self->gl_attrib_position = glGetAttribLocation(self->gl_program, "position");
+    self->gl_attrib_texture = glGetAttribLocation(self->gl_program, "texture");
+    g_assert(self->gl_attrib_position >= 0 && self->gl_attrib_texture >= 0 && self->gl_uniform_texture >= 0);
+
+    return true;
+}
+
+static bool
+cog_drm_gles_renderer_initialize_texture(CogDrmGlesRenderer *self, GError **error)
+{
+    glGenTextures(1, &self->gl_texture);
+    glBindTexture(GL_TEXTURE_2D, self->gl_texture);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
+    glBindTexture(GL_TEXTURE_2D, 0);
+
+    return true;
+}
+
+static gboolean
+cog_drm_gles_renderer_dispatch_drm_events(int fd, GIOCondition condition, void *data)
+{
+    if (condition & (G_IO_ERR | G_IO_HUP)) {
+        g_debug("%s: hangup/error, removing source.", __func__);
+        return G_SOURCE_REMOVE;
+    }
+    if (condition & G_IO_IN) {
+        CogDrmGlesRenderer *self = data;
+        drmHandleEvent(fd, &self->drm_context);
+    }
+    return G_SOURCE_CONTINUE;
 }
 
 static bool
 cog_drm_gles_renderer_initialize(CogDrmRenderer *renderer, GError **error)
 {
     CogDrmGlesRenderer *self = wl_container_of(renderer, self, base);
-    return true;
+
+    static const char *required_egl_extensions[] = {
+        "EGL_KHR_image_base",
+        "EGL_KHR_image",
+    };
+    for (unsigned i = 0; i < G_N_ELEMENTS(required_egl_extensions); i++) {
+        if (!epoxy_has_egl_extension(self->egl_display, required_egl_extensions[i])) {
+            g_set_error(error, COG_PLATFORM_WPE_ERROR, COG_PLATFORM_WPE_ERROR_INIT, "EGL extension %s missing",
+                        required_egl_extensions[i]);
+            return false;
+        }
+    }
+
+    if (!eglBindAPI(EGL_OPENGL_ES_API)) {
+        g_set_error_literal(error, COG_PLATFORM_EGL_ERROR, eglGetError(), "eglBindAPI");
+        return false;
+    }
+
+    /* clang-format off */
+    static const EGLint context_attr[] = {
+        EGL_CONTEXT_CLIENT_VERSION, 2,
+        EGL_NONE,
+    };
+    static const EGLint config_attr[] = {
+        EGL_SURFACE_TYPE, EGL_WINDOW_BIT,
+        EGL_RED_SIZE, 1,
+        EGL_GREEN_SIZE, 1,
+        EGL_BLUE_SIZE, 1,
+        EGL_ALPHA_SIZE, 0,
+        EGL_RENDERABLE_TYPE, EGL_OPENGL_ES2_BIT,
+        EGL_SAMPLES, 0,
+        EGL_NONE,
+    };
+    /* clang-format on */
+
+    EGLint count = 0, matched = 0;
+    if (!eglGetConfigs(self->egl_display, NULL, 0, &count) || count < 1) {
+        g_set_error_literal(error, COG_PLATFORM_EGL_ERROR, eglGetError(), "eglGetConfigs");
+        return false;
+    }
+
+    g_autofree EGLConfig *configs = g_new0(EGLConfig, count);
+    if (!eglChooseConfig(self->egl_display, config_attr, configs, count, &matched)) {
+        g_set_error_literal(error, COG_PLATFORM_EGL_ERROR, eglGetError(), "eglChooseConfig");
+        return false;
+    }
+    if (!matched) {
+        g_set_error_literal(error, COG_PLATFORM_WPE_ERROR, COG_PLATFORM_WPE_ERROR_INIT, "No suitable EGLConfig found");
+        return false;
+    }
+
+    /*
+     * Make sure to pick an EGL configuration with a pixel format compatible
+     * with the chosen output plane, otherwise page-flipping to the BO backing
+     * the surface will fail.
+     */
+    g_autoptr(drmModePlane) plane = drmModeGetPlane(gbm_device_get_fd(self->gbm_device), self->plane_id);
+    if (!plane) {
+        g_set_error(error, COG_PLATFORM_WPE_ERROR, COG_PLATFORM_WPE_ERROR_INIT,
+                    "Cannot get information for DRM/KMS plane #%" PRIu32, self->plane_id);
+        return false;
+    }
+
+    bool config_found = false;
+    for (EGLint i = 0; !config_found && i < matched; i++) {
+        EGLint gbm_format;
+        if (!eglGetConfigAttrib(self->egl_display, configs[i], EGL_NATIVE_VISUAL_ID, &gbm_format)) {
+            g_set_error(error, COG_PLATFORM_EGL_ERROR, eglGetError(), "Cannot get GBM format for config #%d", i);
+            return false;
+        }
+
+        for (uint32_t j = 0; j < plane->count_formats; j++) {
+            if (plane->formats[j] == gbm_format) {
+                self->egl_config = configs[i];
+                self->gbm_format = gbm_format;
+                config_found = true;
+                g_debug("%s: Using config #%d with format '%c%c%c%c'", __func__, i, (gbm_format >> 0) & 0xFF,
+                        (gbm_format >> 8) & 0xFF, (gbm_format >> 16) & 0xFF, (gbm_format >> 24) & 0xFF);
+                break;
+            }
+        }
+    }
+    if (!config_found) {
+        g_set_error(error, COG_PLATFORM_WPE_ERROR, COG_PLATFORM_WPE_ERROR_INIT,
+                    "Cannot find an EGL configuration with a pixel format compatible with plane #%" PRIu32,
+                    self->plane_id);
+        return false;
+    }
+
+    self->egl_context = eglCreateContext(self->egl_display, self->egl_config, EGL_NO_CONTEXT, context_attr);
+    if (self->egl_context == EGL_NO_CONTEXT) {
+        g_set_error_literal(error, COG_PLATFORM_EGL_ERROR, eglGetError(), "eglCreateContext");
+        return false;
+    }
+
+    if (!(self->gbm_surface = gbm_surface_create(self->gbm_device, self->mode.hdisplay, self->mode.vdisplay,
+                                                 self->gbm_format, GBM_BO_USE_SCANOUT | GBM_BO_USE_RENDERING))) {
+        g_set_error(error, COG_PLATFORM_WPE_ERROR, COG_PLATFORM_WPE_ERROR_INIT,
+                    "Cannot create GBM surface for output rendering (%s)", g_strerror(errno));
+        return false;
+    }
+
+    if (epoxy_has_egl_extension(self->egl_display, "EGL_MESA_platform_gbm")) {
+        self->egl_surface =
+            eglCreatePlatformWindowSurfaceEXT(self->egl_display, self->egl_config, self->gbm_surface, NULL);
+    } else {
+        self->egl_surface =
+            eglCreateWindowSurface(self->egl_display, self->egl_config, (EGLNativeWindowType) self->gbm_surface, NULL);
+    }
+    if (!self->egl_surface) {
+        g_set_error(error, COG_PLATFORM_EGL_ERROR, eglGetError(), "Cannot create EGL window surface");
+        return false;
+    }
+
+    /* An active context is needed in order to check for GL extensions. */
+    if (!eglMakeCurrent(self->egl_display, EGL_NO_SURFACE, EGL_NO_SURFACE, self->egl_context)) {
+        g_set_error_literal(error, COG_PLATFORM_EGL_ERROR, eglGetError(),
+                            "Could not activate EGL context for shader compilation");
+        return false;
+    }
+
+    static const char *required_gl_extensions[] = {
+        "GL_OES_EGL_image",
+    };
+    for (unsigned i = 0; i < G_N_ELEMENTS(required_gl_extensions); i++) {
+        if (!epoxy_has_gl_extension(required_gl_extensions[i])) {
+            g_set_error(error, COG_PLATFORM_WPE_ERROR, COG_PLATFORM_WPE_ERROR_INIT, "GL extension %s missing",
+                        required_gl_extensions[i]);
+            return false;
+        }
+    }
+
+    bool ok =
+        cog_drm_gles_renderer_initialize_shaders(self, error) && cog_drm_gles_renderer_initialize_texture(self, error);
+
+    eglMakeCurrent(self->egl_display, EGL_NO_SURFACE, EGL_NO_SURFACE, EGL_NO_CONTEXT);
+
+    self->drm_fd_source =
+        g_unix_fd_add(gbm_device_get_fd(self->gbm_device), G_IO_IN, cog_drm_gles_renderer_dispatch_drm_events, self);
+
+    return ok;
 }
 
 static void
 cog_drm_gles_renderer_destroy(CogDrmRenderer *renderer)
 {
     CogDrmGlesRenderer *self = wl_container_of(renderer, self, base);
+
+    g_clear_handle_id(&self->drm_fd_source, g_source_remove);
+
+    if (self->egl_surface != EGL_NO_SURFACE) {
+        eglDestroySurface(self->egl_display, self->egl_surface);
+        self->egl_surface = EGL_NO_SURFACE;
+    }
+
+    g_clear_pointer(&self->gbm_surface, gbm_surface_destroy);
+
+    if (self->egl_context) {
+        eglDestroyContext(self->egl_display, self->egl_context);
+        self->egl_context = EGL_NO_CONTEXT;
+    }
+}
+
+static void
+cog_drm_gles_renderer_transformed_logical_size(const CogDrmGlesRenderer *self, uint32_t *width, uint32_t *height)
+{
+    switch (self->rotation) {
+    case COG_DRM_RENDERER_ROTATION_0:
+    case COG_DRM_RENDERER_ROTATION_180:
+        *width = self->width;
+        *height = self->height;
+        break;
+    case COG_DRM_RENDERER_ROTATION_90:
+    case COG_DRM_RENDERER_ROTATION_270:
+        *width = self->height;
+        *height = self->width;
+        break;
+    default:
+        g_assert_not_reached();
+    }
+}
+
+static bool
+cog_drm_gles_renderer_set_rotation(CogDrmRenderer *renderer, CogDrmRendererRotation rotation, bool apply)
+{
+    const bool supported = (rotation == COG_DRM_RENDERER_ROTATION_0 || rotation == COG_DRM_RENDERER_ROTATION_90 ||
+                            rotation == COG_DRM_RENDERER_ROTATION_180 || rotation == COG_DRM_RENDERER_ROTATION_270);
+
+    if (!apply)
+        return supported;
+
+    CogDrmGlesRenderer *self = wl_container_of(renderer, self, base);
+    if (self->rotation == rotation)
+        return true;
+
+    self->rotation = rotation;
+
+    if (self->exportable) {
+        uint32_t width, height;
+        cog_drm_gles_renderer_transformed_logical_size(self, &width, &height);
+        wpe_view_backend_dispatch_set_size(wpe_view_backend_exportable_fdo_get_view_backend(self->exportable), width,
+                                           height);
+    }
+    return true;
 }
 
 static struct wpe_view_backend_exportable_fdo *
 cog_drm_gles_renderer_create_exportable(CogDrmRenderer *renderer, uint32_t width, uint32_t height)
 {
+    CogDrmGlesRenderer *self = wl_container_of(renderer, self, base);
+
+    self->width = width;
+    self->height = height;
+    cog_drm_gles_renderer_transformed_logical_size(self, &width, &height);
+
     static const struct wpe_view_backend_exportable_fdo_egl_client client = {
         .export_fdo_egl_image = cog_drm_gles_renderer_handle_egl_image,
     };
-
-    CogDrmGlesRenderer *self = wl_container_of(renderer, self, base);
     return (self->exportable = wpe_view_backend_exportable_fdo_egl_create(&client, renderer, width, height));
 }
 
 CogDrmRenderer *
-cog_drm_gles_renderer_new(EGLDisplay display)
+cog_drm_gles_renderer_new(struct gbm_device     *gbm_device,
+                          EGLDisplay             egl_display,
+                          uint32_t               plane_id,
+                          uint32_t               crtc_id,
+                          uint32_t               connector_id,
+                          const drmModeModeInfo *mode,
+                          bool                   atomic_modesetting)
 {
-    g_assert(display != EGL_NO_DISPLAY);
+    g_assert(gbm_device);
+    g_assert(egl_display != EGL_NO_DISPLAY);
 
     CogDrmGlesRenderer *self = g_slice_new(CogDrmGlesRenderer);
     *self = (CogDrmGlesRenderer){
         .base.name = "gles",
         .base.initialize = cog_drm_gles_renderer_initialize,
         .base.destroy = cog_drm_gles_renderer_destroy,
+        .base.set_rotation = cog_drm_gles_renderer_set_rotation,
         .base.create_exportable = cog_drm_gles_renderer_create_exportable,
+
+        .rotation = COG_DRM_RENDERER_ROTATION_0,
+
+        .gbm_device = gbm_device,
+        .egl_display = egl_display,
+        .egl_context = EGL_NO_CONTEXT,
+        .egl_surface = EGL_NO_SURFACE,
+
+        .drm_context.version = DRM_EVENT_CONTEXT_VERSION,
+        .drm_context.page_flip_handler = cog_drm_gles_renderer_handle_page_flip,
+
+        .crtc_id = crtc_id,
+        .connector_id = connector_id,
+        .plane_id = plane_id,
+        .atomic_modesetting = atomic_modesetting,
     };
+
+    memcpy(&self->mode, mode, sizeof(drmModeModeInfo));
+
+    int drm_fd = gbm_device_get_fd(gbm_device);
+
+    self->connector_props.props = drmModeObjectGetProperties(drm_fd, self->connector_id, DRM_MODE_OBJECT_CONNECTOR);
+    if (self->connector_props.props) {
+        self->connector_props.props_info = g_new0(drmModePropertyRes *, self->connector_props.props->count_props);
+        for (uint32_t i = 0; i < self->connector_props.props->count_props; i++)
+            self->connector_props.props_info[i] = drmModeGetProperty(drm_fd, self->connector_props.props->props[i]);
+    }
+
+    self->crtc_props.props = drmModeObjectGetProperties(drm_fd, self->crtc_id, DRM_MODE_OBJECT_CRTC);
+    if (self->crtc_props.props) {
+        self->crtc_props.props_info = g_new0(drmModePropertyRes *, self->crtc_props.props->count_props);
+        for (uint32_t i = 0; i < self->crtc_props.props->count_props; i++)
+            self->crtc_props.props_info[i] = drmModeGetProperty(drm_fd, self->crtc_props.props->props[i]);
+    }
+
+    self->plane_props.props = drmModeObjectGetProperties(drm_fd, self->plane_id, DRM_MODE_OBJECT_PLANE);
+    if (self->plane_props.props) {
+        self->plane_props.props_info = g_new0(drmModePropertyRes *, self->plane_props.props->count_props);
+        for (uint32_t i = 0; i < self->plane_props.props->count_props; i++)
+            self->plane_props.props_info[i] = drmModeGetProperty(drm_fd, self->plane_props.props->props[i]);
+    }
+
+    g_debug("%s: Using plane #%" PRIu32 ", crtc #%" PRIu32 ", connector #%" PRIu32 " (%s).", __func__, plane_id,
+            crtc_id, connector_id, atomic_modesetting ? "atomic" : "legacy");
 
     return &self->base;
 }

--- a/platform/drm/cog-drm-gles-renderer.c
+++ b/platform/drm/cog-drm-gles-renderer.c
@@ -1,0 +1,69 @@
+/*
+ * cog-drm-gles-renderer.c
+ * Copyright (C) 2021 Igalia S.L.
+ *
+ * Distributed under terms of the MIT license.
+ */
+
+#include "cog-drm-renderer.h"
+#include <epoxy/gl.h>
+#include <wayland-util.h>
+#include <wpe/fdo-egl.h>
+#include <wpe/fdo.h>
+
+typedef struct {
+    CogDrmRenderer base;
+
+    struct wpe_view_backend_exportable_fdo *exportable;
+} CogDrmGlesRenderer;
+
+static void
+cog_drm_gles_renderer_handle_egl_image(void *data, struct wpe_fdo_egl_exported_image *image)
+{
+    CogDrmGlesRenderer *self = data;
+
+    /* TODO: Actually do display the image. */
+    wpe_view_backend_exportable_fdo_egl_dispatch_release_exported_image(self->exportable, image);
+
+    wpe_view_backend_exportable_fdo_dispatch_frame_complete(self->exportable);
+}
+
+static bool
+cog_drm_gles_renderer_initialize(CogDrmRenderer *renderer, GError **error)
+{
+    CogDrmGlesRenderer *self = wl_container_of(renderer, self, base);
+    return true;
+}
+
+static void
+cog_drm_gles_renderer_destroy(CogDrmRenderer *renderer)
+{
+    CogDrmGlesRenderer *self = wl_container_of(renderer, self, base);
+}
+
+static struct wpe_view_backend_exportable_fdo *
+cog_drm_gles_renderer_create_exportable(CogDrmRenderer *renderer, uint32_t width, uint32_t height)
+{
+    static const struct wpe_view_backend_exportable_fdo_egl_client client = {
+        .export_fdo_egl_image = cog_drm_gles_renderer_handle_egl_image,
+    };
+
+    CogDrmGlesRenderer *self = wl_container_of(renderer, self, base);
+    return (self->exportable = wpe_view_backend_exportable_fdo_egl_create(&client, renderer, width, height));
+}
+
+CogDrmRenderer *
+cog_drm_gles_renderer_new(EGLDisplay display)
+{
+    g_assert(display != EGL_NO_DISPLAY);
+
+    CogDrmGlesRenderer *self = g_slice_new(CogDrmGlesRenderer);
+    *self = (CogDrmGlesRenderer){
+        .base.name = "gles",
+        .base.initialize = cog_drm_gles_renderer_initialize,
+        .base.destroy = cog_drm_gles_renderer_destroy,
+        .base.create_exportable = cog_drm_gles_renderer_create_exportable,
+    };
+
+    return &self->base;
+}

--- a/platform/drm/cog-drm-modeset-renderer.c
+++ b/platform/drm/cog-drm-modeset-renderer.c
@@ -687,5 +687,8 @@ cog_drm_modeset_renderer_new(struct gbm_device     *gbm_dev,
             self->plane_props.props_info[i] = drmModeGetProperty(get_drm_fd(self), self->plane_props.props->props[i]);
     }
 
+    g_debug("%s: Using plane #%" PRIu32 ", crtc #%" PRIu32 ", connector #%" PRIu32 " (%s).", __func__, plane_id,
+            crtc_id, connector_id, atomic_modesetting ? "atomic" : "legacy");
+
     return &self->base;
 }

--- a/platform/drm/cog-drm-modeset-renderer.c
+++ b/platform/drm/cog-drm-modeset-renderer.c
@@ -1,0 +1,691 @@
+/*
+ * cog-drm-modeset-renderer.c
+ * Copyright (C) 2021 Igalia S.L.
+ *
+ * Distributed under terms of the MIT license.
+ */
+
+#include "../../core/cog.h"
+#include "cog-drm-renderer.h"
+#include <errno.h>
+#include <gbm.h>
+#include <wayland-server.h>
+#include <wpe/fdo.h>
+#include <xf86drm.h>
+#include <xf86drmMode.h>
+
+typedef struct {
+    GSource         base;
+    GPollFD         pfd;
+    drmEventContext event_context;
+} DrmEventSource;
+
+static gboolean
+drm_source_check(GSource *source)
+{
+    DrmEventSource *self = wl_container_of(source, self, base);
+    return !!self->pfd.revents;
+}
+
+static gboolean
+drm_source_dispatch(GSource *source, GSourceFunc callback, gpointer user_data)
+{
+    DrmEventSource *self = wl_container_of(source, self, base);
+    if (self->pfd.revents & (G_IO_ERR | G_IO_HUP))
+        return FALSE;
+
+    if (self->pfd.revents & G_IO_IN)
+        drmHandleEvent(self->pfd.fd, &self->event_context);
+    self->pfd.revents = 0;
+    return TRUE;
+}
+
+static void drm_page_flip_handler(int fd, unsigned int frame, unsigned int sec, unsigned int usec, void *);
+
+static GSource *
+drm_event_source_new(int fd)
+{
+    static GSourceFuncs funcs = {
+        .check = drm_source_check,
+        .dispatch = drm_source_dispatch,
+    };
+
+    DrmEventSource *self = (DrmEventSource *) g_source_new(&funcs, sizeof(DrmEventSource));
+    self->event_context = (drmEventContext){
+        .version = DRM_EVENT_CONTEXT_VERSION,
+        .page_flip_handler = drm_page_flip_handler,
+    };
+    self->pfd = (GPollFD){
+        .fd = fd,
+        .events = G_IO_IN | G_IO_ERR | G_IO_HUP,
+    };
+
+    g_source_add_poll(&self->base, &self->pfd);
+    g_source_set_name(&self->base, "cog: drm");
+    g_source_set_can_recurse(&self->base, TRUE);
+
+    return &self->base;
+}
+
+struct buffer_object {
+    struct wl_list     link;
+    struct wl_listener destroy_listener;
+
+    uint32_t            fb_id;
+    struct gbm_bo      *bo;
+    struct wl_resource *buffer_resource;
+
+    struct {
+        struct wl_resource                 *resource;
+        struct wpe_fdo_shm_exported_buffer *shm_buffer;
+    } export;
+};
+
+typedef struct {
+    CogDrmRenderer base;
+
+    GSource *drm_source;
+
+    struct buffer_object *committed_buffer;
+    struct wl_list        buffer_list; /* buffer_object::link */
+
+    struct wpe_view_backend_exportable_fdo *exportable;
+
+    struct gbm_device *gbm_dev;
+
+    uint32_t        crtc_id;
+    uint32_t        connector_id;
+    uint32_t        plane_id;
+    drmModeModeInfo mode;
+    bool            mode_set;
+    bool            atomic_modesetting;
+
+    struct {
+        drmModeObjectProperties *props;
+        drmModePropertyRes     **props_info;
+    } connector_props, crtc_props, plane_props;
+} CogDrmModesetRenderer;
+
+static inline int
+get_drm_fd(CogDrmModesetRenderer *self)
+{
+    DrmEventSource *s = wl_container_of(self->drm_source, s, base);
+    return s->pfd.fd;
+}
+
+static void
+destroy_buffer(CogDrmModesetRenderer *renderer, struct buffer_object *buffer)
+{
+    drmModeRmFB(get_drm_fd(renderer), buffer->fb_id);
+    gbm_bo_destroy(buffer->bo);
+
+    if (buffer->export.resource) {
+        wpe_view_backend_exportable_fdo_dispatch_release_buffer(renderer->exportable, buffer->export.resource);
+        buffer->export.resource = NULL;
+    }
+
+    if (buffer->export.shm_buffer) {
+        wpe_view_backend_exportable_fdo_dispatch_release_shm_exported_buffer(renderer->exportable,
+                                                                             buffer->export.shm_buffer);
+        buffer->export.shm_buffer = NULL;
+    }
+
+    g_free(buffer);
+}
+
+static void
+destroy_buffer_notify(struct wl_listener *listener, void *data)
+{
+    struct buffer_object  *buffer = wl_container_of(listener, buffer, destroy_listener);
+    CogDrmModesetRenderer *renderer = wl_resource_get_user_data(buffer->buffer_resource);
+
+    if (renderer->committed_buffer == buffer)
+        renderer->committed_buffer = NULL;
+
+    wl_list_remove(&buffer->link);
+
+    wl_resource_set_user_data(buffer->buffer_resource, NULL);
+    destroy_buffer(renderer, buffer);
+}
+
+static struct buffer_object *
+drm_buffer_for_resource(CogDrmModesetRenderer *renderer, struct wl_resource *buffer_resource)
+{
+    struct buffer_object *buffer;
+    wl_list_for_each(buffer, &renderer->buffer_list, link) {
+        if (buffer->buffer_resource == buffer_resource)
+            return buffer;
+    }
+    return NULL;
+}
+
+static struct buffer_object *
+drm_create_buffer_for_bo(CogDrmModesetRenderer *self,
+                         struct gbm_bo         *bo,
+                         struct wl_resource    *buffer_resource,
+                         uint32_t               width,
+                         uint32_t               height,
+                         uint32_t               format)
+{
+    uint32_t in_handles[4] = {
+        0,
+    };
+    uint32_t in_strides[4] = {
+        0,
+    };
+    uint32_t in_offsets[4] = {
+        0,
+    };
+    uint64_t in_modifiers[4] = {
+        0,
+    };
+
+    in_modifiers[0] = gbm_bo_get_modifier(bo);
+
+    int plane_count = MIN(gbm_bo_get_plane_count(bo), 4);
+    for (int i = 0; i < plane_count; ++i) {
+        in_handles[i] = gbm_bo_get_handle_for_plane(bo, i).u32;
+        in_strides[i] = gbm_bo_get_stride_for_plane(bo, i);
+        in_offsets[i] = gbm_bo_get_offset(bo, i);
+        in_modifiers[i] = in_modifiers[0];
+    }
+
+    int flags = 0;
+    if (in_modifiers[0])
+        flags = DRM_MODE_FB_MODIFIERS;
+
+    uint32_t fb_id = 0;
+    int ret = drmModeAddFB2WithModifiers(get_drm_fd(self), width, height, format, in_handles, in_strides, in_offsets,
+                                         in_modifiers, &fb_id, flags);
+    if (ret) {
+        in_handles[0] = gbm_bo_get_handle(bo).u32;
+        in_handles[1] = in_handles[2] = in_handles[3] = 0;
+        in_strides[0] = gbm_bo_get_stride(bo);
+        in_strides[1] = in_strides[2] = in_strides[3] = 0;
+        in_offsets[0] = in_offsets[1] = in_offsets[2] = in_offsets[3] = 0;
+
+        ret = drmModeAddFB2(get_drm_fd(self), width, height, format, in_handles, in_strides, in_offsets, &fb_id, 0);
+    }
+
+    if (ret) {
+        g_warning("failed to create framebuffer: %s", strerror(errno));
+        return NULL;
+    }
+
+    struct buffer_object *buffer = g_new0(struct buffer_object, 1);
+    wl_list_insert(&self->buffer_list, &buffer->link);
+    buffer->destroy_listener.notify = destroy_buffer_notify;
+    wl_resource_add_destroy_listener(buffer_resource, &buffer->destroy_listener);
+    wl_resource_set_user_data(buffer_resource, self);
+
+    buffer->fb_id = fb_id;
+    buffer->bo = bo;
+    buffer->buffer_resource = buffer_resource;
+
+    return buffer;
+}
+
+static struct buffer_object *
+drm_create_buffer_for_shm_buffer(CogDrmModesetRenderer *self,
+                                 struct wl_resource    *buffer_resource,
+                                 struct wl_shm_buffer  *shm_buffer)
+{
+    uint32_t format = wl_shm_buffer_get_format(shm_buffer);
+    if (format != WL_SHM_FORMAT_ARGB8888 && format != WL_SHM_FORMAT_XRGB8888) {
+        g_warning("failed to handle non-32-bit ARGB/XRGB format");
+        return NULL;
+    }
+
+    int32_t width = wl_shm_buffer_get_width(shm_buffer);
+    int32_t height = wl_shm_buffer_get_height(shm_buffer);
+
+    // TODO: don't ignore the alpha channel in case of ARGB8888 SHM data
+    uint32_t       gbm_format = GBM_FORMAT_XRGB8888;
+    struct gbm_bo *bo = gbm_bo_create(self->gbm_dev, width, height, gbm_format, GBM_BO_USE_SCANOUT | GBM_BO_USE_WRITE);
+    if (!bo) {
+        g_warning("failed to create a gbm_bo object");
+        return NULL;
+    }
+
+    uint32_t in_handles[4] = {
+        0,
+    };
+    uint32_t in_strides[4] = {
+        0,
+    };
+    uint32_t in_offsets[4] = {
+        0,
+    };
+    in_handles[0] = gbm_bo_get_handle(bo).u32;
+    in_strides[0] = gbm_bo_get_stride(bo);
+
+    uint32_t fb_id = 0;
+    int ret = drmModeAddFB2(get_drm_fd(self), width, height, gbm_format, in_handles, in_strides, in_offsets, &fb_id, 0);
+    if (ret) {
+        gbm_bo_destroy(bo);
+        g_warning("failed to create framebuffer: %s", g_strerror(errno));
+        return NULL;
+    }
+
+    struct buffer_object *buffer = g_new0(struct buffer_object, 1);
+    wl_list_insert(&self->buffer_list, &buffer->link);
+    buffer->destroy_listener.notify = destroy_buffer_notify;
+    wl_resource_add_destroy_listener(buffer_resource, &buffer->destroy_listener);
+    wl_resource_set_user_data(buffer_resource, self);
+
+    buffer->fb_id = fb_id;
+    buffer->bo = bo;
+    buffer->buffer_resource = buffer_resource;
+
+    return buffer;
+}
+
+static void
+drm_copy_shm_buffer_into_bo(struct wl_shm_buffer *shm_buffer, struct gbm_bo *bo)
+{
+    int32_t width = wl_shm_buffer_get_width(shm_buffer);
+    int32_t height = wl_shm_buffer_get_height(shm_buffer);
+    int32_t stride = wl_shm_buffer_get_stride(shm_buffer);
+
+    uint32_t bo_stride = 0;
+    void    *map_data = NULL;
+    gbm_bo_map(bo, 0, 0, width, height, GBM_BO_TRANSFER_WRITE, &bo_stride, &map_data);
+    if (!map_data)
+        return;
+
+    wl_shm_buffer_begin_access(shm_buffer);
+
+    uint8_t *src = wl_shm_buffer_get_data(shm_buffer);
+    uint8_t *dst = map_data;
+
+    uint32_t bo_width = gbm_bo_get_width(bo);
+    uint32_t bo_height = gbm_bo_get_height(bo);
+    if (!(width == bo_width && height == bo_height && stride == bo_stride)) {
+        for (uint32_t y = 0; y < height; ++y) {
+            for (uint32_t x = 0; x < width; ++x) {
+                dst[bo_stride * y + 4 * x + 0] = src[stride * y + 4 * x + 0];
+                dst[bo_stride * y + 4 * x + 1] = src[stride * y + 4 * x + 1];
+                dst[bo_stride * y + 4 * x + 2] = src[stride * y + 4 * x + 2];
+                dst[bo_stride * y + 4 * x + 3] = src[stride * y + 4 * x + 3];
+            }
+        }
+    } else
+        memcpy(dst, src, stride * height);
+
+    wl_shm_buffer_end_access(shm_buffer);
+    gbm_bo_unmap(bo, map_data);
+}
+
+typedef struct {
+    CogDrmModesetRenderer *renderer;
+    struct buffer_object  *buffer;
+} FlipHandlerData;
+
+static int
+drm_commit_buffer_nonatomic(CogDrmModesetRenderer *self, struct buffer_object *buffer)
+{
+    if (!self->mode_set) {
+        int ret =
+            drmModeSetCrtc(get_drm_fd(self), self->crtc_id, buffer->fb_id, 0, 0, &self->connector_id, 1, &self->mode);
+        if (ret)
+            return -1;
+
+        self->mode_set = true;
+    }
+
+    FlipHandlerData *data = g_slice_new(FlipHandlerData);
+    *data = (FlipHandlerData){self, buffer};
+
+    return drmModePageFlip(get_drm_fd(self), self->crtc_id, buffer->fb_id, DRM_MODE_PAGE_FLIP_EVENT, data);
+}
+
+static int
+add_property(drmModeObjectProperties *props,
+             drmModePropertyRes     **props_info,
+             drmModeAtomicReq        *req,
+             uint32_t                 obj_id,
+             const char              *name,
+             uint64_t                 value)
+{
+    for (int i = 0; i < props->count_props; ++i) {
+        if (!g_strcmp0(props_info[i]->name, name)) {
+            int ret = drmModeAtomicAddProperty(req, obj_id, props_info[i]->prop_id, value);
+            return (ret > 0) ? 0 : -1;
+        }
+    }
+
+    return -1;
+}
+
+static int
+add_connector_property(CogDrmModesetRenderer *self,
+                       drmModeAtomicReq      *req,
+                       uint32_t               obj_id,
+                       const char            *name,
+                       uint64_t               value)
+{
+    return add_property(self->connector_props.props, self->connector_props.props_info, req, obj_id, name, value);
+}
+
+static int
+add_crtc_property(CogDrmModesetRenderer *self, drmModeAtomicReq *req, uint32_t obj_id, const char *name, uint64_t value)
+{
+    return add_property(self->crtc_props.props, self->crtc_props.props_info, req, obj_id, name, value);
+}
+
+static int
+add_plane_property(CogDrmModesetRenderer *self,
+                   drmModeAtomicReq      *req,
+                   uint32_t               obj_id,
+                   const char            *name,
+                   uint64_t               value)
+{
+    return add_property(self->plane_props.props, self->plane_props.props_info, req, obj_id, name, value);
+}
+
+static int
+drm_commit_buffer_atomic(CogDrmModesetRenderer *self, struct buffer_object *buffer)
+{
+    int      ret = 0;
+    uint32_t flags = DRM_MODE_PAGE_FLIP_EVENT | DRM_MODE_ATOMIC_NONBLOCK;
+
+    drmModeAtomicReq *req = drmModeAtomicAlloc();
+
+    if (!self->mode_set) {
+        flags |= DRM_MODE_ATOMIC_ALLOW_MODESET;
+
+        uint32_t blob_id;
+        ret = drmModeCreatePropertyBlob(get_drm_fd(self), &self->mode, sizeof(drmModeModeInfo), &blob_id);
+        if (ret) {
+            drmModeAtomicFree(req);
+            return -1;
+        }
+
+        ret |= add_connector_property(self, req, self->connector_id, "CRTC_ID", self->crtc_id);
+        ret |= add_crtc_property(self, req, self->crtc_id, "MODE_ID", blob_id);
+        ret |= add_crtc_property(self, req, self->crtc_id, "ACTIVE", 1);
+        if (ret) {
+            drmModeAtomicFree(req);
+            return -1;
+        }
+
+        self->mode_set = true;
+    }
+
+    ret |= add_plane_property(self, req, self->plane_id, "FB_ID", buffer->fb_id);
+    ret |= add_plane_property(self, req, self->plane_id, "CRTC_ID", self->crtc_id);
+    ret |= add_plane_property(self, req, self->plane_id, "SRC_X", 0);
+    ret |= add_plane_property(self, req, self->plane_id, "SRC_Y", 0);
+    ret |= add_plane_property(self, req, self->plane_id, "SRC_W", ((uint64_t) self->mode.hdisplay) << 16);
+    ret |= add_plane_property(self, req, self->plane_id, "SRC_H", ((uint64_t) self->mode.vdisplay) << 16);
+    ret |= add_plane_property(self, req, self->plane_id, "CRTC_X", 0);
+    ret |= add_plane_property(self, req, self->plane_id, "CRTC_Y", 0);
+    ret |= add_plane_property(self, req, self->plane_id, "CRTC_W", self->mode.hdisplay);
+    ret |= add_plane_property(self, req, self->plane_id, "CRTC_H", self->mode.vdisplay);
+    if (ret) {
+        drmModeAtomicFree(req);
+        return -1;
+    }
+
+    FlipHandlerData *data = g_slice_new(FlipHandlerData);
+    *data = (FlipHandlerData){self, buffer};
+
+    ret = drmModeAtomicCommit(get_drm_fd(self), req, flags, data);
+    if (ret) {
+        drmModeAtomicFree(req);
+        return -1;
+    }
+
+    drmModeAtomicFree(req);
+    return 0;
+}
+
+static void
+drm_commit_buffer(CogDrmModesetRenderer *self, struct buffer_object *buffer)
+{
+    int ret;
+    if (self->atomic_modesetting)
+        ret = drm_commit_buffer_atomic(self, buffer);
+    else
+        ret = drm_commit_buffer_nonatomic(self, buffer);
+
+    if (ret)
+        g_warning("failed to schedule a page flip: %s", g_strerror(errno));
+}
+
+static void
+on_export_buffer_resource(void *data, struct wl_resource *buffer_resource)
+{
+    CogDrmModesetRenderer *self = data;
+    struct buffer_object  *buffer = drm_buffer_for_resource(self, buffer_resource);
+    if (buffer) {
+        buffer->export.resource = buffer_resource;
+        drm_commit_buffer(self, buffer);
+        return;
+    }
+
+    struct gbm_bo *bo =
+        gbm_bo_import(self->gbm_dev, GBM_BO_IMPORT_WL_BUFFER, (void *) buffer_resource, GBM_BO_USE_SCANOUT);
+    if (!bo) {
+        g_warning("failed to import a wl_buffer resource into gbm_bo");
+        return;
+    }
+
+    uint32_t width = gbm_bo_get_width(bo);
+    uint32_t height = gbm_bo_get_height(bo);
+    uint32_t format = gbm_bo_get_format(bo);
+
+    buffer = drm_create_buffer_for_bo(self, bo, buffer_resource, width, height, format);
+    if (buffer) {
+        buffer->export.resource = buffer_resource;
+        drm_commit_buffer(self, buffer);
+    }
+}
+
+static void
+on_export_dmabuf_resource(void *data, struct wpe_view_backend_exportable_fdo_dmabuf_resource *dmabuf_resource)
+{
+    CogDrmModesetRenderer *self = data;
+
+    struct buffer_object *buffer = drm_buffer_for_resource(self, dmabuf_resource->buffer_resource);
+    if (buffer) {
+        buffer->export.resource = dmabuf_resource->buffer_resource;
+        drm_commit_buffer(self, buffer);
+        return;
+    }
+
+    struct gbm_import_fd_modifier_data modifier_data = {
+        .width = dmabuf_resource->width,
+        .height = dmabuf_resource->height,
+        .format = dmabuf_resource->format,
+        .num_fds = dmabuf_resource->n_planes,
+        .modifier = dmabuf_resource->modifiers[0],
+    };
+    for (uint32_t i = 0; i < modifier_data.num_fds; ++i) {
+        modifier_data.fds[i] = dmabuf_resource->fds[i];
+        modifier_data.strides[i] = dmabuf_resource->strides[i];
+        modifier_data.offsets[i] = dmabuf_resource->offsets[i];
+    }
+
+    struct gbm_bo *bo =
+        gbm_bo_import(self->gbm_dev, GBM_BO_IMPORT_FD_MODIFIER, (void *) (&modifier_data), GBM_BO_USE_SCANOUT);
+    if (!bo) {
+        g_warning("failed to import a dma-buf resource into gbm_bo");
+        return;
+    }
+
+    buffer = drm_create_buffer_for_bo(self, bo, dmabuf_resource->buffer_resource, dmabuf_resource->width,
+                                      dmabuf_resource->height, dmabuf_resource->format);
+    if (buffer) {
+        buffer->export.resource = dmabuf_resource->buffer_resource;
+        drm_commit_buffer(self, buffer);
+    }
+}
+
+static void
+on_export_shm_buffer(void *data, struct wpe_fdo_shm_exported_buffer *exported_buffer)
+{
+    CogDrmModesetRenderer *self = data;
+
+    struct wl_resource   *exported_resource = wpe_fdo_shm_exported_buffer_get_resource(exported_buffer);
+    struct wl_shm_buffer *exported_shm_buffer = wpe_fdo_shm_exported_buffer_get_shm_buffer(exported_buffer);
+
+    struct buffer_object *buffer = drm_buffer_for_resource(self, exported_resource);
+    if (buffer) {
+        drm_copy_shm_buffer_into_bo(exported_shm_buffer, buffer->bo);
+
+        buffer->export.shm_buffer = exported_buffer;
+        drm_commit_buffer(self, buffer);
+        return;
+    }
+
+    buffer = drm_create_buffer_for_shm_buffer(self, exported_resource, exported_shm_buffer);
+    if (buffer) {
+        drm_copy_shm_buffer_into_bo(exported_shm_buffer, buffer->bo);
+
+        buffer->export.shm_buffer = exported_buffer;
+        drm_commit_buffer(self, buffer);
+    }
+}
+
+static void
+drm_page_flip_handler(int fd, unsigned int frame, unsigned int sec, unsigned int usec, void *data)
+{
+    CogDrmModesetRenderer *self = ((FlipHandlerData *) data)->renderer;
+    struct buffer_object  *buffer = ((FlipHandlerData *) data)->buffer;
+    g_slice_free(FlipHandlerData, data);
+
+    if (self->committed_buffer) {
+        struct buffer_object *buffer = self->committed_buffer;
+
+        if (buffer->export.resource) {
+            wpe_view_backend_exportable_fdo_dispatch_release_buffer(self->exportable, buffer->export.resource);
+            buffer->export.resource = NULL;
+        }
+
+        if (buffer->export.shm_buffer) {
+            wpe_view_backend_exportable_fdo_dispatch_release_shm_exported_buffer(self->exportable,
+                                                                                 buffer->export.shm_buffer);
+            buffer->export.shm_buffer = NULL;
+        }
+    }
+
+    self->committed_buffer = buffer;
+    wpe_view_backend_exportable_fdo_dispatch_frame_complete(self->exportable);
+}
+
+static bool
+cog_drm_modeset_renderer_initialize(CogDrmRenderer *renderer, GError **error)
+{
+    CogDrmModesetRenderer *self = wl_container_of(renderer, self, base);
+
+    g_source_attach(self->drm_source, g_main_context_get_thread_default());
+
+    return true;
+}
+
+static void
+cog_drm_modeset_renderer_destroy(CogDrmRenderer *renderer)
+{
+    CogDrmModesetRenderer *self = wl_container_of(renderer, self, base);
+
+    struct buffer_object *buffer, *tmp;
+    wl_list_for_each_safe(buffer, tmp, &self->buffer_list, link) {
+        wl_list_remove(&buffer->link);
+        wl_list_remove(&buffer->destroy_listener.link);
+        destroy_buffer(self, buffer);
+    }
+    wl_list_init(&self->buffer_list);
+    self->committed_buffer = NULL;
+
+    if (self->connector_props.props_info) {
+        for (uint32_t i = 0; i < self->connector_props.props->count_props; i++)
+            drmModeFreeProperty(self->connector_props.props_info[i]);
+    }
+    g_clear_pointer(&self->connector_props.props, drmModeFreeObjectProperties);
+    g_clear_pointer(&self->connector_props.props_info, g_free);
+
+    if (self->crtc_props.props_info) {
+        for (uint32_t i = 0; i < self->crtc_props.props->count_props; ++i)
+            drmModeFreeProperty(self->crtc_props.props_info[i]);
+    }
+    g_clear_pointer(&self->crtc_props.props, drmModeFreeObjectProperties);
+    g_clear_pointer(&self->crtc_props.props_info, g_free);
+
+    if (self->plane_props.props_info) {
+        for (uint32_t i = 0; i < self->plane_props.props->count_props; ++i)
+            drmModeFreeProperty(self->plane_props.props_info[i]);
+    }
+    g_clear_pointer(&self->plane_props.props, drmModeFreeObjectProperties);
+    g_clear_pointer(&self->plane_props.props_info, g_free);
+
+    g_clear_pointer(&self->gbm_dev, gbm_device_destroy);
+
+    g_slice_free(CogDrmModesetRenderer, renderer);
+}
+
+static struct wpe_view_backend_exportable_fdo *
+cog_drm_modeset_renderer_create_exportable(CogDrmRenderer *renderer, uint32_t width, uint32_t height)
+{
+    static const struct wpe_view_backend_exportable_fdo_client client = {
+        .export_buffer_resource = on_export_buffer_resource,
+        .export_dmabuf_resource = on_export_dmabuf_resource,
+        .export_shm_buffer = on_export_shm_buffer,
+    };
+
+    CogDrmModesetRenderer *self = wl_container_of(renderer, self, base);
+    return (self->exportable = wpe_view_backend_exportable_fdo_create(&client, renderer, width, height));
+}
+
+CogDrmRenderer *
+cog_drm_modeset_renderer_new(struct gbm_device     *gbm_dev,
+                             uint32_t               plane_id,
+                             uint32_t               crtc_id,
+                             uint32_t               connector_id,
+                             const drmModeModeInfo *mode,
+                             bool                   atomic_modesetting)
+{
+    CogDrmModesetRenderer *self = g_slice_new0(CogDrmModesetRenderer);
+
+    *self = (CogDrmModesetRenderer){
+        .base.name = "modeset",
+        .base.initialize = cog_drm_modeset_renderer_initialize,
+        .base.destroy = cog_drm_modeset_renderer_destroy,
+        .base.create_exportable = cog_drm_modeset_renderer_create_exportable,
+
+        .drm_source = drm_event_source_new(gbm_device_get_fd(gbm_dev)),
+        .gbm_dev = gbm_dev,
+
+        .crtc_id = crtc_id,
+        .connector_id = connector_id,
+        .plane_id = plane_id,
+        .atomic_modesetting = atomic_modesetting,
+    };
+    wl_list_init(&self->buffer_list);
+    memcpy(&self->mode, mode, sizeof(drmModeModeInfo));
+
+    self->connector_props.props =
+        drmModeObjectGetProperties(get_drm_fd(self), self->connector_id, DRM_MODE_OBJECT_CONNECTOR);
+    if (self->connector_props.props) {
+        self->connector_props.props_info = g_new0(drmModePropertyRes *, self->connector_props.props->count_props);
+        for (uint32_t i = 0; i < self->connector_props.props->count_props; i++)
+            self->connector_props.props_info[i] =
+                drmModeGetProperty(get_drm_fd(self), self->connector_props.props->props[i]);
+    }
+
+    self->crtc_props.props = drmModeObjectGetProperties(get_drm_fd(self), self->crtc_id, DRM_MODE_OBJECT_CRTC);
+    if (self->crtc_props.props) {
+        self->crtc_props.props_info = g_new0(drmModePropertyRes *, self->crtc_props.props->count_props);
+        for (uint32_t i = 0; i < self->crtc_props.props->count_props; i++)
+            self->crtc_props.props_info[i] = drmModeGetProperty(get_drm_fd(self), self->crtc_props.props->props[i]);
+    }
+
+    self->plane_props.props = drmModeObjectGetProperties(get_drm_fd(self), self->plane_id, DRM_MODE_OBJECT_PLANE);
+    if (self->plane_props.props) {
+        self->plane_props.props_info = g_new0(drmModePropertyRes *, self->plane_props.props->count_props);
+        for (uint32_t i = 0; i < self->plane_props.props->count_props; i++)
+            self->plane_props.props_info[i] = drmModeGetProperty(get_drm_fd(self), self->plane_props.props->props[i]);
+    }
+
+    return &self->base;
+}

--- a/platform/drm/cog-drm-renderer.c
+++ b/platform/drm/cog-drm-renderer.c
@@ -1,0 +1,17 @@
+/*
+ * cog-drm-renderer.c
+ * Copyright (C) 2021 Igalia S.L.
+ *
+ * Distributed under terms of the MIT license.
+ */
+
+#include "cog-drm-renderer.h"
+
+void
+cog_drm_renderer_destroy(CogDrmRenderer *self)
+{
+    if (self) {
+        g_assert(self->destroy);
+        self->destroy(self);
+    }
+}

--- a/platform/drm/cog-drm-renderer.h
+++ b/platform/drm/cog-drm-renderer.h
@@ -1,0 +1,50 @@
+/*
+ * cog-drm-renderer.h
+ * Copyright (C) 2021 Igalia S.L.
+ *
+ * Distributed under terms of the MIT license.
+ */
+
+#pragma once
+
+#include <glib.h>
+#include <inttypes.h>
+#include <stdbool.h>
+
+struct gbm_device;
+struct wpe_view_backend_exportable_fdo;
+typedef struct _drmModeModeInfo drmModeModeInfo;
+typedef struct _CogDrmRenderer  CogDrmRenderer;
+
+struct _CogDrmRenderer {
+    const char *name;
+
+    bool (*initialize)(CogDrmRenderer *, GError **);
+    void (*destroy)(CogDrmRenderer *);
+
+    struct wpe_view_backend_exportable_fdo *(*create_exportable)(CogDrmRenderer *, uint32_t width, uint32_t height);
+};
+
+void cog_drm_renderer_destroy(CogDrmRenderer *self);
+G_DEFINE_AUTOPTR_CLEANUP_FUNC(CogDrmRenderer, cog_drm_renderer_destroy)
+
+static inline bool
+cog_drm_renderer_initialize(CogDrmRenderer *self, GError **error)
+{
+    if (self->initialize)
+        return self->initialize(self, error);
+    return true;
+}
+
+static inline struct wpe_view_backend_exportable_fdo *
+cog_drm_renderer_create_exportable(CogDrmRenderer *self, uint32_t width, uint32_t height)
+{
+    return self->create_exportable(self, width, height);
+}
+
+CogDrmRenderer *cog_drm_modeset_renderer_new(struct gbm_device     *dev,
+                                             uint32_t               plane_id,
+                                             uint32_t               crtc_id,
+                                             uint32_t               connector_id,
+                                             const drmModeModeInfo *mode,
+                                             bool                   atomic_modesetting);

--- a/platform/drm/cog-drm-renderer.h
+++ b/platform/drm/cog-drm-renderer.h
@@ -7,6 +7,7 @@
 
 #pragma once
 
+#include <epoxy/egl.h>
 #include <glib.h>
 #include <inttypes.h>
 #include <stdbool.h>
@@ -48,3 +49,5 @@ CogDrmRenderer *cog_drm_modeset_renderer_new(struct gbm_device     *dev,
                                              uint32_t               connector_id,
                                              const drmModeModeInfo *mode,
                                              bool                   atomic_modesetting);
+
+CogDrmRenderer *cog_drm_gles_renderer_new(EGLDisplay display);

--- a/platform/drm/cog-platform-drm.c
+++ b/platform/drm/cog-platform-drm.c
@@ -16,8 +16,7 @@
 #include "kms.h"
 #include "cursor-drm.h"
 
-#include <EGL/egl.h>
-#include <EGL/eglext.h>
+#include <epoxy/egl.h>
 
 #include "../common/egl-proc-address.h"
 

--- a/platform/drm/cog-platform-drm.c
+++ b/platform/drm/cog-platform-drm.c
@@ -1238,7 +1238,13 @@ cog_drm_platform_setup(CogPlatform *platform, CogShell *shell, const char *param
     }
 
     if (use_gles_renderer) {
-        self->renderer = cog_drm_gles_renderer_new(egl_data.display);
+        self->renderer = cog_drm_gles_renderer_new(gbm_data.device,
+                                                   egl_data.display,
+                                                   drm_data.plane.obj_id,
+                                                   drm_data.crtc.obj_id,
+                                                   drm_data.connector.obj_id,
+                                                   drm_data.mode,
+                                                   drm_data.atomic_modesetting);
     } else {
         self->renderer = cog_drm_modeset_renderer_new(gbm_data.device,
                                                       drm_data.plane.obj_id,


### PR DESCRIPTION
This is an alternative take on #360 — as it turns out using DRM/KMS exclusively is a can of works:

- In many cases graphics hardware imposes stringent restrictions on how to use hardware-assisted rotation support for DRM/KMS planes. For example on Intel GPUs typically one needs framebuffers with the `I915_FORMAT_MOD_Y_TILED` or `I915_FORMAT_MOD_Yf_TILED` modifiers for 90º/270º rotations, and on OMAP hardware one needs to manually use `ioctl()` and set one of the `OMAP_BO_TILED_*` flags in BOs which will be used for rotated scanout. Ad-hoc support for each hardware would be needed in `cog-platform-drm.c`.
- In some cases using one more hardware block results in more power consumption than using OpenGL because the GPU would be active and running anyway, and if unused the additional hardware needed to do the rotation (i.e the “tiler” block in OMAP devices) can stay powered off.
- Some hardware plainly does not provide a way to rotate the output on scanout.

For example  Jonas Ådahl mentioned to me in IRC that GNOME Shell [blacklists some configurations](https://gitlab.gnome.org/GNOME/mutter/-/blob/69fcb3a1464716ea8a61e311fa60a0cb6a358fe3/src/backends/native/meta-kms-plane.c#L134) for some of the reasons above.

In order to avoid hitting the issues and complexities above, this patch set:

- Introduces the concept of “renderers“, which implement the mechanism that actually puts the content on the screen.
- Splits a good chunk of the existing code into a new “modeset” renderer (c.f. `cog-drm-modeset-renderer.c`)
- Adds a new “gles“ renderer (c.f. `cog-drm-gles-renderer.c`).
- Adds support for 90º/180º/270º rotations into the “gles“ renderer.
- Adds the needed calls for `libinput` to report events rotated for devices that need it (basically those which are ”touchable”, so not only touch screens, but also tablets and touchpads).
- Allows changing settings from the config file (renderer), on `CogDrmPlatform` (renderer as construct-only, rotation at any time), and passing them as parameters to `cog_platform_setup()` (both renderer and rotation e.g. with a string of comma-separated items `"renderer=gles,rotation=1"`).

There are a few things which are intentionally left out of this PR to avoid making it too big: further refactoring the code from both renderers (there is some duplication), splitting the DRM/KMS handling code into helper functions in their own source file, painting the cursor in the “gles“ renderer when KMS cursor planes are not available, etc. — those I would rather do as follow-ups later on.