### PR TITLE
Fix touch limit raw region when  rotate screen

### DIFF
--- a/platform/drm/cog-platform-drm.c
+++ b/platform/drm/cog-platform-drm.c
@@ -1201,6 +1201,11 @@ init_input(CogDrmPlatform *platform)
     input_data.input_width = drm_data.mode->hdisplay;
     input_data.input_height = drm_data.mode->vdisplay;
 
+    if (platform->rotation == COG_GL_RENDERER_ROTATION_90 || platform->rotation == COG_GL_RENDERER_ROTATION_270){
+        input_data.input_width = drm_data.mode->vdisplay;
+        input_data.input_height = drm_data.mode->hdisplay;
+    }
+
     for (int i = 0; i < G_N_ELEMENTS (input_data.touch_points); ++i) {
         struct wpe_input_touch_event_raw *touch_point = &input_data.touch_points[i];
 


### PR DESCRIPTION
I have a touchscreen:
```
cog -P drm -O renderer=gles,rotation=1
```
but the touchscreen libinput  report `Rotation` is not available 
```
$ libinput list-devices
Device:           Goodix Capacitive TouchScreen
Kernel:           /dev/input/event2
Group:            2
Seat:             seat0, default
Capabilities:     keyboard touch 
Tap-to-click:     n/a
Tap-and-drag:     n/a
Tap drag lock:    n/a
Left-handed:      n/a
Nat.scrolling:    n/a
Middle emulation: n/a
Calibration:      identity matrix
Scroll methods:   none
Click methods:    none
Disable-w-typing: n/a
Disable-w-trackpointing: n/a
Accel profiles:   n/a
Rotation:         n/a
```
so I rotate touchscreen use device tree,then touch limit raw region when  rotate screen,this patch fix it when rotate angle  on 90 or 270.

By the way,I use  device tree rotate the display pannel,but I use weston or gnome not need rotate again like cog. so maybe some thing not right on cog.