### PR TITLE
docs: Fix gi-docgen wrong type for GKeyFile warning

### DIFF
--- a/core/cog-webkit-utils.c
+++ b/core/cog-webkit-utils.c
@@ -473,7 +473,7 @@ cog_web_view_connect_default_progress_handlers (WebKitWebView *web_view)
  * @group: Name of a group from the key file.
  * @error: (out) (nullable): Location where to store an error, if any.
  *
- * Reads values from a given `group` of a [class@GLib.KeyFile] object,
+ * Reads values from a given `group` of a [struct@GLib.KeyFile] object,
  * and uses them to set the writable properties of a [class@WebKit.Settings]
  * object.
  *


### PR DESCRIPTION
This fixes the following warning:

    WARNING: Invalid fragment for 'GLib.KeyFile': it should be struct
    Reads values from a given `group` of a [class@GLib.KeyFile] object,
                                           ^~~~~~~~~~~~~~~~~~~~