### PR TITLE
Fix build without gamepad manette

### DIFF
--- a/core/cog-gamepad.c
+++ b/core/cog-gamepad.c
@@ -34,7 +34,9 @@ static const struct CogGamepadBackend {
 
 /* selected gamepad backend interfaces */
 static const struct CogGamepadBackend       *s_backend = &s_gamepad_backends[0];
+#if COG_ENABLE_GAMEPAD_MANETTE
 static struct wpe_gamepad_provider_interface s_provider_interface;
+#endif
 
 void
 cog_gamepad_set_backend(const char *name)
@@ -69,11 +71,13 @@ cog_gamepad_setup(GamepadProviderGetViewBackend *gamepad_get_view)
     if (!s_backend->provider)
         return;
 
+#if COG_ENABLE_GAMEPAD_MANETTE
     /* to add gamepad_get_view, use a non-const temporal provider interface */
     s_provider_interface = (struct wpe_gamepad_provider_interface) * s_backend->provider;
     s_provider_interface.get_view_backend = gamepad_get_view;
 
     wpe_gamepad_set_handler(&s_provider_interface, s_backend->device);
+#endif
 
     initialized = true;
 }


### PR DESCRIPTION
Fixes:
```c
../core/cog-gamepad.c: In function ‘cog_gamepad_setup’: ../core/cog-gamepad.c:73:68: error: invalid use of undefined type ‘const struct wpe_gamepad_provider_interface’
   73 |     s_provider_interface = (struct wpe_gamepad_provider_interface) * s_backend->provider;
      |                                                                    ^
../core/cog-gamepad.c:73:26: error: ‘s_provider_interface’ has an incomplete type ‘struct wpe_gamepad_provider_interface’
   73 |     s_provider_interface = (struct wpe_gamepad_provider_interface) * s_backend->provider;
      |                          ^
../core/cog-gamepad.c:74:25: error: invalid use of undefined type ‘struct wpe_gamepad_provider_interface’
   74 |     s_provider_interface.get_view_backend = gamepad_get_view;
      |                         ^
../core/cog-gamepad.c:76:5: warning: implicit declaration of function ‘wpe_gamepad_set_handler’ [-Wimplicit-function-declaration]
   76 |     wpe_gamepad_set_handler(&s_provider_interface, s_backend->device);
      |     ^~~~~~~~~~~~~~~~~~~~~~~
../core/cog-gamepad.c: At top level:
../core/cog-gamepad.c:37:46: error: storage size of ‘s_provider_interface’ isn’t known
   37 | static struct wpe_gamepad_provider_interface s_provider_interface;
      |                                              ^~~~~~~~~~~~~~~~~~~~
```
