### PR TITLE
Fix missing headers

### DIFF
--- a/platform/drm/cog-platform-drm.c
+++ b/platform/drm/cog-platform-drm.c
@@ -18,12 +18,14 @@
 #include <gbm.h>
 #include <libinput.h>
 #include <libudev.h>
+#include <stdio.h>
 #include <string.h>
 #include <wayland-server.h>
 #include <wpe/fdo-egl.h>
 #include <wpe/fdo.h>
 #include <xf86drm.h>
 #include <xf86drmMode.h>
+#include <xkbcommon/xkbcommon.h>
 
 #include <epoxy/egl.h>
 

--- a/platform/wayland/cog-im-context-wl-v1.c
+++ b/platform/wayland/cog-im-context-wl-v1.c
@@ -7,6 +7,8 @@
 
 #include "cog-im-context-wl-v1.h"
 
+#include <xkbcommon/xkbcommon.h>
+
 static struct {
     struct zwp_text_input_v1 *text_input;
     struct wl_seat *seat;


### PR DESCRIPTION
WPE Non-unified build bot was failing due to missing headers in Cog.