### PR TITLE
cmake: fix .pc file when configuring an absolute libdir

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,6 +18,7 @@ project(cog VERSION "${PROJECT_VERSION}" LANGUAGES C)
 include(CMakeDependentOption)
 include(DistTargets)
 include(GNUInstallDirs)
+include(JoinPaths)
 
 set(COG_VERSION_EXTRA "")
 if (IS_DIRECTORY "${CMAKE_SOURCE_DIR}/.git")
@@ -203,6 +204,9 @@ install(FILES ${COGCORE_API_HEADERS}
     DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/cog
     COMPONENT "development"
 )
+
+join_paths(COG_PKGCONFIG_LIBDIR "\${prefix}" "${CMAKE_INSTALL_LIBDIR}")
+join_paths(COG_PKGCONFIG_INCLUDEDIR "\${prefix}" "${CMAKE_INSTALL_INCLUDEDIR}")
 
 configure_file(core/cog-config.h.in cog-config.h @ONLY)
 configure_file(core/cogcore.pc.in cogcore.pc @ONLY)

--- a/cmake/JoinPaths.cmake
+++ b/cmake/JoinPaths.cmake
@@ -1,0 +1,23 @@
+# This module provides function for joining paths
+# known from most languages
+#
+# SPDX-License-Identifier: (MIT OR CC0-1.0)
+# Copyright 2020 Jan Tojnar
+# https://github.com/jtojnar/cmake-snips
+#
+# Modelled after Python’s os.path.join
+# https://docs.python.org/3.7/library/os.path.html#os.path.join
+# Windows not supported
+function(join_paths joined_path first_path_segment)
+    set(temp_path "${first_path_segment}")
+    foreach(current_segment IN LISTS ARGN)
+        if(NOT ("${current_segment}" STREQUAL ""))
+            if(IS_ABSOLUTE "${current_segment}")
+                set(temp_path "${current_segment}")
+            else()
+                set(temp_path "${temp_path}/${current_segment}")
+            endif()
+        endif()
+    endforeach()
+    set(${joined_path} "${temp_path}" PARENT_SCOPE)
+endfunction()

--- a/core/cogcore.pc.in
+++ b/core/cogcore.pc.in
@@ -1,6 +1,6 @@
 prefix=@CMAKE_INSTALL_PREFIX@
-libdir=${prefix}/@CMAKE_INSTALL_LIBDIR@
-includedir=${prefix}/include
+libdir=@COG_PKGCONFIG_LIBDIR@
+includedir=@COG_PKGCONFIG_INCLUDEDIR@
 
 Name: cogcore
 Description: Cog Core - WPE WebKit base launcher


### PR DESCRIPTION
Instead of blindly concatenate `CMAKE_INSTALL_LIBDIR`, let CMake resolve the paths first to avoid the concatenation in case the variable contains an absolute path. While at it, do the same
for `CMAKE_INSTALL_INCLUDEDIR`.

Fixes #438