### PR TITLE
launcher: Only include proxy options if supported

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -162,12 +162,6 @@ else()
     set(HAVE_WEBKIT_MEM_PRESSURE_API 0)
 endif()
 
-if (WebKit_VERSION VERSION_GREATER_EQUAL 2.32.0)
-    set(HAVE_WEBKIT_NETWORK_PROXY_API 1)
-else()
-    set(HAVE_WEBKIT_NETWORK_PROXY_API 0)
-endif()
-
 include(CheckCCompilerFlag)
 check_c_compiler_flag(-Wall HAS_WALL)
 


### PR DESCRIPTION
Recognize `--proxy`/`--ignore-host` only when the version of WebKit being used supports the proxy API. While at it, do the check with `WEBKIT_CHECK_VERSION()` directly in C code, instead of relying on adding more gunk to the CMake build system.

----

It was only after merging https://github.com/Igalia/cog/pull/462 that I noticed that the version check could be done in C, and that usually we prefer to not have CLI options for unsupported features.

WDYT @philn, is there some reason to keep recognizing the CLI flags even if unsupported? Alternatively, we could raise the minimum supported WebKit version to 2.32, and avoid the conditional compilation.