### PR TITLE
wl: Improve handling of Wayland protocol interface versions

### DIFF
--- a/platform/wayland/cog-platform-wl.c
+++ b/platform/wayland/cog-platform-wl.c
@@ -753,35 +753,35 @@ registry_global (void               *data,
     gboolean interface_used = TRUE;
 
     if (strcmp(interface, wl_compositor_interface.name) == 0) {
-        wl_data.compositor = wl_registry_bind(registry, name, &wl_compositor_interface, version);
+        wl_data.compositor = wl_registry_bind(registry, name, &wl_compositor_interface, 1);
     } else if (strcmp(interface, wl_subcompositor_interface.name) == 0) {
-        wl_data.subcompositor = wl_registry_bind(registry, name, &wl_subcompositor_interface, version);
+        wl_data.subcompositor = wl_registry_bind(registry, name, &wl_subcompositor_interface, 1);
     } else if (strcmp(interface, wl_shell_interface.name) == 0) {
-        wl_data.shell = wl_registry_bind(registry, name, &wl_shell_interface, version);
+        wl_data.shell = wl_registry_bind(registry, name, &wl_shell_interface, 1);
     } else if (strcmp(interface, wl_shm_interface.name) == 0) {
-        wl_data.shm = wl_registry_bind(registry, name, &wl_shm_interface, version);
+        wl_data.shm = wl_registry_bind(registry, name, &wl_shm_interface, 1);
     } else if (strcmp(interface, xdg_wm_base_interface.name) == 0) {
-        wl_data.xdg_shell = wl_registry_bind(registry, name, &xdg_wm_base_interface, version);
+        wl_data.xdg_shell = wl_registry_bind(registry, name, &xdg_wm_base_interface, 1);
         g_assert(wl_data.xdg_shell);
         xdg_wm_base_add_listener(wl_data.xdg_shell, &xdg_shell_listener, NULL);
     } else if (strcmp(interface, zwp_fullscreen_shell_v1_interface.name) == 0) {
-        wl_data.fshell = wl_registry_bind(registry, name, &zwp_fullscreen_shell_v1_interface, version);
+        wl_data.fshell = wl_registry_bind(registry, name, &zwp_fullscreen_shell_v1_interface, 1);
     } else if (strcmp(interface, wl_seat_interface.name) == 0) {
-        wl_data.seat = wl_registry_bind(registry, name, &wl_seat_interface, version);
+        wl_data.seat = wl_registry_bind(registry, name, &wl_seat_interface, 2);
 #if COG_ENABLE_WESTON_DIRECT_DISPLAY
     } else if (strcmp(interface, zwp_linux_dmabuf_v1_interface.name) == 0) {
         if (version < 3) {
             g_warning("Version %d of the zwp_linux_dmabuf_v1 protocol is not supported", version);
             return;
         }
-        wl_data.dmabuf = wl_registry_bind(registry, name, &zwp_linux_dmabuf_v1_interface, version);
+        wl_data.dmabuf = wl_registry_bind(registry, name, &zwp_linux_dmabuf_v1_interface, 3);
     } else if (strcmp(interface, weston_direct_display_v1_interface.name) == 0) {
-        wl_data.direct_display = wl_registry_bind(registry, name, &weston_direct_display_v1_interface, version);
+        wl_data.direct_display = wl_registry_bind(registry, name, &weston_direct_display_v1_interface, 1);
     } else if (strcmp(interface, weston_content_protection_interface.name) == 0) {
-        wl_data.protection = wl_registry_bind(registry, name, &weston_content_protection_interface, version);
+        wl_data.protection = wl_registry_bind(registry, name, &weston_content_protection_interface, 1);
 #endif /* COG_ENABLE_WESTON_DIRECT_DISPLAY */
     } else if (strcmp(interface, wl_output_interface.name) == 0) {
-        struct wl_output *output = wl_registry_bind(registry, name, &wl_output_interface, version);
+        struct wl_output *output = wl_registry_bind(registry, name, &wl_output_interface, 3);
         wl_output_add_listener(output, &output_listener, NULL);
         bool inserted = false;
         for (int i = 0; i < G_N_ELEMENTS(wl_data.metrics); i++) {
@@ -796,15 +796,11 @@ registry_global (void               *data,
             g_warning("Exceeded %" G_GSIZE_FORMAT " connected outputs(!)", G_N_ELEMENTS(wl_data.metrics));
         }
     } else if (strcmp(interface, zwp_text_input_manager_v3_interface.name) == 0) {
-        wl_data.text_input_manager = wl_registry_bind(registry, name, &zwp_text_input_manager_v3_interface, version);
+        wl_data.text_input_manager = wl_registry_bind(registry, name, &zwp_text_input_manager_v3_interface, 1);
     } else if (strcmp(interface, zwp_text_input_manager_v1_interface.name) == 0) {
-        wl_data.text_input_manager_v1 = wl_registry_bind(registry, name, &zwp_text_input_manager_v1_interface, version);
-#ifdef COG_USE_WAYLAND_CURSOR
-    } else if (strcmp(interface, wl_shm_interface.name) == 0) {
-        wl_data.wl_shm = wl_registry_bind(registry, name, &wl_shm_interface, version);
-#endif /* COG_USE_WAYLAND_CURSOR */
+        wl_data.text_input_manager_v1 = wl_registry_bind(registry, name, &zwp_text_input_manager_v1_interface, 1);
     } else if (strcmp(interface, wp_presentation_interface.name) == 0) {
-        wl_data.presentation = wl_registry_bind(registry, name, &wp_presentation_interface, version);
+        wl_data.presentation = wl_registry_bind(registry, name, &wp_presentation_interface, 1);
     } else {
         interface_used = FALSE;
     }

--- a/platform/wayland/cog-platform-wl.c
+++ b/platform/wayland/cog-platform-wl.c
@@ -71,13 +71,6 @@
 #    define HAVE_FULLSCREEN_HANDLING 0
 #endif
 
-#if defined(WAYLAND_VERSION_MAJOR) && defined(WAYLAND_VERSION_MINOR)
-# define WAYLAND_1_10_OR_GREATER ((WAYLAND_VERSION_MAJOR >= 2) || \
-                                  (WAYLAND_VERSION_MAJOR == 1 && WAYLAND_VERSION_MINOR >= 10))
-#else
-# define WAYLAND_1_10_OR_GREATER 0
-#endif
-
 struct _CogWlPlatformClass {
     CogPlatformClass parent_class;
 };
@@ -767,7 +760,7 @@ registry_global (void               *data,
     } else if (strcmp(interface, zwp_fullscreen_shell_v1_interface.name) == 0) {
         wl_data.fshell = wl_registry_bind(registry, name, &zwp_fullscreen_shell_v1_interface, 1);
     } else if (strcmp(interface, wl_seat_interface.name) == 0) {
-        wl_data.seat = wl_registry_bind(registry, name, &wl_seat_interface, 2);
+        wl_data.seat = wl_registry_bind(registry, name, &wl_seat_interface, MAX(3, MAX(version, 7)));
 #if COG_ENABLE_WESTON_DIRECT_DISPLAY
     } else if (strcmp(interface, zwp_linux_dmabuf_v1_interface.name) == 0) {
         if (version < 3) {
@@ -936,6 +929,16 @@ dispatch_axis_event()
     wl_data.axis.x_delta = wl_data.axis.y_delta = 0;
 }
 
+static inline bool
+pointer_uses_frame_event(struct wl_pointer *pointer)
+{
+#ifdef WL_POINTER_FRAME_SINCE_VERSION
+    return wl_pointer_get_version(pointer) >= WL_POINTER_FRAME_SINCE_VERSION;
+#else
+    return false;
+#endif
+}
+
 static void
 pointer_on_axis (void* data,
                  struct wl_pointer *pointer,
@@ -955,14 +958,11 @@ pointer_on_axis (void* data,
         wl_data.axis.x_delta += value;
     }
 
-#if !WAYLAND_1_10_OR_GREATER
-    // No 'frame' event in this case, so dispatch immediately.
-    dispatch_axis_event ();
-#endif
+    if (!pointer_uses_frame_event(pointer))
+        dispatch_axis_event();
 }
 
-#if WAYLAND_1_10_OR_GREATER
-
+#ifdef WL_POINTER_FRAME_SINCE_VERSION
 static void
 pointer_on_frame (void* data,
                   struct wl_pointer *pointer)
@@ -973,31 +973,7 @@ pointer_on_frame (void* data,
 
     dispatch_axis_event();
 }
-
-static void
-pointer_on_axis_source (void *data,
-                        struct wl_pointer *wl_pointer,
-                        uint32_t axis_source)
-{
-}
-
-static void
-pointer_on_axis_stop (void *data,
-                      struct wl_pointer *wl_pointer,
-                      uint32_t time,
-                      uint32_t axis)
-{
-}
-
-static void
-pointer_on_axis_discrete (void *data,
-                          struct wl_pointer *wl_pointer,
-                          uint32_t axis,
-                          int32_t discrete)
-{
-}
-
-#endif /* WAYLAND_1_10_OR_GREATER */
+#endif /* WL_POINTER_FRAME_SINCE_VERSION */
 
 static const struct wl_pointer_listener pointer_listener = {
     .enter = pointer_on_enter,
@@ -1006,12 +982,12 @@ static const struct wl_pointer_listener pointer_listener = {
     .button = pointer_on_button,
     .axis = pointer_on_axis,
 
-#if WAYLAND_1_10_OR_GREATER
+#ifdef WL_POINTER_FRAME_SINCE_VERSION
     .frame = pointer_on_frame,
-    .axis_source = pointer_on_axis_source,
-    .axis_stop = pointer_on_axis_stop,
-    .axis_discrete = pointer_on_axis_discrete,
-#endif /* WAYLAND_1_10_OR_GREATER */
+    .axis_source = noop,
+    .axis_stop = noop,
+    .axis_discrete = noop,
+#endif /* WL_POINTER_FRAME_SINCE_VERSION */
 };
 
 static void
@@ -1026,7 +1002,7 @@ keyboard_on_keymap (void *data,
         return;
     }
 
-    int map_mode = wl_seat_interface.version > 6 ? MAP_PRIVATE : MAP_SHARED;
+    const int map_mode = wl_seat_get_version(wl_data.seat) > 6 ? MAP_PRIVATE : MAP_SHARED;
     void* mapping = mmap (NULL, size, PROT_READ, map_mode, fd, 0);
     if (mapping == MAP_FAILED) {
         close (fd);


### PR DESCRIPTION
Define bounds to the versions of Wayland protocol interfaces requested from the compositor on calls to `wl_registry_bind()`. This prevents the compositor from using newer features for which there is no client side implementation in Cog.

While at it, improve checks on protocol bits that depend on the version of the protocols being used, mainly for `wl_seat` and `wl_pointer` (which is part of the former) to use the correct checks at runtime, and to feature-check at build time (instead of depending on version of the Wayland library headers present at build time).

Fixes #396