### PR TITLE
cmake: Enable usage of libsoup3 by default

### DIFF
--- a/.github/workflows/ci-cross.yml
+++ b/.github/workflows/ci-cross.yml
@@ -34,7 +34,8 @@ jobs:
             -DWAYLAND_SCANNER=/usr/bin/wayland-scanner \
             -DCMAKE_BUILD_TYPE=${BUILD_TYPE} \
             -DCOG_PLATFORM_FDO=ON \
-            -DCOG_PLATFORM_DRM=ON
+            -DCOG_PLATFORM_DRM=ON \
+            -DUSE_SOUP2=ON
       - name: Build
         env:
           TERM: dumb

--- a/.github/workflows/ci-native.yml
+++ b/.github/workflows/ci-native.yml
@@ -86,6 +86,7 @@ jobs:
             -DCOG_PLATFORM_DRM=ON \
             -DCOG_PLATFORM_X11=ON \
             -DBUILD_DOCS=ON \
+            -DUSE_SOUP2=ON \
             -GNinja
       - name: Build
         env:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -69,7 +69,7 @@ option(COG_WESTON_DIRECT_DISPLAY "Build direct display support for the Wayland p
 cmake_dependent_option(COG_WESTON_CONTENT_PROTECTION "Build direct content protection for the Wayland platform module" OFF "COG_WESTON_DIRECT_DISPLAY" OFF)
 option(BUILD_DOCS "Build the documentation" OFF)
 
-option(USE_SOUP2 "Build with libsoup2 instead of libsoup3" ON)
+option(USE_SOUP2 "Build with libsoup2 instead of libsoup3" OFF)
 
 set(COG_APPID "" CACHE STRING "Default GApplication unique identifier")
 set(COG_HOME_URI "" CACHE STRING "Default home URI")


### PR DESCRIPTION
In order to nudge packagers into using libsoup3, make it slightly more convenient by being the default.