### PR TITLE
Ensure to free the GOption values that will not longer be needed

### DIFF
--- a/launcher/cog-launcher.c
+++ b/launcher/cog-launcher.c
@@ -313,6 +313,7 @@ cog_launcher_create_view(CogLauncher *self, CogShell *shell)
         else
             g_error("'%s' doesn't represent a valid #RRGGBBAA or CSS color format.", s_options.background_color);
     }
+    g_clear_pointer(&s_options.background_color, g_free);
 
     switch (s_options.on_failure.action_id) {
     case WEBPROCESS_FAIL_ERROR_PAGE:
@@ -380,6 +381,7 @@ cog_launcher_startup(GApplication *application)
                                                         s_options.web_extensions_dir);
     webkit_web_context_set_sandbox_enabled(cog_shell_get_web_context(self->shell), s_options.enable_sandbox);
 #endif
+    g_clear_pointer(&s_options.web_extensions_dir, g_free);
 
     g_object_set(self->shell, "device-scale-factor", s_options.device_scale_factor, NULL);
 
@@ -1256,8 +1258,7 @@ cog_launcher_handle_local_options(GApplication *application, GVariantDict *optio
         g_printerr("%s: URI '%s' is invalid UTF-8: %s\n", g_get_prgname(), uri, error->message);
         return EXIT_FAILURE;
     }
-    g_strfreev(s_options.arguments);
-    s_options.arguments = NULL;
+    g_clear_pointer(&s_options.arguments, g_strfreev);
 
     /*
      * Validate the supplied local URI handler specification and check
@@ -1293,8 +1294,7 @@ cog_launcher_handle_local_options(GApplication *application, GVariantDict *optio
         *colon = '\0'; /* NULL-terminate the URI scheme name. */
         g_hash_table_insert(handler_map, g_strdup(s_options.dir_handlers[i]), cog_directory_files_handler_new(file));
     }
-    if (s_options.dir_handlers)
-        g_strfreev(s_options.dir_handlers);
+    g_clear_pointer(&s_options.dir_handlers, g_strfreev);
     s_options.handler_map = g_hash_table_size(handler_map) ? g_steal_pointer(&handler_map) : NULL;
 
     s_options.home_uri = g_steal_pointer(&utf8_uri);
@@ -1316,7 +1316,7 @@ cog_launcher_handle_local_options(GApplication *application, GVariantDict *optio
             return EXIT_FAILURE;
         }
 
-        g_free(s_options.config_file);
+        g_clear_pointer(&s_options.config_file, g_free);
         s_options.key_file = g_steal_pointer(&key_file);
     }
 
@@ -1346,6 +1346,8 @@ cog_launcher_handle_local_options(GApplication *application, GVariantDict *optio
 
         g_autoptr(WebKitNetworkProxySettings) webkit_proxy_settings =
             webkit_network_proxy_settings_new(s_options.proxy, (const gchar *const *) s_options.ignore_hosts);
+        g_clear_pointer(&s_options.proxy, g_free);
+        g_clear_pointer(&s_options.ignore_hosts, g_strfreev);
 #    if COG_USE_WPE2
         webkit_network_session_set_proxy_settings(launcher->network_session,
                                                   WEBKIT_NETWORK_PROXY_MODE_CUSTOM,


### PR DESCRIPTION
 * GOptionEntry documentation says the following:

> If arg type is G_OPTION_ARG_STRING or G_OPTION_ARG_FILENAME, the location will contain a newly allocated string if the option was given. That string needs to be freed by the callee using g_free(). Likewise if arg type is G_OPTION_ARG_STRING_ARRAY or G_OPTION_ARG_FILENAME_ARRAY, the data should be freed using g_strfreev().

This PR ensures to free all those types from the GOptionEntries that we currently use. Most of them were already freed but a few of them were missing.

It switches some of them to use [`g_clear_pointer()`](https://docs.gtk.org/glib/func.clear_pointer.html) as that helper function sets the pointer to `NULL` after freeing it. Is also safe to call it with a reference pointing to `NULL`.

There is one GOptionEntry missing on this PR that is `s_options.platform_params` .. that one is fixed at PR #561