### PR TITLE
x11: Fix underlinking when --as-needed is used

### DIFF
--- a/platform/x11/CMakeLists.txt
+++ b/platform/x11/CMakeLists.txt
@@ -2,7 +2,7 @@
 
 pkg_check_modules(Epoxy IMPORTED_TARGET REQUIRED epoxy)
 pkg_check_modules(COGPLATFORM_X11_DEPS IMPORTED_TARGET
-    REQUIRED egl xcb xkbcommon-x11)
+    REQUIRED egl xcb xkbcommon-x11 x11-xcb)
 find_package(WpeFDO REQUIRED)
 
 add_library(cogplatform-x11 MODULE


### PR DESCRIPTION
Add the `x11-xcb` module as dependency as well. The corresponding library is needed for its `XGetXCBConnection` symbol, which will be reported as missing when the platform plug-in was built with the `--as-needed` linker flag.