### PR TITLE
Add support for weston 12 protocols

### DIFF
--- a/platform/wayland/meson.build
+++ b/platform/wayland/meson.build
@@ -48,6 +48,7 @@ wayland_protocols_path = wayland_protocols_dep.get_variable(pkgconfig: 'pkgdatad
 
 if wayland_platform_weston_protocols.length() > 0
     foreach weston_dep_name : [
+            'libweston-12-protocols',
             'libweston-11-protocols',
             'libweston-10-protocols',
             'libweston-9-protocols',


### PR DESCRIPTION
Weston 11 was released recently and the weston development branch is now using libweston-12-protocols.