### PR TITLE
Allow to pass the values for platform and platform-params via env vars.

### DIFF
--- a/data/cog.1
+++ b/data/cog.1
@@ -68,6 +68,9 @@ white)
 .B \-P,\ \-\-platform=NAME
 Platform plug-in to use.
 .TP
+.B \-O,\ \-\-platform-params=PARAMETERS
+Comma separated list of platform parameters.
+.TP
 .B \-\-web\-extensions\-dir=PATH
 Load Web Extensions from given directory.
 .TP
@@ -78,6 +81,12 @@ Load JSON file as a content filter.
 .PP
 .B COG_URL
 URL of the website to be opened
+.PP
+.B COG_PLATFORM_NAME
+Platform plug-in to use
+.PP
+.B COG_PLATFORM_PARAMS
+Comma separated list of platform parameters.
 
 .SH SEE ALSO
 .BR cogctl (1)


### PR DESCRIPTION
On some cases it is useful to be able to specify the Cog platform plugin and the platform parameters via environment variables.

For example: bots running CI tests may be executing the same command to start Cog but each bot can be configured to use a different platform plugin via enviroment variables.

Another example: The script `run-benchmark` from WebKit doesn't allow the user to pass custom command-line parameters to the browser, so with this environment variables the user should be able to select the platform parameters for Cog via the environment.