### PR TITLE
x11, wl: Make scroll wheel behaviour snappier

### DIFF
--- a/platform/wayland/cog-platform-wl.c
+++ b/platform/wayland/cog-platform-wl.c
@@ -974,23 +974,28 @@ pointer_uses_frame_event(struct wl_pointer *pointer)
 #endif
 }
 
+/*
+ * Wayland reports axis events as being 15 units per scroll wheel step. Scale
+ * values in order to match the 120 value used in the X11 plug-in and by the
+ * libinput_event_pointer_get_scroll_value_v120() function.
+ */
+enum {
+    SCROLL_WHEEL_STEP_SCALING_FACTOR = 8,
+};
+
 static void
-pointer_on_axis (void* data,
-                 struct wl_pointer *pointer,
-                 uint32_t time,
-                 uint32_t axis,
-                 wl_fixed_t value)
+pointer_on_axis(void *data, struct wl_pointer *pointer, uint32_t time, uint32_t axis, wl_fixed_t value)
 {
     if (axis == WL_POINTER_AXIS_VERTICAL_SCROLL) {
         wl_data.axis.has_delta = true;
         wl_data.axis.time = time;
-        wl_data.axis.y_delta += value;
+        wl_data.axis.y_delta += value * SCROLL_WHEEL_STEP_SCALING_FACTOR;
     }
 
     if (axis == WL_POINTER_AXIS_HORIZONTAL_SCROLL) {
         wl_data.axis.has_delta = true;
         wl_data.axis.time = time;
-        wl_data.axis.x_delta += value;
+        wl_data.axis.x_delta += value * SCROLL_WHEEL_STEP_SCALING_FACTOR;
     }
 
     if (!pointer_uses_frame_event(pointer))

--- a/platform/x11/cog-platform-x11.c
+++ b/platform/x11/cog-platform-x11.c
@@ -255,14 +255,26 @@ xcb_handle_axis(xcb_button_press_event_t *event, const int16_t axis_delta[2])
 }
 
 static void
-xcb_handle_button_press (xcb_button_press_event_t *event)
+xcb_handle_button_press(xcb_button_press_event_t *event)
 {
-    static const int16_t axis_delta[4][2] = {
-        {   0, -20 },
-        {   0,  20 },
-        { -20,   0 },
-        {  20,   0 },
+    /*
+     * Match the multiplier value used e.g. by libinput when using
+     * libinput_event_pointer_get_scroll_value_v120(), which in turn is
+     * based on a design document by Microsoft about enhanced mouse wheel
+     * support.
+     */
+    enum {
+        SCROLL_WHEEL_STEP_SIZE = 120,
     };
+
+    /* clang-format off */
+    static const int16_t axis_delta[4][2] = {
+        {  0,  SCROLL_WHEEL_STEP_SIZE },
+        {  0, -SCROLL_WHEEL_STEP_SIZE },
+        {  SCROLL_WHEEL_STEP_SIZE,  0 },
+        { -SCROLL_WHEEL_STEP_SIZE,  0 },
+    };
+    /* clang-format on */
 
     switch (event->detail) {
     case 1:


### PR DESCRIPTION
Adjust the amount of page scrolled when receiving scroll wheel events to make scrolling feel snappier in the Wayland and X11 platforms snappier. The 120 step value comes from the fact that libinput includes the `libinput_event_pointer_get_scroll_value_v120()` function, which in turn is based on a recommendation contained in a design document written by Microsoft.

Also, the table of deltas for X11 has its values reversed, to make the scroll feel more natural, i.e. "pulling" a scroll wheel makes the page scroll downwards. This matches defaults in common desktop environments.