### PR TITLE
cmake: Set default module location from CMAKE_INSTALL_LIBDIR

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -72,7 +72,7 @@ option(USE_SOUP2 "Build with libsoup2 instead of libsoup3" ON)
 set(COG_APPID "" CACHE STRING "Default GApplication unique identifier")
 set(COG_HOME_URI "" CACHE STRING "Default home URI")
 
-set(COG_MODULEDIR "${CMAKE_INSTALL_PREFIX}/lib/cog/modules"
+set(COG_MODULEDIR "${CMAKE_INSTALL_LIBDIR}/cog/modules"
     CACHE STRING "Default search path for loadable modules")
 
 if (NOT COG_APPID OR COG_APPID STREQUAL "")


### PR DESCRIPTION
Derive the location where to install platform modules from the `CMAKE_INSTALL_LIBDIR` variable (instead of `CMAKE_INSTALL_PREFIX`), instead of assuming that the directory is always called `lib/`
inside the prefix. This provides a saner default for distributors which use other kinds of locations, like multilib/multiarch systems.

----

(Thanks to @bertogg for spotting the issue!)