### PR TITLE
launcher: Place built binaries in top level directory

### DIFF
--- a/launcher/CMakeLists.txt
+++ b/launcher/CMakeLists.txt
@@ -2,7 +2,10 @@ add_executable(cog
     cog.c
     cog-launcher.c
 )
-set_property(TARGET cog PROPERTY C_STANDARD 99)
+set_target_properties(cog PROPERTIES
+    C_STANDARD 99
+    RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}
+)
 target_compile_definitions(cog PRIVATE G_LOG_DOMAIN=\"Cog\")
 target_link_libraries(cog cogcore -ldl)
 
@@ -10,7 +13,10 @@ add_executable(cogctl
     cogctl.c
     ../core/cog-utils.c
 )
-set_property(TARGET cogctl PROPERTY C_STANDARD 99)
+set_target_properties(cogctl PROPERTIES
+    C_STANDARD 99
+    RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}
+)
 target_compile_definitions(cogctl PRIVATE G_LOG_DOMAIN=\"Cog-Control\")
 target_link_libraries(cogctl PkgConfig::GIO PkgConfig::SOUP)
 


### PR DESCRIPTION
Explicitly place the built `cog` and `cogctl` binaries in the top level build directory. The location was moved in #376 without giving a second thought about it but it broke the `run-minibrowser` script from the WebKit repository, see: https://bugs.webkit.org/show_bug.cgi?id=234132

On top of preveting breakage of third party tooling, setting the build directory this way is more convenient for running programs for testing during development.