### PR TITLE
core: Remove unneeded CogPlatformClass.teardown vfunc

### DIFF
--- a/cog.c
+++ b/cog.c
@@ -342,13 +342,7 @@ platform_setup (CogShell *shell)
 static void
 on_shutdown (CogLauncher *launcher G_GNUC_UNUSED, void *user_data G_GNUC_UNUSED)
 {
-    g_debug ("%s: Platform = %p", __func__, s_options.platform);
-
-    if (s_options.platform) {
-        cog_platform_teardown (s_options.platform);
-        g_clear_object(&s_options.platform);
-        g_debug ("%s: Platform teardown completed.", __func__);
-    }
+    g_clear_object(&s_options.platform);
 }
 
 static void*

--- a/core/cog-platform.c
+++ b/core/cog-platform.c
@@ -93,16 +93,6 @@ cog_platform_new(const char *name, GError **error)
     return g_steal_pointer(&self);
 }
 
-void
-cog_platform_teardown(CogPlatform *platform)
-{
-    g_return_if_fail(COG_IS_PLATFORM(platform));
-
-    CogPlatformClass *klass = COG_PLATFORM_GET_CLASS(platform);
-    if (klass->teardown)
-        klass->teardown(platform);
-}
-
 gboolean
 cog_platform_setup (CogPlatform *platform,
                     CogShell    *shell,

--- a/core/cog-platform.h
+++ b/core/cog-platform.h
@@ -47,7 +47,6 @@ struct _CogPlatformClass {
     /*< public >*/
     gboolean (*is_supported)(void);
     gboolean (*setup)(CogPlatform *, CogShell *shell, const char *params, GError **);
-    void (*teardown)(CogPlatform *);
     WebKitWebViewBackend *(*get_view_backend)(CogPlatform *, WebKitWebView *related_view, GError **);
     void (*init_web_view)(CogPlatform *, WebKitWebView *);
     WebKitInputMethodContext *(*create_im_context)(CogPlatform *);
@@ -58,8 +57,6 @@ CogPlatform *cog_platform_get_default(void);
 CogPlatform *cog_platform_new(const char *name, GError **);
 
 gboolean cog_platform_setup(CogPlatform *platform, CogShell *shell, const char *params, GError **error);
-
-void                      cog_platform_teardown          (CogPlatform   *platform);
 
 WebKitWebViewBackend     *cog_platform_get_view_backend  (CogPlatform   *platform,
                                                           WebKitWebView *related_view,

--- a/platform/drm/cog-platform-drm.c
+++ b/platform/drm/cog-platform-drm.c
@@ -1827,18 +1827,17 @@ cog_drm_platform_setup(CogPlatform *platform, CogShell *shell, const char *param
 }
 
 static void
-cog_drm_platform_teardown(CogPlatform *platform)
+cog_drm_platform_finalize(GObject *object)
 {
-    g_assert (platform);
-
     clear_buffers ();
-
     clear_glib ();
     clear_input ();
     clear_egl ();
     clear_gbm ();
     clear_cursor ();
     clear_drm ();
+
+    G_OBJECT_CLASS(cog_drm_platform_parent_class)->finalize(object);
 }
 
 static WebKitWebViewBackend *
@@ -1880,10 +1879,12 @@ cog_drm_platform_init_web_view(CogPlatform *platform, WebKitWebView *view)
 static void
 cog_drm_platform_class_init(CogDrmPlatformClass *klass)
 {
+    GObjectClass *object_class = G_OBJECT_CLASS(klass);
+    object_class->finalize = cog_drm_platform_finalize;
+
     CogPlatformClass *platform_class = COG_PLATFORM_CLASS(klass);
     platform_class->is_supported = cog_drm_platform_is_supported;
     platform_class->setup = cog_drm_platform_setup;
-    platform_class->teardown = cog_drm_platform_teardown;
     platform_class->get_view_backend = cog_drm_platform_get_view_backend;
     platform_class->init_web_view = cog_drm_platform_init_web_view;
 }

--- a/platform/gtk4/cog-platform-gtk4.c
+++ b/platform/gtk4/cog-platform-gtk4.c
@@ -772,12 +772,6 @@ cog_gtk4_platform_setup(CogPlatform* platform, CogShell* shell, const char* para
     return TRUE;
 }
 
-static void
-cog_gtk4_platform_teardown(CogPlatform* platform)
-{
-    g_assert_nonnull(platform);
-}
-
 static WebKitWebViewBackend*
 cog_gtk4_platform_get_view_backend(CogPlatform* platform, WebKitWebView* related_view, GError** error)
 {
@@ -865,7 +859,6 @@ cog_gtk4_platform_class_init(CogGtk4PlatformClass* klass)
     CogPlatformClass* platform_class = COG_PLATFORM_CLASS(klass);
     platform_class->is_supported = cog_gtk4_platform_is_supported;
     platform_class->setup = cog_gtk4_platform_setup;
-    platform_class->teardown = cog_gtk4_platform_teardown;
     platform_class->get_view_backend = cog_gtk4_platform_get_view_backend;
     platform_class->init_web_view = cog_gtk4_platform_init_web_view;
 }

--- a/platform/headless/cog-platform-headless.c
+++ b/platform/headless/cog-platform-headless.c
@@ -81,10 +81,12 @@ cog_headless_platform_setup(CogPlatform* platform, CogShell* shell G_GNUC_UNUSED
 }
 
 static void
-cog_headless_platform_teardown(CogPlatform* platform)
+cog_headless_platform_finalize(GObject* object)
 {
     g_source_remove(win.tick_source);
     wpe_view_backend_exportable_fdo_destroy(win.exportable);
+
+    G_OBJECT_CLASS(cog_headless_platform_parent_class)->finalize(object);
 }
 
 static WebKitWebViewBackend*
@@ -97,9 +99,11 @@ cog_headless_platform_get_view_backend(CogPlatform* platform, WebKitWebView* rel
 static void
 cog_headless_platform_class_init(CogHeadlessPlatformClass* klass)
 {
+    GObjectClass* object_class = G_OBJECT_CLASS(klass);
+    object_class->finalize = cog_headless_platform_finalize;
+
     CogPlatformClass* platform_class = COG_PLATFORM_CLASS(klass);
     platform_class->setup = cog_headless_platform_setup;
-    platform_class->teardown = cog_headless_platform_teardown;
     platform_class->get_view_backend = cog_headless_platform_get_view_backend;
 }
 

--- a/platform/wayland/cog-platform-wl.c
+++ b/platform/wayland/cog-platform-wl.c
@@ -2451,10 +2451,8 @@ cog_wl_platform_setup(CogPlatform *platform, CogShell *shell G_GNUC_UNUSED, cons
 }
 
 static void
-cog_wl_platform_teardown(CogPlatform *platform)
+cog_wl_platform_finalize(GObject *object)
 {
-    g_assert (platform);
-
     /* free WPE view data */
     if (wpe_view_data.frame_callback != NULL)
         wl_callback_destroy(wpe_view_data.frame_callback);
@@ -2480,6 +2478,8 @@ cog_wl_platform_teardown(CogPlatform *platform)
     destroy_window ();
     clear_egl();
     clear_wayland ();
+
+    G_OBJECT_CLASS(cog_wl_platform_parent_class)->finalize(object);
 }
 
 static WebKitWebViewBackend *
@@ -2547,10 +2547,12 @@ cog_wl_platform_create_im_context(CogPlatform *platform)
 static void
 cog_wl_platform_class_init(CogWlPlatformClass *klass)
 {
+    GObjectClass *object_class = G_OBJECT_CLASS(klass);
+    object_class->finalize = cog_wl_platform_finalize;
+
     CogPlatformClass *platform_class = COG_PLATFORM_CLASS(klass);
     platform_class->is_supported = cog_wl_platform_is_supported;
     platform_class->setup = cog_wl_platform_setup;
-    platform_class->teardown = cog_wl_platform_teardown;
     platform_class->get_view_backend = cog_wl_platform_get_view_backend;
     platform_class->init_web_view = cog_wl_platform_init_web_view;
     platform_class->create_im_context = cog_wl_platform_create_im_context;

--- a/platform/x11/cog-platform-x11.c
+++ b/platform/x11/cog-platform-x11.c
@@ -863,10 +863,8 @@ cog_x11_platform_setup(CogPlatform *platform, CogShell *shell G_GNUC_UNUSED, con
 }
 
 static void
-cog_x11_platform_teardown(CogPlatform *platform)
+cog_x11_platform_finalize(GObject *object)
 {
-    g_assert (platform);
-
     clear_glib ();
     clear_gl ();
     clear_egl ();
@@ -875,6 +873,8 @@ cog_x11_platform_teardown(CogPlatform *platform)
 
     g_clear_pointer (&s_window, free);
     g_clear_pointer (&s_display, free);
+
+    G_OBJECT_CLASS(cog_x11_platform_parent_class)->finalize(object);
 }
 
 static WebKitWebViewBackend *
@@ -931,10 +931,12 @@ cog_x11_platform_is_supported(void)
 static void
 cog_x11_platform_class_init(CogX11PlatformClass *klass)
 {
+    GObjectClass *object_class = G_OBJECT_CLASS(klass);
+    object_class->finalize = cog_x11_platform_finalize;
+
     CogPlatformClass *platform_class = COG_PLATFORM_CLASS(klass);
     platform_class->is_supported = cog_x11_platform_is_supported;
     platform_class->setup = cog_x11_platform_setup;
-    platform_class->teardown = cog_x11_platform_teardown;
     platform_class->get_view_backend = cog_x11_platform_get_view_backend;
 }
 


### PR DESCRIPTION
Use `GObjectClass.finalize` instead of `CogPlatformClass.teardown`. Now that `CogPlatform` derives from `GObject`, it is possible to reuse its functionality instead of having an ad-hoc vfunc that gets called immediately before destroying an instance. As a bonus, not only the implementations follow a more idiomatic GObject approach, but also it is not possible anymore to forget a call to `cog_platform_teardown()` before destruction.
