### PR TITLE
core: Introduce a new CogView class

### DIFF
--- a/core/cog-platform.h
+++ b/core/cog-platform.h
@@ -47,6 +47,8 @@ struct _CogPlatformClass {
     WebKitWebViewBackend *(*get_view_backend)(CogPlatform *, WebKitWebView *related_view, GError **);
     void (*init_web_view)(CogPlatform *, WebKitWebView *);
     WebKitInputMethodContext *(*create_im_context)(CogPlatform *);
+
+    GType (*get_view_type)(CogPlatform *self);
 };
 
 void cog_platform_set_default(CogPlatform *);

--- a/core/cog-shell.c
+++ b/core/cog-shell.c
@@ -7,7 +7,7 @@
 
 #include "cog-shell.h"
 
-#include <wpe/webkit.h>
+#include "cog-view.h"
 
 /**
  * CogShell:
@@ -79,7 +79,7 @@ static WebKitWebView*
 cog_shell_create_view_base (CogShell *shell)
 {
     CogShellPrivate *priv = PRIV(shell);
-    return g_object_new(WEBKIT_TYPE_WEB_VIEW, "settings", cog_shell_get_web_settings(shell), "web-context",
+    return g_object_new(cog_view_get_impl_type(), "settings", cog_shell_get_web_settings(shell), "web-context",
                         cog_shell_get_web_context(shell), "is-controlled-by-automation", priv->automated, NULL);
 }
 
@@ -357,16 +357,15 @@ cog_shell_class_init (CogShellClass *klass)
      * Returns: (transfer full) (nullable): A new web view that will be used
      *   by the shell.
      */
-    s_signals[CREATE_VIEW] =
-        g_signal_new ("create-view",
-                      COG_TYPE_SHELL,
-                      G_SIGNAL_RUN_LAST,
-                      G_STRUCT_OFFSET (CogShellClass, create_view),
-                      g_signal_accumulator_first_wins,
-                      NULL,
-                      NULL,
-                      WEBKIT_TYPE_WEB_VIEW,
-                      0);
+    s_signals[CREATE_VIEW] = g_signal_new("create-view",
+                                          COG_TYPE_SHELL,
+                                          G_SIGNAL_RUN_LAST,
+                                          G_STRUCT_OFFSET(CogShellClass, create_view),
+                                          g_signal_accumulator_first_wins,
+                                          NULL,
+                                          NULL,
+                                          COG_TYPE_VIEW,
+                                          0);
 
     /**
      * CogShell:name: (attributes org.gtk.Property.get=cog_shell_get_name):

--- a/core/cog-view.c
+++ b/core/cog-view.c
@@ -1,0 +1,177 @@
+/*
+ * cog-view.c
+ * Copyright (C) 2023 Igalia S.L.
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#include "cog-view.h"
+#include "cog-platform.h"
+
+/**
+ * CogView:
+ *
+ * Convenience base class for web views.
+ *
+ * Most of the functionality dealing with web views when using the
+ * Cog core library uses #CogView instead of [class@WPEWebKit.WebView].
+ * The base class is extended to delegate the creation of its
+ * [struct@WPEWebKit.WebViewBackend] to the current [class@CogPlatform]
+ * implementation. Optionally, platform plug-in implementations can
+ * provide their own view class implementation by overriding
+ * [vfunc@CogPlatform.get_view_type].
+ *
+ * A number of utility functions are also provided.
+ */
+
+G_DEFINE_ABSTRACT_TYPE(CogView, cog_view, WEBKIT_TYPE_WEB_VIEW)
+
+struct _CogCoreViewClass {
+    CogViewClass parent_class;
+};
+
+G_DECLARE_DERIVABLE_TYPE(CogCoreView, cog_core_view, COG, CORE_VIEW, CogView)
+G_DEFINE_TYPE(CogCoreView, cog_core_view, COG_TYPE_VIEW)
+
+static GObject *
+cog_view_constructor(GType type, unsigned n_properties, GObjectConstructParam *properties)
+{
+    GObject *object = G_OBJECT_CLASS(cog_view_parent_class)->constructor(type, n_properties, properties);
+
+    CogViewClass *view_class = COG_VIEW_GET_CLASS(object);
+    if (view_class->create_backend) {
+        WebKitWebViewBackend *backend = (*view_class->create_backend)((CogView *) object);
+
+        GValue backend_value = G_VALUE_INIT;
+        g_value_take_boxed(g_value_init(&backend_value, WEBKIT_TYPE_WEB_VIEW_BACKEND), backend);
+        g_object_set_property(object, "backend", &backend_value);
+    } else {
+        g_error("Type %s did not define the create_backend vfunc", g_type_name(type));
+    }
+
+    return object;
+}
+
+static void
+cog_view_class_init(CogViewClass *klass)
+{
+    GObjectClass *object_class = G_OBJECT_CLASS(klass);
+    object_class->constructor = cog_view_constructor;
+}
+
+static void
+cog_view_init(CogView *self)
+{
+}
+
+/**
+ * cog_view_get_backend:
+ * @self: A view.
+ *
+ * Get the backend for the view.
+ *
+ * Returns: (transfer none) (not nullable): The WPE view backend for the view.
+ */
+struct wpe_view_backend *
+cog_view_get_backend(CogView *self)
+{
+    g_return_val_if_fail(COG_IS_VIEW(self), NULL);
+
+    WebKitWebViewBackend *backend = webkit_web_view_get_backend(WEBKIT_WEB_VIEW(self));
+    return webkit_web_view_backend_get_wpe_backend(backend);
+}
+
+static void *
+_cog_view_get_impl_type_init(GType *type)
+{
+    *type = cog_core_view_get_type();
+
+    CogPlatform *platform = cog_platform_get_default();
+    if (platform) {
+        CogPlatformClass *platform_class = COG_PLATFORM_GET_CLASS(platform);
+        if (platform_class->get_view_type) {
+            GType view_type = (*platform_class->get_view_type)(platform);
+            *type = view_type;
+        }
+    }
+
+    g_debug("%s: using %s", G_STRFUNC, g_type_name(*type));
+    return NULL;
+}
+
+/**
+ * cog_view_get_impl_type:
+ *
+ * Get the type of the web view implementation in use.
+ *
+ * This function always returns a valid type. If the If the active
+ * [class@CogPlatform] does not provide a custom view type, the default
+ * built-in type included as part of the Cog core library is returned.
+ *
+ * When creating web views, this function must be used to retrieve the
+ * type to use, e.g.:
+ *
+ * ```c
+ * WebKitWebView *view = g_object_new(cog_view_get_impl_type(), NULL);
+ * ```
+ *
+ * In most cases it should be possible to use the convenience function
+ * [ctor@View.new], which uses this function internally.
+ *
+ * Returns: Type of the view implementation in use.
+ */
+GType
+cog_view_get_impl_type(void)
+{
+    static GType view_type;
+    static GOnce once = G_ONCE_INIT;
+
+    g_once(&once, (GThreadFunc) _cog_view_get_impl_type_init, &view_type);
+
+    return view_type;
+}
+
+/**
+ * cog_view_new: (constructor)
+ * @first_property_name: Name of the first property.
+ * @...: Value of the first property, followed optionally by more name/value
+ *    pairs, followed by %NULL.
+ *
+ * Creates a new instance of a view implementation and sets its properties.
+ *
+ * Returns: (transfer full): A new web view.
+ */
+CogView *
+cog_view_new(const char *first_property_name, ...)
+{
+    va_list args;
+    va_start(args, first_property_name);
+    void *view = g_object_new_valist(cog_view_get_impl_type(), first_property_name, args);
+    va_end(args);
+    return view;
+}
+
+static WebKitWebViewBackend *
+cog_core_view_create_backend(CogView *view G_GNUC_UNUSED)
+{
+    g_autoptr(GError) error = NULL;
+
+    WebKitWebViewBackend *backend = cog_platform_get_view_backend(cog_platform_get_default(), NULL, &error);
+    if (!backend)
+        g_error("%s: Could not create view backend, %s", G_STRFUNC, error->message);
+
+    g_debug("%s: backend %p", G_STRFUNC, backend);
+    return backend;
+}
+
+static void
+cog_core_view_class_init(CogCoreViewClass *klass)
+{
+    CogViewClass *view_class = COG_VIEW_CLASS(klass);
+    view_class->create_backend = cog_core_view_create_backend;
+}
+
+static void
+cog_core_view_init(CogCoreView *self)
+{
+}

--- a/core/cog-view.h
+++ b/core/cog-view.h
@@ -1,0 +1,38 @@
+/*
+ * cog-view.h
+ * Copyright (C) 2023 Igalia S.L.
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#pragma once
+
+#if !(defined(COG_INSIDE_COG__) && COG_INSIDE_COG__)
+#    error "Do not include this header directly, use <cog.h> instead"
+#endif
+
+#include "cog-webkit-utils.h"
+
+G_BEGIN_DECLS
+
+typedef struct _WebKitWebViewBackend WebKitWebViewBackend;
+struct wpe_view_backend;
+
+#define COG_TYPE_VIEW (cog_view_get_type())
+
+G_DECLARE_DERIVABLE_TYPE(CogView, cog_view, COG, VIEW, WebKitWebView)
+
+struct _CogViewClass {
+    /*< private >*/
+    WebKitWebViewClass parent_class;
+
+    WebKitWebViewBackend *(*create_backend)(CogView *);
+};
+
+#define COG_TYPE_VIEW_IMPL (cog_view_get_impl_type())
+
+GType                    cog_view_get_impl_type(void);
+CogView                 *cog_view_new(const char *first_property_name, ...);
+struct wpe_view_backend *cog_view_get_backend(CogView *view);
+
+G_END_DECLS

--- a/core/cog.h
+++ b/core/cog.h
@@ -22,6 +22,7 @@
 #include "cog-request-handler.h"
 #include "cog-shell.h"
 #include "cog-utils.h"
+#include "cog-view.h"
 #include "cog-webkit-utils.h"
 
 #undef COG_INSIDE_COG__

--- a/core/meson.build
+++ b/core/meson.build
@@ -32,6 +32,7 @@ cogcore_headers = files(
     'cog-platform.h',
     'cog-modules.h',
     'cog-gamepad.h',
+    'cog-view.h',
 )
 cogcore_sources = files(
     'cog-directory-files-handler.c',
@@ -44,6 +45,7 @@ cogcore_sources = files(
     'cog-utils.c',
     'cog-webkit-utils.c',
     'cog-gamepad.c',
+    'cog-view.c',
 )
 
 cogcore_dependencies = [


### PR DESCRIPTION
Add a new `CogView` class, which extends `WebKitWebView` to avoid needing to specify the view backend for each instantiated view. Instead, the creation is delegated to the current CogPlatform, in one of the following two ways:

- Overriding a new `get_view_type` vfunc, which returns the `GType` of a `CogView` subclass specific to the platform plug-in. The custom view class needs to implement a `create_backend` vfunc that creates the view backend to use.

- Letting the core library use its fallback `CogView` subclass, which relies on the platform's `get_view_backend` vfunc. This matches the existing behaviour.

This way platform plug-ins can opt-in to the new behaviour by implementing their own `CogView` subclass, and unchanged plug-ins will continue working during the transition.