### PR TITLE
gtk4: Remove the requirement of a shader language version.

### DIFF
--- a/platform/gtk4/cog-platform-gtk4.c
+++ b/platform/gtk4/cog-platform-gtk4.c
@@ -84,8 +84,7 @@ static struct platform_window win = {
     .device_scale_factor = 1,
 };
 
-static const char s_vertex_shader[] = "#version 330\n"
-                                      "attribute vec2 pos;\n"
+static const char s_vertex_shader[] = "attribute vec2 pos;\n"
                                       "attribute vec2 texture;\n"
                                       "varying vec2 v_texture;\n"
                                       "void main() {\n"
@@ -93,8 +92,7 @@ static const char s_vertex_shader[] = "#version 330\n"
                                       "  gl_Position = vec4(pos, 0, 1);\n"
                                       "}\n";
 
-static const char s_fragment_shader[] = "#version 330\n"
-                                        "precision mediump float;\n"
+static const char s_fragment_shader[] = "precision mediump float;\n"
                                         "uniform sampler2D u_tex;\n"
                                         "varying vec2 v_texture;\n"
                                         "void main() {\n"


### PR DESCRIPTION
The shader does not need this version.