### PR TITLE
drm, wl, x11: Use wpe_view_backend_set_target_refresh_rate() conditionally

### DIFF
--- a/platform/drm/cog-platform-drm.c
+++ b/platform/drm/cog-platform-drm.c
@@ -35,6 +35,12 @@
          (LIBINPUT_VER_MAJOR == (a) && (LIBINPUT_VER_MINOR == (b)) && (LIBINPUT_VER_MICRO >= (c))))
 #endif /* !LIBINPUT_CHECK_VERSION */
 
+#if defined(WPE_CHECK_VERSION)
+#    define HAVE_REFRESH_RATE_HANDLING WPE_CHECK_VERSION(1, 13, 2)
+#else
+#    define HAVE_REFRESH_RATE_HANDLING 0
+#endif
+
 #if !defined(EGL_EXT_platform_base)
 typedef EGLDisplay (EGLAPIENTRYP PFNEGLGETPLATFORMDISPLAYEXTPROC) (EGLenum platform, void *native_display, const EGLint *attrib_list);
 #endif
@@ -1455,17 +1461,22 @@ cog_drm_platform_get_view_backend(CogPlatform *platform, WebKitWebView *related_
     return wk_view_backend;
 }
 
+#if HAVE_REFRESH_RATE_HANDLING
 static gboolean
 set_target_refresh_rate(gpointer user_data)
 {
     wpe_view_backend_set_target_refresh_rate(wpe_view_data.backend, drm_data.refresh * 1000);
 }
+#endif /* HAVE_REFRESH_RATE_HANDLING */
 
 static void
 cog_drm_platform_init_web_view(CogPlatform *platform, WebKitWebView *view)
 {
     wpe_view_backend_dispatch_set_device_scale_factor(wpe_view_data.backend, drm_data.device_scale);
+
+#if HAVE_REFRESH_RATE_HANDLING
     g_idle_add(G_SOURCE_FUNC(set_target_refresh_rate), &wpe_view_data);
+#endif /* HAVE_REFRESH_RATE_HANDLING */
 }
 
 static void

--- a/platform/gtk4/cog-platform-gtk4.c
+++ b/platform/gtk4/cog-platform-gtk4.c
@@ -18,6 +18,12 @@
 #define DEFAULT_WIDTH 1280
 #define DEFAULT_HEIGHT 720
 
+#if defined(WPE_CHECK_VERSION)
+#    define HAVE_REFRESH_RATE_HANDLING WPE_CHECK_VERSION(1, 13, 2)
+#else
+#    define HAVE_REFRESH_RATE_HANDLING 0
+#endif
+
 #if defined(WPE_FDO_CHECK_VERSION)
 #    define HAVE_FULLSCREEN_HANDLING WPE_FDO_CHECK_VERSION(1, 11, 1)
 #else
@@ -153,6 +159,7 @@ setup_shader(struct platform_window* window, GError** error)
     return true;
 }
 
+#if HAVE_REFRESH_RATE_HANDLING
 static void
 enter_monitor(GdkSurface *surface, GdkMonitor *monitor, gpointer user_data)
 {
@@ -160,6 +167,7 @@ enter_monitor(GdkSurface *surface, GdkMonitor *monitor, gpointer user_data)
     wpe_view_backend_set_target_refresh_rate(wpe_view_backend_exportable_fdo_get_view_backend(win->exportable),
                                              gdk_monitor_get_refresh_rate(monitor));
 }
+#endif /* HAVE_REFRESH_RATE_HANDLING */
 
 static void
 realize(GtkWidget *widget, gpointer user_data)
@@ -172,8 +180,10 @@ realize(GtkWidget *widget, gpointer user_data)
         g_application_quit(g_application_get_default());
     }
 
+#if HAVE_REFRESH_RATE_HANDLING
     g_signal_connect(gtk_native_get_surface(gtk_widget_get_native(win->gtk_window)), "enter-monitor",
                      G_CALLBACK(enter_monitor), user_data);
+#endif /* HAVE_REFRESH_RATE_HANDLING */
 }
 
 static gboolean

--- a/platform/wayland/cog-platform-wl.c
+++ b/platform/wayland/cog-platform-wl.c
@@ -66,6 +66,12 @@
 
 #define DEFAULT_ZOOM_STEP 0.1f
 
+#if defined(WPE_CHECK_VERSION)
+#    define HAVE_REFRESH_RATE_HANDLING WPE_CHECK_VERSION(1, 13, 2)
+#else
+#    define HAVE_REFRESH_RATE_HANDLING 0
+#endif
+
 #if defined(WPE_FDO_CHECK_VERSION)
 #    define HAVE_SHM_EXPORTED_BUFFER WPE_FDO_CHECK_VERSION(1, 9, 0)
 #    define HAVE_FULLSCREEN_HANDLING WPE_FDO_CHECK_VERSION(1, 11, 1)
@@ -748,10 +754,13 @@ surface_handle_enter(void *data, struct wl_surface *surface, struct wl_output *o
     if (wl_surface_get_version(surface) >= WL_SURFACE_SET_BUFFER_SCALE_SINCE_VERSION) {
         wl_surface_set_buffer_scale(surface, scale_factor);
         wpe_view_backend_dispatch_set_device_scale_factor(wpe_view_data.backend, scale_factor);
-        wpe_view_backend_set_target_refresh_rate(wpe_view_data.backend, refresh);
         wl_data.current_output.scale = scale_factor;
     }
 #endif /* WL_SURFACE_SET_BUFFER_SCALE_SINCE_VERSION */
+
+#if HAVE_REFRESH_RATE_HANDLING
+    wpe_view_backend_set_target_refresh_rate(wpe_view_data.backend, refresh);
+#endif /* HAVE_REFRESH_RATE_HANDLING */
 }
 
 static const struct wl_surface_listener surface_listener = {


### PR DESCRIPTION
The new API was introduced in the [libwpe 1.13.2 development release](https://wpewebkit.org/release/libwpe-1.13.2.html). Typically we support building Cog with one or two major release series back of the main dependencies (libwpe, wpebackend-fdo, wpewebkit), so
add guards to use the `wpe_view_backend_set_target_refresh_rate()` only on newer versions.