### PR TITLE
core: Add missing dependencies in generated .pc file

### DIFF
--- a/core/meson.build
+++ b/core/meson.build
@@ -75,4 +75,5 @@ import('pkgconfig').generate(
     cogcore_lib,
     description: 'Cog Core - WPE WebKit base launcher',
     subdirs: 'cog',
+    requires: cogcore_dependencies,
 )


### PR DESCRIPTION
Add the Cog core library dependencies as requirements to be listed in the generated `cogcore.pc` file. Otherwise users would need to manually specify e.g. the WPE WebKit library by hand for linking, while it is preferable to have `pkg-config` list it itself.