### PR TITLE
Add new Meson build system

### DIFF
--- a/core/meson.build
+++ b/core/meson.build
@@ -1,0 +1,70 @@
+cog_config = configuration_data()
+cog_config.set('COG_MODULEDIR', plugin_path)
+cog_config.set('PROJECT_VERSION_MAJOR', project_version_components[0])
+cog_config.set('PROJECT_VERSION_MINOR', project_version_components[1])
+cog_config.set('PROJECT_VERSION_PATCH', project_version_components[2])
+cog_config.set('PROJECT_VERSION', meson.project_version())
+cog_config.set('COG_VERSION_EXTRA', project_version_git_tag)
+cog_config.set('COG_DEFAULT_APPID', cog_launcher_appid)
+cog_config.set('COG_DEFAULT_HOME_URI', cog_launcher_home_uri)
+cog_config.set10('HAVE_WEBKIT_MEM_PRESSURE_API',
+    wpewebkit_dep.version().version_compare('>=2.34.0'))
+
+cogcore_config_h = configure_file(
+    input: 'cog-config.h.in',
+    output: 'cog-config.h',
+    format: 'cmake@',
+    configuration: cog_config,
+)
+
+cogcore_headers = files(
+    'cog.h',
+    'cog-request-handler.h',
+    'cog-directory-files-handler.h',
+    'cog-host-routes-handler.h',
+    'cog-prefix-routes-handler.h',
+    'cog-shell.h',
+    'cog-utils.h',
+    'cog-webkit-utils.h',
+    'cog-platform.h',
+    'cog-modules.h',
+)
+cogcore_sources = files(
+    'cog-directory-files-handler.c',
+    'cog-host-routes-handler.c',
+    'cog-modules.c',
+    'cog-platform.c',
+    'cog-prefix-routes-handler.c',
+    'cog-request-handler.c',
+    'cog-shell.c',
+    'cog-utils.c',
+    'cog-webkit-utils.c',
+)
+
+cogcore_dependencies = [
+    wpewebkit_dep,
+]
+
+install_headers(cogcore_headers, cogcore_config_h, subdir: 'cog')
+
+cogcore_lib = shared_library('cogcore',
+    cogcore_config_h,
+    cogcore_sources,
+    c_args: ['-DG_LOG_DOMAIN="Cog-Core"'],
+    dependencies: cogcore_dependencies,
+    version: cogcore_soversion,
+    soversion: cogcore_soversion_major,
+    install: true,
+)
+
+cogcore_dep = declare_dependency(
+    link_with: cogcore_lib,
+    dependencies: cogcore_dependencies,
+    include_directories: include_directories('.'),
+)
+
+import('pkgconfig').generate(
+    cogcore_lib,
+    description: 'Cog Core - WPE WebKit base launcher',
+    subdirs: 'cog',
+)

--- a/docs/meson.build
+++ b/docs/meson.build
@@ -1,0 +1,46 @@
+gi_docgen_exe = find_program('gi-docgen', 'gi-docgen.py', native: true)
+
+# XXX: gi-docgen needs to be able to spit out a depfile.
+docs_md = [
+    'contributing.md',
+    'overview.md',
+    'platform-drm.md',
+    'platform-headless.md',
+    'platform-wl.md',
+    'platform-x11.md',
+    'webdriver.md',
+]
+
+docs_toml = configure_file(
+    input: 'cog.toml.in',
+    output: 'cog.toml',
+    configuration: cog_config,
+)
+
+gi_outputs = import('gnome').generate_gir(
+    cogcore_lib,
+    sources: [cogcore_sources, cogcore_headers],
+    dependencies: cogcore_dep,
+    nsversion: '@0@.0'.format(project_version_components[0]),
+    header: 'cog/cog.h',
+    namespace: 'Cog',
+    identifier_prefix: 'Cog',
+    symbol_prefix: 'cog',
+    install: false,
+)
+gi_cogcore_gir = gi_outputs[0]
+
+custom_target('docs',
+    build_by_default: true,
+    input: [docs_toml, gi_cogcore_gir],
+    output: 'html',
+    depend_files: docs_md,
+    command: [gi_docgen_exe, 'generate',
+        '--quiet',
+        '--no-namespace-dir',
+        '--content-dir', '@CURRENT_SOURCE_DIR@',
+        '--output-dir', '@OUTPUT@',
+        '--config', '@INPUT0@',
+        '@INPUT1@',
+    ],
+)

--- a/launcher/meson.build
+++ b/launcher/meson.build
@@ -1,0 +1,14 @@
+executable('cog',
+    'cog.c',
+    'cog-launcher.c',
+    c_args: ['-DG_LOG_DOMAIN="Cog"'],
+    dependencies: cogcore_dep,
+    install: true,
+)
+executable('cogctl',
+    'cogctl.c',
+    '../core/cog-utils.c',
+    c_args: ['-DG_LOG_DOMAIN="Cog-Control"'],
+    dependencies: [libsoup_dep, cogcore_dep.partial_dependency(includes: true)],
+    install: true,
+)

--- a/meson.build
+++ b/meson.build
@@ -1,0 +1,140 @@
+project('cog', 'c',
+    meson_version: '>=0.53.2',
+    default_options: [
+        'buildtype=debugoptimized',
+        'b_ndebug=if-release',
+        'c_std=c99',
+    ],
+    license: 'MIT',
+    version: '0.15.0',
+)
+
+# Before making a release, the LT_VERSION string should be modified.
+# The string is of the form [C, R, A].
+# - If interfaces have been changed or added, but binary compatibility has
+#   been preserved, change to [C+1, 0, A+1].
+# - If binary compatibility has been broken (eg removed or changed interfaces)
+#   change to [C+1, 0, 0]
+# - If the interface is the same as the previous version, use [C, R+1, A].
+cogcore_soversion = [10, 0, 1]
+
+# Mangle [C, R, A] into an actual usable *soversion*.
+cogcore_soversion_major = cogcore_soversion[0] - cogcore_soversion[2]  # Current-Age
+cogcore_soversion_minor = cogcore_soversion[2]  # Age
+cogcore_soversion_micro = cogcore_soversion[1]  # Revision
+cogcore_soversion = '@0@.@1@.@2@'.format(cogcore_soversion_major, cogcore_soversion_minor, cogcore_soversion_micro)
+
+project_version_components = meson.project_version().split('.')
+
+# When running from a Git checkout, try to obtain the current revision.
+project_version_git_tag = ''
+if meson.version().version_compare('>=0.56')
+    git_dir = join_paths(meson.project_source_root(), '.git')
+else
+    git_dir = join_paths(meson.current_source_dir(), '.git')
+endif
+
+if import('fs').exists(git_dir)
+    project_version_git_tag = '+git'
+
+    git_exe = find_program('git', native: true, required: false)
+    if git_exe.found()
+        git_result = run_command(git_exe, 'rev-list', '--max-count=1',
+            '--abbrev-commit', 'HEAD',
+            env: {'GIT_DIR': git_dir},
+            capture: true,
+            check: false,
+        )
+        git_output = git_result.stdout().strip()
+        if git_result.returncode() == 0 and git_output != ''
+            project_version_git_tag = '@0@-@1@'.format(project_version_git_tag, git_output)
+        endif
+
+        git_result = run_command(git_exe, 'status', '--porcelain',
+            env: {'GIT_DIR': git_dir},
+            capture: true,
+            check: false,
+        )
+        git_output = git_result.stdout().strip()
+        if git_result.returncode() == 0 and git_output != ''
+            project_version_git_tag = '@0@-dirty'.format(project_version_git_tag)
+        endif
+    endif
+
+    message('Git tag: @0@'.format(project_version_git_tag))
+endif
+
+plugin_path = get_option('plugin_path')
+if plugin_path == ''
+    # TODO: Consider renaming s/modules/plugins/
+    plugin_path = join_paths(get_option('prefix'), get_option('libdir'), 'cog', 'modules')
+endif
+
+platform_plugins = get_option('platforms')
+with_drm_platform = platform_plugins.contains('drm')
+with_headless_platform = platform_plugins.contains('headless')
+with_wayland_platform = platform_plugins.contains('wayland')
+with_gtk4_platform = platform_plugins.contains('gtk4')
+with_x11_platform = platform_plugins.contains('x11')
+
+with_programs = get_option('programs')
+
+with_soup2 = get_option('soup2').enabled()
+if get_option('soup2').auto()
+    # Prefer using API 1.1 level if available.
+    with_soup2 = not dependency('wpe-webkit-1.1', required: false).found()
+endif
+
+cog_launcher_appid = get_option('cog_appid')
+cog_launcher_home_uri = get_option('cog_home_uri')
+cog_launcher_system_bus = with_programs and get_option('cog_dbus_control') == 'system'
+
+add_project_arguments('-DCOG_INSIDE_COG__=1', language: 'c')
+
+if with_soup2
+    add_project_arguments('-DCOG_USE_SOUP2=1', language: 'c')
+    libsoup_dep = dependency('libsoup-2.4')
+    gio_dep = dependency('gio-2.0', version: '>=2.44')
+    wpewebkit_dep = dependency('wpe-webkit-1.0', version: '>=2.28.0')
+else
+    add_project_arguments('-DCOG_USE_SOUP2=0', language: 'c')
+    libsoup_dep = dependency('libsoup-3.0', version: '>=2.99.7')
+    gio_dep = dependency('gio-2.0', version: '>=2.67.4')
+    wpewebkit_dep = dependency('wpe-webkit-1.1', version: '>=2.33.1')
+endif
+
+if cog_launcher_system_bus
+    cog_dbus_system_owner = get_option('cog_dbus_system_owner')
+    # Generate and install D-Bus policy configuration file.
+    configure_file(
+        configuration: {
+            'COG_DEFAULT_APPID': cog_launcher_appid,
+            'COG_DBUS_OWN_USER': cog_dbus_system_owner,
+        },
+        input: 'dbus/policy.conf.in',
+        output: '@0@.conf'.format(cog_launcher_appid),
+        install_dir: join_paths(get_option('datadir'), 'dbus-1', 'system.d'),
+        install: true,
+    )
+
+    # Let the source code know that the option is enabled.
+    add_project_arguments(
+        '-DCOG_DBUS_SYSTEM_BUS=1',
+        '-DCOG_DBUS_OWN_USER="@0@"'.format(cog_dbus_system_owner),
+        language: 'c'
+    )
+endif
+
+subdir('core')
+subdir('platform')
+
+if get_option('documentation')
+    subdir('docs')
+endif
+
+if with_programs
+    subdir('launcher')
+    if get_option('manpages')
+        install_man('data/cog.1', 'data/cogctl.1')
+    endif
+endif

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,0 +1,78 @@
+option(
+    'plugin_path',
+    type: 'string',
+    description: 'Default installation path for loadable plug-ins'
+)
+option(
+    'platforms',
+    type: 'array',
+    value: ['drm', 'headless', 'wayland'],
+    choices: ['drm', 'headless', 'wayland', 'gtk4', 'x11'],
+    description: 'platform plug-ins to build'
+)
+option(
+    'programs',
+    type: 'boolean',
+    value: true,
+    description: 'build and install programs (cog, cogctl)'
+)
+option(
+    'soup2',
+    type: 'feature',
+    value: 'auto',
+    description: 'Build with libsoup2 instead of libsoup3'
+)
+
+# Wayland platform-specific features
+option(
+    'wayland_weston_direct_display',
+    type: 'boolean',
+    value: false,
+    description: 'Build direct-display support in the Wayland platform plug-in'
+)
+option(
+    'wayland_weston_content_protection',
+    type: 'boolean',
+    value: false,
+    description: 'Build content-protection support in the Wayland platform plug-in'
+)
+
+# Additional cog/cogctl options
+option(
+    'cog_appid',
+    type: 'string',
+    value: 'com.igalia.Cog',
+    description: 'Default GApplication unique identifier for Cog'
+)
+option(
+    'cog_home_uri',
+    type: 'string',
+    description: 'Default home URI loaded by Cog at startup'
+)
+option(
+    'cog_dbus_control',
+    type: 'combo',
+    value: 'user',
+    choices: ['user', 'system'],
+    description: 'Bus on which to expose the Cog remote control interface'
+)
+option(
+    'cog_dbus_system_owner',
+    type: 'string',
+    value: '',
+    description: 'Additional user allowed to own the well-known name on the system bus'
+)
+
+# Documentation
+option(
+    'documentation',
+    type: 'boolean',
+    value: false,
+    description: 'Build the documentation'
+)
+option(
+    'manpages',
+    type: 'boolean',
+    value: true,
+    description: 'Install man(1) pages for built programs'
+)

--- a/platform/common/meson.build
+++ b/platform/common/meson.build
@@ -1,0 +1,18 @@
+cogplatformcommon_dependencies = [
+    cogcore_dep,
+    dependency('epoxy'),
+]
+
+cogplatformcommon_lib = static_library('cogplatformcommon',
+    'cog-gl-utils.c',
+    dependencies: cogplatformcommon_dependencies,
+    build_by_default: false,
+    gnu_symbol_visibility: 'hidden',
+    implicit_include_directories: false,
+    pic: true,
+)
+
+cogplatformcommon_dep = declare_dependency(
+    link_with: cogplatformcommon_lib,
+    dependencies: cogplatformcommon_dependencies,
+)

--- a/platform/drm/meson.build
+++ b/platform/drm/meson.build
@@ -1,0 +1,21 @@
+drm_platform_plugin = shared_module('cogplatform-drm',
+    'cog-platform-drm.c',
+    'cog-drm-renderer.c',
+    'cog-drm-gles-renderer.c',
+    'cog-drm-modeset-renderer.c',
+    'kms.c',
+    'cursor-drm.c',
+    c_args: ['-DG_LOG_DOMAIN="Cog-DRM"'],
+    dependencies: [
+        cogcore_dep,
+        wpebackend_fdo_dep,
+        dependency('epoxy'),
+        dependency('libdrm', version: '>=2.4.71'),
+        dependency('libinput'),
+        dependency('libudev'),
+    ],
+    gnu_symbol_visibility: 'hidden',
+    install_dir: plugin_path,
+    install: true,
+)
+platform_plugin_targets += [drm_platform_plugin]

--- a/platform/gtk4/meson.build
+++ b/platform/gtk4/meson.build
@@ -1,0 +1,15 @@
+gtk4_platform_plugin = shared_module('cogplatform-gtk4',
+    'cog-platform-gtk4.c',
+    'cog-gtk-settings-dialog.c',
+    'cog-gtk-settings-cell-renderer-variant.c',
+    c_args: ['-DG_LOG_DOMAIN="Cog-Gtk4"'],
+    dependencies: [
+        cogplatformcommon_dep,
+        wpebackend_fdo_dep,
+        dependency('gtk4'),
+    ],
+    gnu_symbol_visibility: 'hidden',
+    install_dir: plugin_path,
+    install: true,
+)
+platform_plugin_targets += [gtk4_platform_plugin]

--- a/platform/headless/meson.build
+++ b/platform/headless/meson.build
@@ -1,0 +1,9 @@
+headless_platform_plugin = shared_module('cogplatform-headless',
+    'cog-platform-headless.c',
+    c_args: ['-DG_LOG_DOMAIN="Cog-Headless"'],
+    dependencies: [cogcore_dep, wpebackend_fdo_dep],
+    gnu_symbol_visibility: 'hidden',
+    install_dir: plugin_path,
+    install: true,
+)
+platform_plugin_targets += [headless_platform_plugin]

--- a/platform/meson.build
+++ b/platform/meson.build
@@ -1,0 +1,30 @@
+wpebackend_fdo_dep = dependency('wpebackend-fdo-1.0', version: '>=1.8.0')
+
+# Check whether any of the chosen platform plug-ins needs the common library.
+foreach platform_plugin_name : ['drm', 'x11', 'gtk4']
+    if platform_plugins.contains(platform_plugin_name)
+        subdir('common')
+        break
+    endif
+endforeach
+
+platform_plugin_targets = []
+foreach platform_plugin_name : platform_plugins
+    subdir(platform_plugin_name)
+endforeach
+
+fs_mod = import('fs')
+ln_exe = find_program('ln', native: true)
+platform_plugin_symlinks = []
+foreach platform_plugin : platform_plugin_targets
+    platform_plugin_symlinks += [
+        custom_target(
+            'link-@0@'.format(fs_mod.name(platform_plugin.full_path()).underscorify()),
+            output: fs_mod.name(platform_plugin.full_path()),
+            input: platform_plugin,
+            command: [ln_exe, '-srnf', '@INPUT@', '@OUTPUT@'],
+            build_by_default: true,
+        )
+    ]
+endforeach
+alias_target('plugin-symlinks', platform_plugin_symlinks)

--- a/platform/wayland/meson.build
+++ b/platform/wayland/meson.build
@@ -1,0 +1,131 @@
+with_wayland_weston_direct_display = (with_wayland_platform
+    and get_option('wayland_weston_direct_display')
+)
+with_wayland_weston_content_protection = (with_wayland_platform
+    and with_wayland_weston_direct_display
+    and get_option('wayland_weston_content_protection')
+)
+
+wayland_platform_dependencies = [
+    cogcore_dep,
+    wpebackend_fdo_dep,
+    dependency('cairo'),
+    dependency('egl'),
+    dependency('wayland-client'),
+    dependency('wayland-egl', required: false),
+]
+wayland_platform_c_args = [
+    '-DG_LOG_DOMAIN="Cog-Wayland"',
+    '-DCOG_ENABLE_WESTON_DIRECT_DISPLAY=@0@'.format(with_wayland_weston_direct_display.to_int()),
+    '-DCOG_ENABLE_WESTON_CONTENT_PROTECTION=@0@'.format(with_wayland_weston_content_protection.to_int()),
+]
+
+wayland_platform_weston_protocols = []
+if with_wayland_weston_direct_display
+    wayland_platform_weston_protocols += ['weston-direct-display']
+    if with_wayland_weston_content_protection
+        wayland_platform_weston_protocols += ['weston-content-protection']
+    endif
+endif
+
+wayland_platform_protocols = {
+    'stable': [
+        'presentation-time',
+        'xdg-shell',
+    ],
+    'unstable': [
+        ['fullscreen-shell', 1],
+        ['linux-dmabuf', 1],
+        ['text-input', 1],
+        ['text-input', 3],
+    ],
+    'weston': wayland_platform_weston_protocols,
+}
+
+wayland_scanner_exe = find_program('wayland-scanner', native: true)
+wayland_protocols_dep = dependency('wayland-protocols', method: 'pkg-config')
+wayland_protocols_path = wayland_protocols_dep.get_variable(pkgconfig: 'pkgdatadir')
+
+if wayland_platform_weston_protocols.length() > 0
+    foreach weston_dep_name : [
+            'libweston-11-protocols',
+            'libweston-10-protocols',
+            'libweston-9-protocols',
+            'libweston-8-protocols',
+        ]
+        weston_protocols_dep = dependency(weston_dep_name, method: 'pkg-config', required: false)
+        if weston_protocols_dep.found()
+            break
+        endif
+    endforeach
+
+    if not weston_protocols_dep.found()
+        error('No usable weston-protocols dependency found')
+    endif
+
+    weston_protocols_path = weston_protocols_dep.get_variable(pkgconfig: 'pkgdatadir')
+
+    # The code uses definitions from the drm_fourcc.h header, but does not
+    # need to link the library; libdrm here is only a build-time dependency.
+    wayland_platform_dependencies += [dependency('libdrm').partial_dependency(includes: true)]
+endif
+
+
+fs = import('fs')
+wayland_platform_sources = []
+foreach kind, proto_list : wayland_platform_protocols
+    foreach item : proto_list
+        if kind == 'stable'
+            proto_name = item
+            proto_dir = join_paths(wayland_protocols_path, 'stable', item)
+        elif kind == 'unstable' or kind == 'staging'
+            proto_name = '@0@-@1@-v@2@'.format(item[0], kind, item[1])
+            proto_dir = join_paths(wayland_protocols_path, 'unstable', item[0])
+        elif kind == 'weston'
+            proto_name = item
+            proto_dir = weston_protocols_path
+        else
+            error('Unknown Wayland protocol type: @0@'.format(kind))
+        endif
+
+        xml_path = join_paths(proto_dir, '@0@.xml'.format(proto_name))
+        if not fs.is_file(xml_path)
+            error('Cannot find protocol @0@, file does not exist: @1@'.format(proto_name, xml_path))
+        endif
+
+        wayland_platform_sources += [custom_target(
+                '@0@-client-header'.format(proto_name),
+                output: '@0@-client.h'.format(proto_name),
+                input: xml_path,
+                command: [wayland_scanner_exe, 'client-header', '@INPUT@', '@OUTPUT@'],
+            ),
+            custom_target(
+                '@0@-protocol-code'.format(proto_name),
+                output: '@0@-protocol.c'.format(proto_name),
+                input: xml_path,
+                command: [wayland_scanner_exe, 'private-code', '@INPUT@', '@OUTPUT@'],
+            ),
+        ]
+    endforeach
+endforeach
+
+wayland_cursor_dep = dependency('wayland-cursor', required: false)
+if wayland_cursor_dep.found()
+    wayland_platform_dependencies += [wayland_cursor_dep]
+    wayland_platform_c_args += ['-DCOG_USE_WAYLAND_CURSOR=1']
+endif
+
+wayland_platform_plugin = shared_module('cogplatform-wl',
+    'cog-im-context-wl-v1.c',
+    'cog-im-context-wl.c',
+    'cog-platform-wl.c',
+    'cog-popup-menu-wl.c',
+    'os-compatibility.c',
+    wayland_platform_sources,
+    c_args: wayland_platform_c_args,
+    dependencies: wayland_platform_dependencies,
+    gnu_symbol_visibility: 'hidden',
+    install_dir: plugin_path,
+    install: true,
+)
+platform_plugin_targets += [wayland_platform_plugin]

--- a/platform/x11/meson.build
+++ b/platform/x11/meson.build
@@ -1,0 +1,16 @@
+x11_platform_plugin = shared_module('cogplatform-x11',
+    'cog-platform-x11.c',
+    c_args: ['-DG_LOG_DOMAIN="Cog-X11"'],
+    dependencies: [
+        wpebackend_fdo_dep,
+        cogplatformcommon_dep,
+        dependency('egl'),
+        dependency('xcb'),
+        dependency('xkbcommon-x11'),
+        dependency('x11-xcb'),
+    ],
+    gnu_symbol_visibility: 'hidden',
+    install_dir: plugin_path,
+    install: true,
+)
+platform_plugin_targets += [x11_platform_plugin]


### PR DESCRIPTION
- [x] Replicate existing CMake functionality without major changes.

I will leave the following for follow-up patches:

- [ ] Add CI configuration.
- [ ] Remove CMake build system.
- [ ] Simplify/cleanup where possible.
- [ ] Add support for `meson devenv` ([docs](https://mesonbuild.com/Commands.html#devenv)) when using Meson 0.58+

The reason is that I would like to have the Meson build system landed _first_ without removing the CMake one, to avoid having a gap of time between with failed WebKit builds after removing the CMake build system and before landing the needed changes on the WebKit repository to start using Meson.