### PR TITLE
launcher: Add command-line option to enable network proxy support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -162,6 +162,12 @@ else()
     set(HAVE_WEBKIT_MEM_PRESSURE_API 0)
 endif()
 
+if (WebKit_VERSION VERSION_GREATER_EQUAL 2.32.0)
+    set(HAVE_WEBKIT_NETWORK_PROXY_API 1)
+else()
+    set(HAVE_WEBKIT_NETWORK_PROXY_API 0)
+endif()
+
 include(CheckCCompilerFlag)
 check_c_compiler_flag(-Wall HAS_WALL)
 

--- a/launcher/cog-launcher.c
+++ b/launcher/cog-launcher.c
@@ -53,6 +53,8 @@ static struct {
     gboolean ignore_tls_errors;
     gboolean enable_sandbox;
     gboolean automation;
+    char    *proxy;
+    gchar  **ignore_hosts;
 } s_options = {
     .scale_factor = 1.0,
     .device_scale_factor = 1.0,
@@ -1013,6 +1015,8 @@ static GOptionEntry s_cli_options[] = {
      "Enable WebProcess sandbox (default: disabled).", NULL},
     {"automation", '\0', 0, G_OPTION_ARG_NONE, &s_options.automation, "Enable automation mode (default: disabled).",
      NULL},
+    {"proxy", 0, 0, G_OPTION_ARG_STRING, &s_options.proxy, "Set proxy", "PROXY"},
+    {"ignore-host", 0, 0, G_OPTION_ARG_STRING_ARRAY, &s_options.ignore_hosts, "Set proxy ignore hosts", "HOSTS"},
     {G_OPTION_REMAINING, '\0', 0, G_OPTION_ARG_FILENAME_ARRAY, &s_options.arguments, "", "[URL]"},
     {NULL}};
 
@@ -1240,6 +1244,18 @@ cog_launcher_handle_local_options(GApplication *application, GVariantDict *optio
                                                         (GAsyncReadyCallback) on_filter_saved,
                                                         loop);
         g_main_loop_run(loop);
+    }
+
+    if (s_options.proxy) {
+#if HAVE_WEBKIT_NETWORK_PROXY_API
+        WebKitWebsiteDataManager             *data_manager = cog_launcher_get_web_data_manager(launcher);
+        g_autoptr(WebKitNetworkProxySettings) webkit_proxy_settings =
+            webkit_network_proxy_settings_new(s_options.proxy, s_options.ignore_hosts);
+        webkit_website_data_manager_set_network_proxy_settings(data_manager, WEBKIT_NETWORK_PROXY_MODE_CUSTOM,
+                                                               webkit_proxy_settings);
+#else
+        g_printerr("WPEWebKit >= 2.32 is required for network proxy configuration support\n");
+#endif
     }
 
     return -1; /* Continue startup. */


### PR DESCRIPTION
Pass `--proxy=http://ip:port` and optionally `--ignore-host=hostname` to configure
a list of hostnames that will not be proxied.