### PR TITLE
cmake: Turn COG_MODULEDIR into an absolute path

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -73,7 +73,19 @@ set(COG_APPID "" CACHE STRING "Default GApplication unique identifier")
 set(COG_HOME_URI "" CACHE STRING "Default home URI")
 
 set(COG_MODULEDIR "${CMAKE_INSTALL_LIBDIR}/cog/modules"
-    CACHE STRING "Default search path for loadable modules")
+    CACHE PATH "Default search path for loadable modules")
+
+# Make sure that the module path is always absolute. If the specified
+# value is relative, this makes it a child of CMAKE_INSTALL_PREFIX.
+if (CMAKE_VERSION VERSION_GREATER_EQUAL 3.20)
+    cmake_path(ABSOLUTE_PATH COG_MODULEDIR BASE_DIRECTORY ${CMAKE_INSTALL_PREFIX} NORMALIZE)
+elseif (NOT IS_ABSOLUTE ${COG_MODULEDIR})
+    set(COG_MODULEDIR "${CMAKE_INSTALL_PREFIX}/${COG_MODULEDIR}")
+endif ()
+if (NOT IS_ABSOLUTE ${COG_MODULEDIR})
+    message(FATAL_ERROR "Cog module location '${COG_MODULEDIR}' is not an absolute path")
+endif ()
+message(STATUS "Cog module path: ${COG_MODULEDIR}")
 
 if (NOT COG_APPID OR COG_APPID STREQUAL "")
     set(COG_DEFAULT_APPID com.igalia.Cog)


### PR DESCRIPTION
Make the `COG_MODULEDIR` macro expand to an absolute path at runtime to ensure that modules can always be found correctly. Otherwise, it is possible to configure the build e.g. with `COG_MODULEDIR=lib/cog/modules` (basically what is done after a18626b42c58c57208a5c17bd25d09e5d2aa5a16) and the relative path would end up in the built programs, resulting in failure to find the modules (unless, by chance, they are executed while the current directory matches the configured installation prefix.)