### PR TITLE
Add a CogFallbackPlatform implementation

### DIFF
--- a/core/cog-fallback-platform.c
+++ b/core/cog-fallback-platform.c
@@ -1,0 +1,84 @@
+/*
+ * cog-fallback-platform.c
+ * Copyright (C) 2023 Igalia S.L.
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#ifdef G_LOG_DOMAIN
+#    undef G_LOG_DOMAIN
+#endif /* G_LOG_DOMAIN */
+
+#define G_LOG_DOMAIN "Cog-Fallback"
+
+#include "cog-fallback-platform.h"
+#include "cog-modules.h"
+#include "cog-platform.h"
+
+struct _CogFallbackPlatformClass {
+    CogPlatformClass parent_class;
+};
+
+struct _CogFallbackPlatform {
+    CogPlatform parent;
+};
+
+G_DECLARE_FINAL_TYPE(CogFallbackPlatform, cog_fallback_platform, COG, FALLBACK_PLATFORM, CogPlatform)
+G_DEFINE_TYPE_WITH_CODE(
+    CogFallbackPlatform, cog_fallback_platform, COG_TYPE_PLATFORM, (void) cog_modules_get_platform_extension_point();
+    g_io_extension_point_implement(COG_MODULES_PLATFORM_EXTENSION_POINT, g_define_type_id, "fallback", 0))
+
+static gboolean
+cog_fallback_platform_is_supported(void)
+{
+    /* The fallback platform is always supported. */
+    return TRUE;
+}
+
+static gboolean
+cog_fallback_platform_setup(CogPlatform *platform, CogShell *shell G_GNUC_UNUSED, const char *params, GError **error)
+{
+    if (params && *params) {
+        static const char *try_formats[] = {
+            "libWPEBackend-%s-1.0.so.1",
+            "libWPEBackend-%s-1.0.so",
+            "libWPEBackend-%s.so.1",
+            "libWPEBackend-%s.so",
+        };
+
+        for (unsigned i = 0; i < G_N_ELEMENTS(try_formats); i++) {
+            g_autofree char *name = g_strdup_printf(try_formats[i], params);
+            if (wpe_loader_init(name)) {
+                g_debug("%s: Backend implementation '%s' loaded.", G_STRFUNC, name);
+                return TRUE;
+            }
+        }
+
+        g_critical("%s: Could not find a suitable backend.", G_STRFUNC);
+        g_set_error(error, G_FILE_ERROR, G_FILE_ERROR_NOENT, "Backend '%s' not found.", params);
+        return FALSE;
+    }
+
+    g_debug("%s: backend implementation library name not specified, using libwpe defaults.", G_STRFUNC);
+    return TRUE;
+}
+
+static WebKitWebViewBackend *
+cog_fallback_platform_get_view_backend(CogPlatform *platform, WebKitWebView *related_view, GError **error)
+{
+    return webkit_web_view_backend_new(wpe_view_backend_create(), NULL, NULL);
+}
+
+static void
+cog_fallback_platform_class_init(CogFallbackPlatformClass *klass)
+{
+    CogPlatformClass *platform_class = COG_PLATFORM_CLASS(klass);
+    platform_class->is_supported = cog_fallback_platform_is_supported;
+    platform_class->setup = cog_fallback_platform_setup;
+    platform_class->get_view_backend = cog_fallback_platform_get_view_backend;
+}
+
+static void
+cog_fallback_platform_init(CogFallbackPlatform *self)
+{
+}

--- a/core/cog-fallback-platform.h
+++ b/core/cog-fallback-platform.h
@@ -1,0 +1,14 @@
+/*
+ * cog-fallback-platform.h
+ * Copyright (C) 2023 Igalia S.L.
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#pragma once
+
+#include <glib-object.h>
+
+G_BEGIN_DECLS
+G_GNUC_INTERNAL GType cog_fallback_platform_get_type(void);
+G_END_DECLS

--- a/core/meson.build
+++ b/core/meson.build
@@ -39,6 +39,7 @@ cogcore_sources = files(
     'cog-host-routes-handler.c',
     'cog-modules.c',
     'cog-platform.c',
+    'cog-fallback-platform.c',
     'cog-prefix-routes-handler.c',
     'cog-request-handler.c',
     'cog-shell.c',

--- a/docs/cog.toml.in
+++ b/docs/cog.toml.in
@@ -47,6 +47,7 @@ content_files = [
     "platform-drm.md",
     "platform-x11.md",
     "platform-headless.md",
+    "platform-fallback.md",
     "webdriver.md",
 ]
 content_images = [

--- a/docs/platform-fallback.md
+++ b/docs/platform-fallback.md
@@ -1,0 +1,25 @@
+Title: Platform: Fallback
+
+# Fallback Platform
+
+## Requirements
+
+The fallback platform plug-in does not have any additional requirement
+at build time. An usable WPE backend must be installed at run time. The
+following are known to work:
+
+- [WPEBackend-rdk](https://github.com/WebPlatformForEmbedded/WPEBackend-rdk)
+
+
+## Parameters
+
+The only parameter accepted by the plug-in is the name of the WPE backend
+library to search for. This is `default` if not specified, which results
+in searching for a shared library named `libWPEBackend-default.so` (and
+a few related variants).
+
+The following example set the WPE backend library to use WPEBackend-rdk:
+
+```sh
+cog --platform=fallback --platform-params=rdk ...
+```

--- a/launcher/cog-launcher.c
+++ b/launcher/cog-launcher.c
@@ -251,11 +251,9 @@ cog_launcher_create_view(CogLauncher *self, CogShell *shell)
 
     g_signal_connect(web_view, "create", G_CALLBACK(on_web_view_create), NULL);
 
-    if (platform) {
-        cog_platform_init_web_view(platform, web_view);
-        g_autoptr(WebKitInputMethodContext) im_context = cog_platform_create_im_context(platform);
-        webkit_web_view_set_input_method_context(web_view, im_context);
-    }
+    cog_platform_init_web_view(platform, web_view);
+    g_autoptr(WebKitInputMethodContext) im_context = cog_platform_create_im_context(platform);
+    webkit_web_view_set_input_method_context(web_view, im_context);
 
     if (s_options.background_color != NULL) {
         WebKitColor color;


### PR DESCRIPTION
This PR includes two commits:

- The first adds a new `CogFallbackPlatform` implementation, which can handle plain WPE backends (like WPEBackend-rdk). This gets built into the core library and thus is always available, instead of building it as a plug-in.
- The second removes the ad-hoc handling of plain WPE backends, which are left to be handled by `CogFallbackPlatform`.