### PR TITLE
Fix typos in errors, warnings, help strings, comments and docs

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -37,7 +37,7 @@
 
 - core: Fix platform plug-ins not being found due to COG_MODULEDIR being
   incorrectly defined as a relative path at build configuration time.
-- gtk4: Fix handling of mouse events when teh device scale factor changes.
+- gtk4: Fix handling of mouse events when the device scale factor changes.
 - gtk4: Improve compatibility with more graphics drivers by marking shaders
   as compatible with all GLSL versions.
 

--- a/core/cog-directory-files-handler.c
+++ b/core/cog-directory-files-handler.c
@@ -116,7 +116,7 @@ on_file_query_info_async_completed (GObject      *source_object,
                            g_steal_pointer (&request));
     } else if (type == G_FILE_TYPE_DIRECTORY) {
         /*
-         * If the requst has been marked, it means this function is being
+         * If the request has been marked, it means this function is being
          * called after having previously found a directory. In that case,
          * do not try to resolve "index.html" a second time and produce
          * an error instead.
@@ -403,7 +403,7 @@ cog_directory_files_handler_class_init (CogDirectoryFilesHandlerClass *klass)
      * Number of leading path components to strip (ignore) at the beginning
      * of request URIs.
      *
-     * For example, when set to `2`, a  request for an URI with path
+     * For example, when set to `2`, a  request for a URI with path
      * `/a/b/c/d.html` will ignore the `/a/b` prefix and search for `c/d.html`.
      */
     s_properties[PROP_STRIP_COMPONENTS] =

--- a/core/cog-platform.c
+++ b/core/cog-platform.c
@@ -78,7 +78,7 @@ cog_platform_new(const char *name, GError **error)
 
     if (platform_type == G_TYPE_INVALID) {
         g_set_error_literal(error, COG_PLATFORM_ERROR, COG_PLATFORM_ERROR_NO_MODULE,
-                            "Could not find an usable platform module");
+                            "Could not find a usable platform module");
         return NULL;
     }
 

--- a/core/cog-utils.c
+++ b/core/cog-utils.c
@@ -99,11 +99,11 @@ cog_uri_guess_internal(const char *utf8_uri_like)
 
 /**
  * cog_uri_guess_from_user_input:
- * @uri_like: String containing an URI-like value.
+ * @uri_like: String containing a URI-like value.
  * @is_cli_arg: Whether the URI-like string is from a command line option.
  * @error: (out) (nullable): Location where to store an error, if any.
  *
- * Tries to assemble a valid URI from input that resembles an URI.
+ * Tries to assemble a valid URI from input that resembles a URI.
  *
  * First, if `is_cli_arg` is set, the input string is converted to UTF-8.
  * Then, the following heuristics may applied:
@@ -111,11 +111,11 @@ cog_uri_guess_internal(const char *utf8_uri_like)
  * - If the input is already a valid URI with a known scheme, return it as-is.
  * - If the input is a relative path, or resembles a local file path, try to
  *   resolve it to a full path and return a `file://` URI.
- * - If an URI does not have any path, set `/` as the path.
+ * - If a URI does not have any path, set `/` as the path.
  * - As a last resort, try to prepend the `http://` scheme.
  *
  * The main use case for this function is turning some “simpler” version
- * of an URI, as typically entered by an user in a browser URL entry
+ * of a URI, as typically entered by a user in a browser URL entry
  * (e.g. `wpewebkit.org/release`) and turn it into an actual
  * URI (`http://wpewebkit.org/release/`) which can be then passed to
  * [method@WebKit.WebView.load_uri].
@@ -147,7 +147,7 @@ cog_uri_guess_from_user_input (const char *uri_like,
     }
 
     // At this point we know that we have been given a shorthand without an
-    // URI scheme, or something that cannot be parsed as an URI: try to find
+    // URI scheme, or something that cannot be parsed as a URI: try to find
     // a local file, otherwise add http:// as the scheme.
     g_autoptr(GFile) file = is_cli_arg
         ? g_file_new_for_commandline_arg (uri_like)

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -2,7 +2,7 @@ Title: Overview
 
 # Overview
 
-Cog is both an utility library (`cogcore`) for developing applications which
+Cog is both a utility library (`cogcore`) for developing applications which
 embed the [WPE WebKit][wpewebkit] web rendering engine and a reference
 launcher (`cog`, a minimal browser) which is suitable to be used as a web
 application container. Cog is released under the terms of the [MIT/X11

--- a/launcher/cog-launcher.c
+++ b/launcher/cog-launcher.c
@@ -903,7 +903,7 @@ cog_launcher_add_mem_pressure_option_entries(CogLauncher *self)
                            "  and thresholds relative to the limit which determine at which points memory\n"
                            "  will be reclaimed. The conservative threshold is typically lower when reached\n"
                            "  memory will be reclaimed; the strict threshold works in the same way but the\n"
-                           "  process is more aggresive. The kill threshold configures when worker processes\n"
+                           "  process is more aggressive. The kill threshold configures when worker processes\n"
                            "  will be forcibly killed. Note that if there is no memory limit set, the other\n"
                            "  settings are ignored.\n",
                            "Options to configure memory usage limits",

--- a/launcher/cogctl.c
+++ b/launcher/cogctl.c
@@ -271,7 +271,7 @@ cmd_find_by_name (const char *name)
         },
         {
             .name = "open",
-            .desc = "Open an URL",
+            .desc = "Open a URL",
             .handler = cmd_open,
         },
         {

--- a/platform/wayland/os-compatibility.c
+++ b/platform/wayland/os-compatibility.c
@@ -95,7 +95,7 @@ create_tmpfile_cloexec(char *tmpname)
  *
  * If the C library implements posix_fallocate(), it is used to
  * guarantee that disk space is available for the file at the
- * given size. If disk space is insufficent, errno is set to ENOSPC.
+ * given size. If disk space is insufficient, errno is set to ENOSPC.
  * If posix_fallocate() is not supported, program may receive
  * SIGBUS on accessing mmap()'ed file contents instead.
  *

--- a/platform/x11/cog-platform-x11.c
+++ b/platform/x11/cog-platform-x11.c
@@ -639,7 +639,7 @@ init_egl (void)
 
     if (!epoxy_has_egl_extension(s_display->egl.display, "EGL_EXT_platform_x11"))
         g_warning("eglGetPlatformDisplayEXT() returned a display, but "
-                  "EGL_EXT_platform_x11 is mising. Continuing anyway, but things may break unexpectedly.");
+                  "EGL_EXT_platform_x11 is missing. Continuing anyway, but things may break unexpectedly.");
 
     if (!eglInitialize (s_display->egl.display, NULL, NULL))
         return FALSE;


### PR DESCRIPTION
Motivated by various occurrences of "a"/"an" mix-ups in errors (it's "an" before a vowel _sound_, not before a written vowel in general), I ran [codespell](https://github.com/codespell-project/codespell) and fixed all typos it found. I was unsure whether to squash them all into a single commit, so I separated code, comments, docs and NEWS. I'm happy to change that if suggested.