### PR TITLE
build: Homogenize linked wpebackend-fdo version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 3.3)
+cmake_minimum_required (VERSION 3.12)
 
 list(INSERT CMAKE_MODULE_PATH 0 "${CMAKE_SOURCE_DIR}/cmake")
 include(VersioningUtils)

--- a/cmake/FindWpeFDO.cmake
+++ b/cmake/FindWpeFDO.cmake
@@ -1,0 +1,12 @@
+find_package (PkgConfig REQUIRED QUIET)
+pkg_check_modules(WpeFDO QUIET wpebackend-fdo-1.0>=1.8.0 IMPORTED_TARGET)
+
+if (TARGET PkgConfig::WpeFDO)
+  add_library(Wpe::FDO ALIAS PkgConfig::WpeFDO)
+endif()
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(WpeFDO
+  REQUIRED_VARS WpeFDO_LIBRARIES WpeFDO_INCLUDE_DIRS
+  FOUND_VAR WpeFDO_FOUND
+  VERSION_VAR WpeFDO_VERSION)

--- a/platform/drm/CMakeLists.txt
+++ b/platform/drm/CMakeLists.txt
@@ -1,12 +1,14 @@
 # libcogplatform-drm
 
 pkg_check_modules(Epoxy IMPORTED_TARGET REQUIRED epoxy)
-pkg_check_modules(WpeFDO IMPORTED_TARGET REQUIRED wpebackend-fdo-1.0>=1.4.0)
 pkg_check_modules(LibDRM IMPORTED_TARGET REQUIRED libdrm>=2.4.71)
 pkg_check_modules(LibGBM IMPORTED_TARGET REQUIRED gbm>=13.0)
 pkg_check_modules(LibInput IMPORTED_TARGET REQUIRED libinput)
 pkg_check_modules(LibUdev IMPORTED_TARGET REQUIRED libudev)
 pkg_check_modules(WaylandServer IMPORTED_TARGET REQUIRED wayland-server)
+if (NOT TARGET Wpe::FDO)
+  find_package(WpeFDO REQUIRED)
+endif()
 
 add_library(cogplatform-drm MODULE
     ../common/cog-gl-utils.c
@@ -30,7 +32,7 @@ target_link_libraries(cogplatform-drm PRIVATE
     PkgConfig::LibUdev
     PkgConfig::WaylandServer
     PkgConfig::WebKit
-    PkgConfig::WpeFDO
+    Wpe::FDO
 )
 
 string(REGEX MATCH "^([0-9]+)\.([0-9]+)\.([0-9]+)" _ "${LibInput_VERSION}")

--- a/platform/gtk4/CMakeLists.txt
+++ b/platform/gtk4/CMakeLists.txt
@@ -1,5 +1,8 @@
 pkg_check_modules(COGPLATFORM_GTK4_DEPS REQUIRED
-    IMPORTED_TARGET gtk4 wpebackend-fdo-1.0)
+    IMPORTED_TARGET gtk4)
+if (NOT TARGET Wpe::FDO)
+  find_package(WpeFDO REQUIRED)
+endif()
 add_library(cogplatform-gtk4 MODULE
     ../common/cog-gl-utils.c
     cog-platform-gtk4.c
@@ -8,6 +11,7 @@ add_library(cogplatform-gtk4 MODULE
 target_link_libraries(cogplatform-gtk4 PRIVATE
     PkgConfig::COGPLATFORM_GTK4_DEPS
     PkgConfig::WebKit
+    Wpe::FDO
 )
 set_target_properties(cogplatform-gtk4 PROPERTIES
     LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/modules

--- a/platform/headless/CMakeLists.txt
+++ b/platform/headless/CMakeLists.txt
@@ -1,5 +1,7 @@
 
-pkg_check_modules(WpeFDO IMPORTED_TARGET REQUIRED wpebackend-fdo-1.0>=1.8.0)
+if (NOT TARGET Wpe::FDO)
+  find_package(WpeFDO REQUIRED)
+endif()
 add_library(cogplatform-headless MODULE cog-platform-headless.c)
 set_target_properties(cogplatform-headless PROPERTIES
     C_STANDARD 99
@@ -9,7 +11,7 @@ set_target_properties(cogplatform-headless PROPERTIES
 target_compile_definitions(cogplatform-headless PRIVATE G_LOG_DOMAIN=\"Cog-HEADLESS\")
 target_link_libraries(cogplatform-headless PRIVATE
     cogcore
-    PkgConfig::WpeFDO
+    Wpe::FDO
 )
 
 install(TARGETS cogplatform-headless

--- a/platform/wayland/CMakeLists.txt
+++ b/platform/wayland/CMakeLists.txt
@@ -24,8 +24,10 @@ add_wayland_protocol(cogplatform-wl CLIENT xdg-shell)
 pkg_check_modules(Cairo IMPORTED_TARGET cairo)
 pkg_check_modules(EGL IMPORTED_TARGET REQUIRED egl)
 pkg_check_modules(WAYLAND IMPORTED_TARGET REQUIRED wayland-client)
-pkg_check_modules(WpeFDO IMPORTED_TARGET REQUIRED wpebackend-fdo-1.0>=1.6.0)
 pkg_check_modules(XkbCommon IMPORTED_TARGET REQUIRED xkbcommon)
+if (NOT TARGET Wpe::FDO)
+  find_package(WpeFDO REQUIRED)
+endif()
 
 target_link_libraries(cogplatform-wl PRIVATE
     cogcore
@@ -33,9 +35,8 @@ target_link_libraries(cogplatform-wl PRIVATE
     PkgConfig::EGL
     PkgConfig::WAYLAND
     PkgConfig::WebKit
-    PkgConfig::WpeFDO
+    Wpe::FDO
 )
-
 
 pkg_check_modules(WAYLAND_EGL IMPORTED_TARGET wayland-egl)
 if (TARGET PkgConfig::WAYLAND_EGL)

--- a/platform/x11/CMakeLists.txt
+++ b/platform/x11/CMakeLists.txt
@@ -2,7 +2,10 @@
 
 pkg_check_modules(Epoxy IMPORTED_TARGET REQUIRED epoxy)
 pkg_check_modules(COGPLATFORM_X11_DEPS IMPORTED_TARGET
-    REQUIRED wpebackend-fdo-1.0>=1.6.0 egl xcb xkbcommon-x11)
+    REQUIRED egl xcb xkbcommon-x11)
+if (NOT TARGET Wpe::FDO)
+  find_package(WpeFDO REQUIRED)
+endif()
 
 add_library(cogplatform-x11 MODULE
     ../common/cog-gl-utils.c
@@ -17,6 +20,7 @@ target_link_libraries(cogplatform-x11 PRIVATE cogcore
     PkgConfig::Epoxy
     PkgConfig::COGPLATFORM_X11_DEPS
     PkgConfig::WebKit
+    Wpe::FDO
 )
 
 install(TARGETS cogplatform-x11


### PR DESCRIPTION
If not, there might be linking poisoning at compilation time, if a
custom wpebackend-fdo is used (by the uninstalled method, for
example) different to the one system-wide.