### PR TITLE
headless: Allow configuring the maximum refresh rate

### DIFF
--- a/docs/platform-headless.md
+++ b/docs/platform-headless.md
@@ -1,3 +1,22 @@
 Title: Platform: Headless
 
 # Headless Platform
+
+## Requirements
+
+The headless platform plug-in additionally requires the following libraries:
+
+- **WPEBackend-fdo**
+
+
+## Parameters
+
+The only parameter accepted by the plug-in is a single unsigned number, used
+to configure the maximum allowed refresh rate in frames per second (FPS/Hz);
+the default value is 30 Hz.
+
+The following example sets the maximum refresh rate to 60 Hz:
+
+```sh
+cog --platform=headless --platform-params=60 ...
+```


### PR DESCRIPTION
Recognize the parameters string as the maximum frame rate (FPS/Hz) at which frames are acknowledged.