### PR TITLE
cmake: Write correct wpe-webkit requirement in .pc file

### DIFF
--- a/core/cogcore.pc.in
+++ b/core/cogcore.pc.in
@@ -6,6 +6,6 @@ Name: cogcore
 Description: Cog Core - WPE WebKit base launcher
 Version: @PROJECT_VERSION@
 
-Requires.private: wpe-webkit-1.0
+Requires: @WPEWEBKIT_PC_NAME@
 Libs: -L${libdir} -lcogcore
 Cflags: -I${includedir}/cog


### PR DESCRIPTION
Arrange for the generated `cogcore.pc` file to include the version of the `wpe-webkit-1.x` dependency, instead of hardcoding `1.0`; this solves issues when Cog was configured against `wpe-webkit-1.1` where the `.pc` file would have the wrong version.

The switch from `Requires.private` to plain `Requires` is needed to let `pkg-config` add the WPE WebKit library in the output for `pkg-config cogcore --libs`, otherwise users need to specify
both `cogcore` and `wpe-webkit-1.x` as dependencies, when using `cogcore` should be enough.