### PR TITLE
CI: Improve cross-toolchain reliability

### DIFF
--- a/.github/toolchain.sh
+++ b/.github/toolchain.sh
@@ -3,7 +3,7 @@ set -eu -o pipefail
 
 # Info on available toolchains: https://wk-contrib.igalia.com/
 INSTALL_DIR=${1:-${HOME}/toolchain}
-BASEURL=https://wk-contrib.igalia.com/yocto/meta-perf-browser/browsers/nightly/sdk
+BASEURL=https://wk-contrib.igalia.com/yocto/meta-perf-browser/browsers/stable/sdk
 FILE=wandboard-mesa/browsers-glibc-x86_64-core-image-weston-browsers-cortexa9t2hf-neon-wandboard-mesa-toolchain-1.0.sh
 
 declare -r INSTALL_DIR BASEURL FILE

--- a/.github/workflows/ci-cross.yml
+++ b/.github/workflows/ci-cross.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Install Debian Packages
         run: |
           sudo apt update
-          sudo apt install -y cmake ninja-build
+          sudo apt install -y cmake ninja-build libwayland-bin
       - name: Cache
         uses: actions/cache@v2
         id: cache
@@ -31,6 +31,7 @@ jobs:
         run: |-
           . ~/toolchain/environment-setup-*-poky-linux-gnueabi
           cmake -GNinja -S. -Bbuild \
+            -DWAYLAND_SCANNER=/usr/bin/wayland-scanner \
             -DCMAKE_BUILD_TYPE=${BUILD_TYPE} \
             -DCOG_PLATFORM_FDO=ON \
             -DCOG_PLATFORM_DRM=ON


### PR DESCRIPTION
This does two things:

- Switches the ARM cross-toolchain builds to use the system-provided `wayland-scanner` binary, as it seems that newer versions of the toolchains either do not include it, or it is an ARM binary and thus CMake cannot run it to determine its version. Eventually this should be solved in the toolchain.
- Make toolchain download retries more reliable by also inspecting the exit code from the `curl` program and acting accordingly.

Closes #374 