### PR TITLE
drm: ignore key event if no xkb context is available

### DIFF
--- a/platform/drm/cog-platform-drm.c
+++ b/platform/drm/cog-platform-drm.c
@@ -689,7 +689,24 @@ static void
 input_dispatch_key_event (uint32_t time, uint32_t key, enum libinput_key_state state)
 {
     struct wpe_input_xkb_context *default_context = wpe_input_xkb_context_get_default ();
+
+    // if wpe is unable to prepare an xkb context (e.g. environment without
+    // any prepared keymap data), ignore the key event
+    if (!default_context)
+        return;
+
+    // libwpe (<=v1.14.1) may provide a broken context; ensure an underlying
+    // xkb_context has been configured
+    struct xkb_context *ctx = wpe_input_xkb_context_get_context(default_context);
+    if (!ctx)
+        return;
+
     struct xkb_state *context_state = wpe_input_xkb_context_get_state (default_context);
+
+    // if wpe cannot determine the xkb state (e.g. required keymap does are not
+    // available in this environment), ignore the key event
+    if (!context_state)
+        return;
 
     uint32_t keysym = wpe_input_xkb_context_get_key_code (default_context, key, !!state);
 


### PR DESCRIPTION
When a key event occurs, Cog will ask WPE from its managed XKB context for an associated key code. If WPE fails to acquire a default XKB context, requests to fetch the state/key-code is undefined. This will cause Cog to fault on a first detected input.

Part of the issue is that `wpe_input_xkb_context_get_default` does not gracefully handle failed attempts to initialize the XKB context \[1\]. Assuming WPE does give Cog proper notice of a fail context, Cog should also limiting attempts to query state information from a context that is not available (assuming Cog desires to handle an inputless environment).

This commit tweaks the key event handling to drop any key event if the XKB context is not available.

\[1\]: https://github.com/WebPlatformForEmbedded/libwpe/pull/126