### PR TITLE
cmake: Fix CMake (v3.16) cannot create ALIAS target "Wpe::FDO" error

### DIFF
--- a/cmake/FindWpeFDO.cmake
+++ b/cmake/FindWpeFDO.cmake
@@ -1,5 +1,5 @@
 find_package (PkgConfig REQUIRED QUIET)
-pkg_check_modules(WpeFDO QUIET wpebackend-fdo-1.0>=1.8.0 IMPORTED_TARGET)
+pkg_check_modules(WpeFDO QUIET wpebackend-fdo-1.0>=1.8.0 GLOBAL IMPORTED_TARGET)
 
 if (TARGET PkgConfig::WpeFDO)
   add_library(Wpe::FDO ALIAS PkgConfig::WpeFDO)


### PR DESCRIPTION
... because target "PkgConfig::WpeFDO" is imported but not globally visible in cmake/FindWpeFDO.cmake.

Notice that this issue is not reproducible in CMake v3.22.

CMake doc [1][2] says:

```
The scope of the definition of an IMPORTED target is the directory
where it was defined. It may be accessed and used from
subdirectories, but not from parent directories or sibling directories.
The scope is similar to the scope of a cmake variable.

It is also possible to define a GLOBAL IMPORTED target which is
accessible globally in the buildsystem.
```

[1] 3.16: https://cmake.org/cmake/help/v3.16/manual/cmake-buildsystem.7.html#imported-targets
[2] latest: https://cmake.org/cmake/help/latest/manual/cmake-buildsystem.7.html#imported-targets


**Note:** _Target branch is cog-0.14 since there is not longer CMake rules in the master branch._