### PR TITLE
Drop support for wpe-webkit-1.1, build only for libsoup 3 by default, and don't try to enable sandbox when using new WebKit API

### DIFF
--- a/launcher/cog-launcher.c
+++ b/launcher/cog-launcher.c
@@ -53,7 +53,9 @@ static struct {
     } on_failure;
     char    *web_extensions_dir;
     gboolean ignore_tls_errors;
+#if !COG_USE_WPE2
     gboolean enable_sandbox;
+#endif
     gboolean automation;
 #if HAVE_WEBKIT_NETWORK_PROXY_API
     char    *proxy;
@@ -362,7 +364,9 @@ cog_launcher_startup(GApplication *application)
     if (s_options.web_extensions_dir)
         webkit_web_context_set_web_extensions_directory(cog_shell_get_web_context(self->shell),
                                                         s_options.web_extensions_dir);
+#if !COG_USE_WPE2
     webkit_web_context_set_sandbox_enabled(cog_shell_get_web_context(self->shell), s_options.enable_sandbox);
+#endif
 
     g_object_set(self->shell, "device-scale-factor", s_options.device_scale_factor, NULL);
 
@@ -1025,8 +1029,10 @@ static GOptionEntry s_cli_options[] = {
      "Ignore TLS errors (default: disabled).", NULL},
     {"content-filter", 'F', 0, G_OPTION_ARG_FILENAME, &s_options.filter_path,
      "Path to content filter JSON rule set (default: none).", "PATH"},
+#if !COG_USE_WPE2
     {"enable-sandbox", 's', 0, G_OPTION_ARG_NONE, &s_options.enable_sandbox,
      "Enable WebProcess sandbox (default: disabled).", NULL},
+#endif
     {"automation", '\0', 0, G_OPTION_ARG_NONE, &s_options.automation, "Enable automation mode (default: disabled).",
      NULL},
 #if HAVE_WEBKIT_NETWORK_PROXY_API

--- a/meson.build
+++ b/meson.build
@@ -79,31 +79,13 @@ with_x11_platform = platform_plugins.contains('x11')
 
 with_programs = get_option('programs')
 
-# Prefer using API 2.0 level if available.
-wpewebkit_soup3_dep_info = [
-    ['wpe-webkit-2.0', '>=2.39.0'],
-    ['wpe-webkit-1.1', '>=2.33.1'],
-]
-
-with_soup2 = get_option('soup2').enabled()
-if get_option('soup2').auto()
-    with_soup2 = true
-    foreach dep_info : wpewebkit_soup3_dep_info
-        dep_found = dependency(dep_info[0], version: dep_info[1], required: false).found()
-        if dep_found
-            with_soup2 = false
-            break
-        endif
-    endforeach
-endif
-
 cog_launcher_appid = get_option('cog_appid')
 cog_launcher_home_uri = get_option('cog_home_uri')
 cog_launcher_system_bus = with_programs and get_option('cog_dbus_control') == 'system'
 
 add_project_arguments('-DCOG_INSIDE_COG__=1', language: 'c')
 
-if with_soup2
+if get_option('soup2').enabled()
     add_project_arguments('-DCOG_USE_SOUP2=1', language: 'c')
     libsoup_dep = dependency('libsoup-2.4')
     gio_dep = dependency('gio-2.0', version: '>=2.44')
@@ -112,13 +94,7 @@ else
     add_project_arguments('-DCOG_USE_SOUP2=0', language: 'c')
     libsoup_dep = dependency('libsoup-3.0', version: '>=2.99.7')
     gio_dep = dependency('gio-2.0', version: '>=2.67.4')
-    foreach dep_info : wpewebkit_soup3_dep_info
-        wpewebkit_dep = dependency(dep_info[0], version: dep_info[1], required: false)
-        if wpewebkit_dep.found()
-            break
-        endif
-    endforeach
-    assert(wpewebkit_dep.found())
+    wpewebkit_dep = dependency('wpe-webkit-2.0', version: '>=2.39.0')
 endif
 
 if cog_launcher_system_bus

--- a/meson.build
+++ b/meson.build
@@ -87,11 +87,13 @@ add_project_arguments('-DCOG_INSIDE_COG__=1', language: 'c')
 
 if get_option('soup2').enabled()
     add_project_arguments('-DCOG_USE_SOUP2=1', language: 'c')
+    add_project_arguments('-DCOG_USE_WPE2=0', language: 'c')
     libsoup_dep = dependency('libsoup-2.4')
     gio_dep = dependency('gio-2.0', version: '>=2.44')
     wpewebkit_dep = dependency('wpe-webkit-1.0', version: '>=2.28.0')
 else
     add_project_arguments('-DCOG_USE_SOUP2=0', language: 'c')
+    add_project_arguments('-DCOG_USE_WPE2=1', language: 'c')
     libsoup_dep = dependency('libsoup-3.0', version: '>=2.99.7')
     gio_dep = dependency('gio-2.0', version: '>=2.67.4')
     wpewebkit_dep = dependency('wpe-webkit-2.0', version: '>=2.39.0')

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -19,7 +19,7 @@ option(
 option(
     'soup2',
     type: 'feature',
-    value: 'auto',
+    value: 'disabled',
     description: 'Build with libsoup2 instead of libsoup3'
 )
 


### PR DESCRIPTION
This will allow building cog after https://github.com/WebKit/WebKit/pull/5944/