### PR TITLE
drm, x11, gtk4: Refactor GL textured quad painting code

### DIFF
--- a/platform/common/cog-gl-utils.h
+++ b/platform/common/cog-gl-utils.h
@@ -1,12 +1,13 @@
 /*
  * cog-gl-utils.h
- * Copyright (C) 2021 Igalia S.L.
+ * Copyright (C) 2021-2022 Igalia S.L.
  *
  * Distributed under terms of the MIT license.
  */
 
 #pragma once
 
+#include <epoxy/egl.h>
 #include <epoxy/gl.h>
 #include <glib.h>
 
@@ -22,5 +23,63 @@ CogGLShaderId cog_gl_shader_id_steal(CogGLShaderId *shader_id) G_GNUC_WARN_UNUSE
 CogGLShaderId cog_gl_load_shader(const char *source, GLenum kind, GError **) G_GNUC_WARN_UNUSED_RESULT;
 
 bool cog_gl_link_program(GLuint program, GError **);
+
+/*
+ * CogGLRenderer wraps an EGLImage (for example provided by wpebackend-fdo)
+ * into a texture, then paints a quad which covers the current viewport and
+ * samples said texture.
+ *
+ * A simple GLSL shader program uses the "position" attribute to fetch the
+ * coordinates of the quad, and the "texture" attribute the UV mapping
+ * coordinates for the texture. Rotation is achieved by changing the UV
+ * mapping. The "texture" uniform is used to reference the texture unit
+ * where the frame textures get loaded.
+ *
+ * By itself the renderer only knows how to prepare the shader program
+ * and how to use it to paint a textured quad with the given EGLImage as
+ * its texture. The rest of EGL/GL/GLES handling is left out intentionally.
+ *
+ * To use the renderer:
+ *
+ * - Setup:
+ *   - Embed a CogGLRenderer somewhere. Typically this will be a Cog
+ *     platform implementation.
+ *   - Initialize EGL, ensure eglBindAPI(EGL_OPENGL_ES_API) is called,
+ *     create an EGLContext suitable for rendering.
+ *   - With the EGLContext active, call cog_gl_renderer_initialize().
+ *
+ * - Painting:
+ *   - Activate the EGLContext.
+ *   - Optionally, paint before using the renderer (e.g. some solid color
+ *     background below the image, shows if the web view and its content
+ *     have transparency).
+ *   - Use glViewport() to set the region to be painted on, then
+ *     call cog_gl_renderer_paint() to cover the region with the image.
+ *   - Optionally, paint afterwards (e.g. some user interface shown over
+ *     or around the image).
+ *
+ * - Shutdown:
+ *   - Call cog_gl_renderer_finalize() to dispose of the shader program
+ *     and texture used for painting.
+ */
+
+typedef struct {
+    GLuint program;
+    GLuint texture;
+    GLint  attrib_position;
+    GLint  attrib_texture;
+    GLint  uniform_texture;
+} CogGLRenderer;
+
+typedef enum {
+    COG_GL_RENDERER_ROTATION_0 = 0,
+    COG_GL_RENDERER_ROTATION_90 = 1,
+    COG_GL_RENDERER_ROTATION_180 = 2,
+    COG_GL_RENDERER_ROTATION_270 = 3,
+} CogGLRendererRotation;
+
+bool cog_gl_renderer_initialize(CogGLRenderer *self, GError **error);
+void cog_gl_renderer_finalize(CogGLRenderer *self);
+void cog_gl_renderer_paint(CogGLRenderer *self, EGLImage *image, CogGLRendererRotation rotation);
 
 G_END_DECLS

--- a/platform/drm/cog-drm-renderer.h
+++ b/platform/drm/cog-drm-renderer.h
@@ -1,14 +1,13 @@
 /*
  * cog-drm-renderer.h
- * Copyright (C) 2021 Igalia S.L.
+ * Copyright (C) 2021-2022 Igalia S.L.
  *
  * Distributed under terms of the MIT license.
  */
 
 #pragma once
 
-#include <epoxy/egl.h>
-#include <glib.h>
+#include "../common/cog-gl-utils.h"
 #include <inttypes.h>
 #include <stdbool.h>
 
@@ -17,20 +16,13 @@ struct wpe_view_backend_exportable_fdo;
 typedef struct _drmModeModeInfo drmModeModeInfo;
 typedef struct _CogDrmRenderer  CogDrmRenderer;
 
-typedef enum {
-    COG_DRM_RENDERER_ROTATION_0 = 0,
-    COG_DRM_RENDERER_ROTATION_90 = 1,
-    COG_DRM_RENDERER_ROTATION_180 = 2,
-    COG_DRM_RENDERER_ROTATION_270 = 3,
-} CogDrmRendererRotation;
-
 struct _CogDrmRenderer {
     const char *name;
 
     bool (*initialize)(CogDrmRenderer *, GError **);
     void (*destroy)(CogDrmRenderer *);
 
-    bool (*set_rotation)(CogDrmRenderer *, CogDrmRendererRotation, bool apply);
+    bool (*set_rotation)(CogDrmRenderer *, CogGLRendererRotation, bool apply);
 
     struct wpe_view_backend_exportable_fdo *(*create_exportable)(CogDrmRenderer *, uint32_t width, uint32_t height);
 };
@@ -47,14 +39,14 @@ cog_drm_renderer_initialize(CogDrmRenderer *self, GError **error)
 }
 
 static inline bool
-cog_drm_renderer_supports_rotation(CogDrmRenderer *self, CogDrmRendererRotation rotation)
+cog_drm_renderer_supports_rotation(CogDrmRenderer *self, CogGLRendererRotation rotation)
 {
     const bool apply = false;
     return self->set_rotation && self->set_rotation(self, rotation, apply);
 }
 
 static inline bool
-cog_drm_renderer_set_rotation(CogDrmRenderer *self, CogDrmRendererRotation rotation)
+cog_drm_renderer_set_rotation(CogDrmRenderer *self, CogGLRendererRotation rotation)
 {
     const bool apply = true;
     return self->set_rotation && self->set_rotation(self, rotation, apply);

--- a/platform/drm/cog-platform-drm.c
+++ b/platform/drm/cog-platform-drm.c
@@ -1,3 +1,11 @@
+/*
+ * cog-platform-x11.c
+ * Copyright (C) 2019-2022 Igalia S.L.
+ * Copyright (C) 2020 Michal Artazov <michal@artazov.cz>
+ *
+ * Distributed under terms of the MIT license.
+ */
+
 #include "../../core/cog.h"
 
 #include "cog-drm-renderer.h"
@@ -62,7 +70,7 @@ struct _CogDrmPlatformClass {
 struct _CogDrmPlatform {
     CogPlatform            parent;
     CogDrmRenderer        *renderer;
-    CogDrmRendererRotation rotation;
+    CogGLRendererRotation  rotation;
     GList                 *rotatable_input_devices;
     bool                   use_gles;
 };
@@ -1356,7 +1364,7 @@ cog_drm_platform_setup(CogPlatform *platform, CogShell *shell, const char *param
     } else {
         g_warning("Renderer '%s' does not support rotation %u (%u degrees).", self->renderer->name, self->rotation,
                   self->rotation * 90);
-        self->rotation = COG_DRM_RENDERER_ROTATION_0;
+        self->rotation = COG_GL_RENDERER_ROTATION_0;
     }
 
     if (!init_input(COG_DRM_PLATFORM(platform))) {
@@ -1437,7 +1445,7 @@ cog_drm_platform_set_property(GObject *object, unsigned prop_id, const GValue *v
     CogDrmPlatform *self = COG_DRM_PLATFORM(object);
     switch (prop_id) {
     case PROP_ROTATION: {
-        CogDrmRendererRotation rotation = g_value_get_uint(value);
+        CogGLRendererRotation rotation = g_value_get_uint(value);
         if (rotation == self->rotation)
             return;
 

--- a/platform/gtk4/CMakeLists.txt
+++ b/platform/gtk4/CMakeLists.txt
@@ -1,6 +1,7 @@
 pkg_check_modules(COGPLATFORM_GTK4_DEPS REQUIRED
     IMPORTED_TARGET gtk4 wpebackend-fdo-1.0)
 add_library(cogplatform-gtk4 MODULE
+    ../common/cog-gl-utils.c
     cog-platform-gtk4.c
     cog-gtk-settings-dialog.c
     cog-gtk-settings-cell-renderer-variant.c)

--- a/platform/x11/CMakeLists.txt
+++ b/platform/x11/CMakeLists.txt
@@ -1,5 +1,6 @@
 # libcogplaform-x11
 
+pkg_check_modules(Epoxy IMPORTED_TARGET REQUIRED epoxy)
 pkg_check_modules(COGPLATFORM_X11_DEPS IMPORTED_TARGET
     REQUIRED wpebackend-fdo-1.0>=1.6.0 egl xcb xkbcommon-x11)
 
@@ -10,6 +11,7 @@ set_target_properties(cogplatform-x11 PROPERTIES
 )
 target_compile_definitions(cogplatform-x11 PRIVATE G_LOG_DOMAIN=\"Cog-X11\")
 target_link_libraries(cogplatform-x11 PRIVATE cogcore
+    PkgConfig::Epoxy
     PkgConfig::COGPLATFORM_X11_DEPS
     PkgConfig::WebKit
 )

--- a/platform/x11/CMakeLists.txt
+++ b/platform/x11/CMakeLists.txt
@@ -4,7 +4,10 @@ pkg_check_modules(Epoxy IMPORTED_TARGET REQUIRED epoxy)
 pkg_check_modules(COGPLATFORM_X11_DEPS IMPORTED_TARGET
     REQUIRED wpebackend-fdo-1.0>=1.6.0 egl xcb xkbcommon-x11)
 
-add_library(cogplatform-x11 MODULE cog-platform-x11.c)
+add_library(cogplatform-x11 MODULE
+    ../common/cog-gl-utils.c
+    cog-platform-x11.c
+)
 set_target_properties(cogplatform-x11 PROPERTIES
     C_STANDARD 99
     LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/modules

--- a/platform/x11/cog-platform-x11.c
+++ b/platform/x11/cog-platform-x11.c
@@ -7,10 +7,8 @@
 
 #include "../../core/cog.h"
 
-#include <EGL/egl.h>
-#include <EGL/eglext.h>
-#include <GLES2/gl2.h>
-#include <GLES2/gl2ext.h>
+#include <epoxy/egl.h>
+#include <epoxy/gl.h>
 
 #include <assert.h>
 #include <stdlib.h>
@@ -661,11 +659,11 @@ static void
 clear_egl (void)
 {
     if (s_display->egl.display != EGL_NO_DISPLAY) {
-        eglTerminate (s_display->egl.display);
+        if (epoxy_egl_version(s_display->egl.display) >= 12)
+            eglReleaseThread();
+        eglTerminate(s_display->egl.display);
         s_display->egl.display = EGL_NO_DISPLAY;
     }
-
-    eglReleaseThread ();
 }
 
 static gboolean


### PR DESCRIPTION
This patch set moves the code that paints textured quads out from the DRM platform into the shared GL utility code, and makes the DRM, X11, and GTK4 platform use it—instead of each of them having slightly different copies of the code.

1. First, code that will be shared is moved from `cog-drm-gles-renderer.c` and into `cog-gl-utils.c`, and the DRM plug-in modified accordingly. This adds a new `CogGLRenderer` struct, functions to (de)initialize it, and for painting, accompanied by a comment explaining how to use the shared code.
2. The X11 plug-in is changed to link `libepoxy` in preparation for the next step.
3. The X11 and GTK4 plug-ins get their copy of the code removed and changed to use `CogGLRenderer` instead.