### PR TITLE
CI: Avoid duplicated jobs on pull requests

### DIFF
--- a/.github/workflows/ci-cross.yml
+++ b/.github/workflows/ci-cross.yml
@@ -1,6 +1,15 @@
 ---
 name: "Build - ARM"
-on: [pull_request, push]
+
+on:
+  push:
+    branches:
+    - master
+    - 'cog-*'
+  pull_request:
+    branches:
+    - master
+    - 'cog-*'
 
 jobs:
   build:

--- a/.github/workflows/ci-native.yml
+++ b/.github/workflows/ci-native.yml
@@ -1,6 +1,15 @@
 ---
 name: "Build - Native"
-on: [pull_request, push]
+
+on:
+  push:
+    branches:
+    - master
+    - 'cog-*'
+  pull_request:
+    branches:
+    - master
+    - 'cog-*'
 
 jobs:
   build:

--- a/.github/workflows/codestyle.yml
+++ b/.github/workflows/codestyle.yml
@@ -1,6 +1,10 @@
 ---
 name: Code Style
-on: [pull_request]
+on:
+  pull_request:
+    branches:
+    - master
+    - 'cog-*'
 
 jobs:
   check:


### PR DESCRIPTION
Restrict `push` jobs to development branch and release branches, to avoid having a duplicate set of CI jobs when filing a PR associated to the push event to the branch from which the PR was created. Also, restrict `pull_request` jobs to those PRs targeting the same set of branches.