### PR TITLE
CI: Switch to clang-format version 13

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -61,7 +61,7 @@ ConstructorInitializerIndentWidth: 4
 ContinuationIndentWidth: 4
 Cpp11BracedListStyle: true
 DeriveLineEnding: true
-DerivePointerAlignment: true
+DerivePointerAlignment: false
 DisableFormat: false
 ExperimentalAutoDetectBinPacking: true
 FixNamespaceComments: true

--- a/.github/workflows/codestyle.yml
+++ b/.github/workflows/codestyle.yml
@@ -17,9 +17,9 @@ jobs:
           curl -sL https://apt.llvm.org/llvm-snapshot.gpg.key | \
             sudo apt-key add -
           sudo add-apt-repository \
-            'deb http://apt.llvm.org/focal/ llvm-toolchain-focal-11 main'
+            'deb http://apt.llvm.org/focal/ llvm-toolchain-focal-13 main'
           sudo apt update
-          sudo apt install -y clang-format-11 diffutils
+          sudo apt install -y clang-format-13 diffutils
       - name: Check
         run: |
           data/check-style -ocode-style.diff origin/master

--- a/data/check-style
+++ b/data/check-style
@@ -52,8 +52,8 @@ declare -r BASE HEAD
 
 declare -ra clang_format_diff_candidates=(
     # Search in $PATH (Ubuntu, Debian, maybe others)
-    clang-format-diff-11
-    clang-format-diff-11.py
+    clang-format-diff-13
+    clang-format-diff-13.py
     clang-format-diff
     clang-format-diff.py
     # Arch Linux, Fedora.


### PR DESCRIPTION
Update the `check-style` script and the CI job to use `clang-format` 13, which is the first version that supports combining `PointerAlignment: Right` with `AlignConsecutiveDeclarations: true`. This was unimplemented until recently, see https://reviews.llvm.org/D103245

While at it, do not let clang-format choose a different way of doing pointer alignment by setting `DerivePointerAlignment: false`.