### PR TITLE
Assorted small cleanups

### DIFF
--- a/core/cog-shell.c
+++ b/core/cog-shell.c
@@ -475,10 +475,10 @@ cog_shell_class_init (CogShellClass *klass)
      * CogShell:web-data-manager:
      *
      * Optional `WebKitWebsiteDataManager` to be used by the shell. If
-     * specified at construction, then the [property@Cog.Shell.automated]
+     * specified at construction, then the [property@Cog.Shell:automated]
      * property will be ignored and the provided object should have
-     * [property@WebKit.WebsiteDataManager.is-ephemeral] enabled for running
-     * in automation mode..
+     * [property@WebKit.WebsiteDataManager:is-ephemeral] enabled for running
+     * in automation mode.
      */
     s_properties[PROP_WEB_DATA_MANAGER] =
         g_param_spec_object("web-data-manager",

--- a/platform/common/egl-proc-address.h
+++ b/platform/common/egl-proc-address.h
@@ -12,8 +12,8 @@
 
 #include <EGL/egl.h>
 
-static void*
-load_egl_proc_address (const char *name)
+static inline void *
+load_egl_proc_address(const char *name)
 {
     void *proc_address = eglGetProcAddress (name);
     if (!proc_address)

--- a/platform/drm/cog-drm-modeset-renderer.c
+++ b/platform/drm/cog-drm-modeset-renderer.c
@@ -621,7 +621,7 @@ cog_drm_modeset_renderer_destroy(CogDrmRenderer *renderer)
 
     g_clear_pointer(&self->gbm_dev, gbm_device_destroy);
 
-    g_slice_free(CogDrmModesetRenderer, renderer);
+    g_slice_free(CogDrmModesetRenderer, self);
 }
 
 static struct wpe_view_backend_exportable_fdo *

--- a/platform/gtk4/cog-platform-gtk4.c
+++ b/platform/gtk4/cog-platform-gtk4.c
@@ -12,7 +12,6 @@
 
 #include "../../core/cog.h"
 #include "../common/cog-gl-utils.h"
-#include "../common/egl-proc-address.h"
 #include "cog-gtk-settings-dialog.h"
 
 #define DEFAULT_WIDTH 1280


### PR DESCRIPTION
This includes a number of assorted small cleanups:

```
7e557b6 drm: Avoid warning about mismatched pointer types
4143d6d gtk4: Remove egl-proc-address.h inclusion
8b8c373 common: Mark load_egl_proc_address() as inline
37ef997 core: Fix property references in documentation comments
```