### PR TITLE
data/check-style: fix broken git commit without installed tools

### DIFF
--- a/data/check-style
+++ b/data/check-style
@@ -70,9 +70,6 @@ find_program ()
             return
         fi
     done
-
-    # Not found.
-    return 1
 }
 
 clang_format_diff=$(find_program "${clang_format_diff_candidates[@]}")


### PR DESCRIPTION
The script is set to run strictly at the beginning. Returning 1
from the function results the script to exit quietly, which is
very unhelpful, as it means the moment somebody who does not have
clang-format-diff installed runs cmake, the git hook gets copied
and from that moment running simple "git commit" exits with no
message whatsoever, making one wonder why git broke.

It is not necessary to return 1, as the existence of the program
is checked based on the captured string. Therefore, removing the
return will result in the check working correctly and printing an
error when the tool is not installed, which is much better.