### PR TITLE
Fix COG_WESTON_DIRECT_DISPLAY build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,6 +15,7 @@ set_project_version(0 13 3)
 calculate_library_versions_from_libtool_triple(COGCORE 9 2 0)
 
 project(cog VERSION "${PROJECT_VERSION}" LANGUAGES C)
+include(CMakeDependentOption)
 include(DistTargets)
 include(GNUInstallDirs)
 
@@ -65,6 +66,7 @@ option(COG_PLATFORM_GTK4 "Build the GTK4 platform module" OFF)
 option(COG_BUILD_PROGRAMS "Build and install programs as well" ON)
 option(INSTALL_MAN_PAGES "Install the man(1) pages if COG_BUILD_PROGRAMS is enabled" ON)
 option(COG_WESTON_DIRECT_DISPLAY "Build direct display support for the Wayland platform module" OFF)
+cmake_dependent_option(COG_WESTON_CONTENT_PROTECTION "Build direct content protection for the Wayland platform module" OFF "COG_WESTON_DIRECT_DISPLAY" OFF)
 option(BUILD_DOCS "Build the documentation" OFF)
 
 option(USE_SOUP2 "Build with libsoup2 instead of libsoup3" ON)

--- a/platform/wayland/CMakeLists.txt
+++ b/platform/wayland/CMakeLists.txt
@@ -56,13 +56,19 @@ if (COG_WESTON_DIRECT_DISPLAY)
         REQUIRED
     )
 
-    pkg_check_modules(LIBWESTON REQUIRED libweston-9-protocols)
-    pkg_get_variable(LIBWESTON_PKG_DATA_DIR libweston-9-protocols "pkgdatadir")
+    pkg_search_module(LIBWESTON REQUIRED libweston-11-protocols libweston-10-protocols libweston-9-protocols libweston-8-protocols)
+    pkg_get_variable(LIBWESTON_PKG_DATA_DIR ${LIBWESTON_MODULE_NAME} "pkgdatadir")
     add_wayland_protocol(cogplatform-wl CLIENT "${LIBWESTON_PKG_DATA_DIR}/weston-direct-display.xml")
-    add_wayland_protocol(cogplatform-wl CLIENT "${LIBWESTON_PKG_DATA_DIR}/weston-content-protection.xml")
     target_compile_definitions(cogplatform-wl PRIVATE COG_ENABLE_WESTON_DIRECT_DISPLAY=1)
+    if (COG_WESTON_CONTENT_PROTECTION)
+        add_wayland_protocol(cogplatform-wl CLIENT "${LIBWESTON_PKG_DATA_DIR}/weston-content-protection.xml")
+        target_compile_definitions(cogplatform-wl PRIVATE COG_ENABLE_WESTON_CONTENT_PROTECTION=1)
+    else ()
+        target_compile_definitions(cogplatform-wl PRIVATE COG_ENABLE_WESTON_CONTENT_PROTECTION=0)
+    endif ()
 else ()
     target_compile_definitions(cogplatform-wl PRIVATE COG_ENABLE_WESTON_DIRECT_DISPLAY=0)
+    target_compile_definitions(cogplatform-wl PRIVATE COG_ENABLE_WESTON_CONTENT_PROTECTION=0)
 endif ()
 
 # Optional pointer support


### PR DESCRIPTION
For some reason this option was enabling content protection as well, since that is a separate option that merely depends on direct display move it under COG_WESTON_CONTENT_PROTECTION.

We also need to fix pkg-config search to look for libweston protocols starting with weston version 8(first to introduce direct display), the current weston development branch uses version 11 so lets include that as well.

We also need to [fix the client protocol header names](https://github.com/Igalia/cog/blob/d2720103ff8a5c3c5c056487586ed0b5acdc2b91/cmake/FindWaylandProtocols.cmake#L142) as the current ones are invalid.
