### PR TITLE
Clean up the code of some warnings produced by Clang 14

### DIFF
--- a/core/cog-directory-files-handler.h
+++ b/core/cog-directory-files-handler.h
@@ -16,9 +16,6 @@
 
 G_BEGIN_DECLS
 
-typedef struct _GFile  GFile;
-typedef struct _GError GError;
-
 #define COG_TYPE_DIRECTORY_FILES_HANDLER  (cog_directory_files_handler_get_type ())
 
 G_DECLARE_FINAL_TYPE (CogDirectoryFilesHandler,

--- a/core/cog-platform.h
+++ b/core/cog-platform.h
@@ -30,9 +30,6 @@ GQuark cog_platform_egl_error_quark (void);
 #define COG_PLATFORM_WPE_ERROR  (cog_platform_wpe_error_quark ())
 GQuark cog_platform_wpe_error_quark (void);
 
-typedef struct _WebKitInputMethodContext WebKitInputMethodContext;
-typedef struct _WebKitWebViewBackend WebKitWebViewBackend;
-
 typedef enum {
     COG_PLATFORM_WPE_ERROR_INIT,
 } CogPlatformWpeError;

--- a/core/cog-shell.c
+++ b/core/cog-shell.c
@@ -281,8 +281,6 @@ cog_shell_constructed(GObject *object)
     g_autofree char *cache_dir =
         g_build_filename (g_get_user_cache_dir (), priv->name, NULL);
 
-    g_autoptr(WebKitWebsiteDataManager) manager = NULL;
-
     if (!priv->web_data_manager) {
         if (priv->automated)
             priv->web_data_manager = webkit_website_data_manager_new_ephemeral();

--- a/core/cog-utils.h
+++ b/core/cog-utils.h
@@ -15,8 +15,6 @@
 
 G_BEGIN_DECLS
 
-typedef struct _GObjectClass GObjectClass;
-
 #if !GLIB_CHECK_VERSION(2, 58, 0)
 G_DEFINE_AUTOPTR_CLEANUP_FUNC (GEnumClass, g_type_class_unref)
 #endif // !GLIB_CHECK_VERSION

--- a/platform/wayland/cog-popup-menu-wl.c
+++ b/platform/wayland/cog-popup-menu-wl.c
@@ -11,7 +11,6 @@
 #include <cairo.h>
 #include <sys/mman.h>
 #include <unistd.h>
-#include <wpe/webkit.h>
 
 #include <stdio.h>
 

--- a/platform/wayland/cog-popup-menu-wl.h
+++ b/platform/wayland/cog-popup-menu-wl.h
@@ -7,11 +7,10 @@
 
 #pragma once
 
-#include <glib.h>
 #include <wayland-client.h>
+#include <wpe/webkit.h>
 
 typedef struct _CogPopupMenu CogPopupMenu;
-typedef struct _WebKitOptionMenu WebKitOptionMenu;
 struct wpe_input_pointer_event;
 
 enum {


### PR DESCRIPTION
This includes two commits:

- One removing unneeded forward-declarations of `struct`s which get defined anyway by GLib/GObject/WebKit headers. 
- Removing an unused variable.