### PR TITLE
meson: Build in C11 mode by default

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -3,7 +3,7 @@ project('cog', 'c',
     default_options: [
         'buildtype=debugoptimized',
         'b_ndebug=if-release',
-        'c_std=c99',
+        'c_std=c11',
     ],
     license: 'MIT',
     version: '0.17.0',


### PR DESCRIPTION
Set up the compiler to build in C11 mode by default. This should be fine, the specification has been around for >10 years and any compiler capable of building WebKit and the rest of the dependencies supports C11 anyway.

Fixes #498