### PR TITLE
wl: Fix libdrm dependency when protocols are used

### DIFF
--- a/platform/wayland/meson.build
+++ b/platform/wayland/meson.build
@@ -67,7 +67,7 @@ if wayland_platform_weston_protocols.length() > 0
 
     # The code uses definitions from the drm_fourcc.h header, but does not
     # need to link the library; libdrm here is only a build-time dependency.
-    wayland_platform_dependencies += [dependency('libdrm').partial_dependency(includes: true)]
+    wayland_platform_dependencies += [dependency('libdrm').partial_dependency(compile_args: true)]
 endif
 
 


### PR DESCRIPTION
As the comment says, cog-platform-wl.c needs drm_fourcc.h to build properly when wayland_weston_direct_display is enabled.

However, libdrm.pc doesn't specify "include/libdrm" as part of its includedir but whether in its cflags. So use the compile_args dep instead of includes to fix the build failure.

Signed-off-by: Gary Bisson <gary.bisson@boundarydevices.com>