### PR TITLE
utils: add missing stdint.h include

### DIFF
--- a/core/cog-utils.c
+++ b/core/cog-utils.c
@@ -9,6 +9,7 @@
 #include <errno.h>
 #include <gio/gio.h>
 #include <libsoup/soup.h>
+#include <stdint.h>
 #include <stdlib.h>
 #include <string.h>
 


### PR DESCRIPTION
needed for int64_t

```
ninja: job failed: clang -Icore/libcogcore.so.9.2.0.p -Icore -I../core -I/usr/include/wpe-webkit-1.1 -I/usr/include/glib-2.0 -I/usr/lib/glib-2.0/include -I/usr/include/libsoup-3.0 -I/usr/include/libmount -I/usr/include/blkid -I/usr/include/wpe-1.0 -I/usr/include/libdrm -I/usr/include/libmanette -fcolor-diagnostics -D_FILE_OFFSET_BITS=64 -Wall -Winvalid-pch -std=c11 -O2 -g -DCOG_INSIDE_COG__=1 -DCOG_USE_SOUP2=0 -O3 -flto=thin -march=native -fPIC -fstack-clash-protection -fstack-protector-strong -fcf-protection -pipe -fomit-frame-pointer -fno-plt -fdiagnostics-color=always -O3 -flto=thin -DNDEBUG -march=native -fPIC -fstack-clash-protection -fstack-protector-strong -fcf-protection -fomit-frame-pointer -fno-plt -fdiagnostics-color=always -fPIC -pthread -DWPE_ENABLE_XKB=1 '-DG_LOG_DOMAIN="Cog-Core"' -MD -MQ core/libcogcore.so.9.2.0.p/cog-utils.c.o -MF core/libcogcore.so.9.2.0.p/cog-utils.c.o.d -o core/libcogcore.so.9.2.0.p/cog-utils.c.o -c ../core/cog-utils.c
/home/demon/src/cog/core/cog-utils.c:238:13: error: use of undeclared identifier 'int64_t'
            int64_t prop_value = g_ascii_strtoll (value, &end, 0);
```