### PR TITLE
core: Move platform selection logic into the library

### DIFF
--- a/core/cog-platform.c
+++ b/core/cog-platform.c
@@ -138,3 +138,69 @@ cog_platform_create_im_context(CogPlatform *platform)
 
     return NULL;
 }
+
+/**
+ * cog_platform_configure: (constructor)
+ * @name: (nullable): Name of the platform implementation to use.
+ * @params: (nullable): Parameters passed to the platform implementation.
+ * @env_prefix: (nullable): Prefix for environment variables to check.
+ * @shell: The shell that the platform will be configured for.
+ * @error: Location where to store errors, if any.
+ *
+ * Creates and configures a platform implementation.
+ *
+ * Search and create a platform implementation with the given @name,
+ * configuring it with the passed @params for use with a @shell.
+ *
+ * If the @env_prefix is non-%NULL, then the environment variable
+ * `<env_prefix>_PLATFORM_NAME` can be used to set the platform name
+ * when @name is %NULL, and the variable `<env_prefix>_PLATFORM_PARAMS`
+ * can be used to set the configuration parameters when @params is %NULL.
+ * Environment variables will *not* be used if %NULL is passed as the
+ * prefix.
+ *
+ * If both @name is %NULL and the `<env_prefix>_PLATFORM_NAME` variable
+ * not defined, then the platform implementation will be chosen automatically
+ * among the available ones.
+ *
+ * Note that [id@cog_modules_add_directory] may be used beforehand to
+ * configure where to search for available platform plug-ins.
+ *
+ * Returns: (transfer full): The configured platform.
+ *
+ * Since: 0.18
+ */
+CogPlatform *
+cog_platform_configure(const char *name, const char *params, const char *env_prefix, CogShell *shell, GError **error)
+{
+    g_return_val_if_fail(!default_platform, default_platform);
+
+    g_autofree char *platform_name = g_strdup(name);
+    g_autofree char *platform_params = g_strdup(params);
+
+    if (env_prefix) {
+        if (!platform_name) {
+            g_autofree char *name_var = g_strconcat(env_prefix, "PLATFORM_NAME", NULL);
+            platform_name = g_strdup(g_getenv(name_var));
+        }
+        if (!params) {
+            g_autofree char *params_var = g_strconcat(env_prefix, "PLATFORM_PARAMS", NULL);
+            platform_params = g_strdup(g_getenv(params_var));
+        }
+    }
+    g_debug("%s: name '%s', params '%s'", G_STRFUNC, platform_name, platform_params);
+
+    CogPlatform *platform = cog_platform_new(platform_name, error);
+    if (!platform)
+        return NULL;
+
+    if (!cog_platform_setup(platform, shell, platform_params ?: "", error)) {
+        g_object_unref(platform);
+        g_assert(!default_platform);
+        return NULL;
+    }
+    g_debug("%s: Configured %s @ %p", G_STRFUNC, G_OBJECT_TYPE_NAME(platform), platform);
+
+    g_assert(platform == default_platform);
+    return platform;
+}

--- a/core/cog-platform.h
+++ b/core/cog-platform.h
@@ -64,6 +64,9 @@ void                      cog_platform_init_web_view     (CogPlatform   *platfor
 
 WebKitInputMethodContext *cog_platform_create_im_context (CogPlatform   *platform);
 
+CogPlatform *
+cog_platform_configure(const char *name, const char *params, const char *env_prefix, CogShell *shell, GError **error);
+
 G_END_DECLS
 
 #endif /* !COG_PLATFORM_H */


### PR DESCRIPTION
Take the logic of `platform_setup_once()` out from the launcher into the core library. This will allow reusing the same implementation in other programs.