### PR TITLE
docs: Fix building documentation with libsoup3

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -126,11 +126,13 @@ set(COGCORE_SOURCES
 )
 
 if (USE_SOUP2)
+    set(WPEWEBKIT_PC_NAME "wpe-webkit-1.0")
     set(REQUIRED_GIO_VERSION "gio-2.0>=2.44")
     set(REQUIRED_SOUP_VERSION "libsoup-2.4")
     set(REQUIRED_WEBKIT_VERSION "wpe-webkit-1.0>=2.28.0")
     add_definitions("-DCOG_USE_SOUP2=1")
 else()
+    set(WPEWEBKIT_PC_NAME "wpe-webkit-1.1")
     set(REQUIRED_GIO_VERSION "gio-2.0>=2.67.4")
     set(REQUIRED_SOUP_VERSION "libsoup-3.0>=2.99.7")
     set(REQUIRED_WEBKIT_VERSION "wpe-webkit-1.1>=2.33.1")

--- a/docs/CMakeLists.txt
+++ b/docs/CMakeLists.txt
@@ -63,7 +63,7 @@ add_custom_command(
         --identifier-prefix=Cog
         --symbol-prefix=cog
         --pkg-export=cogcore
-        --pkg=wpe-webkit-1.0
+        --pkg=${WPEWEBKIT_PC_NAME}
         --pkg=gobject-2.0
         --pkg=gio-2.0
         --pkg=glib-2.0


### PR DESCRIPTION
Pass the correct `pkg-config` module name to `gi-docgen` depending on the version of libsoup in use: WPE WebKit builds with libsoup2 have API version 1.0, and builds with libsoup3 have API version 1.1.