### PR TITLE
core: Move key binding handling into CogView

### DIFF
--- a/core/cog-view.h
+++ b/core/cog-view.h
@@ -16,6 +16,7 @@
 G_BEGIN_DECLS
 
 typedef struct _WebKitWebViewBackend WebKitWebViewBackend;
+struct wpe_input_keyboard_event;
 struct wpe_view_backend;
 
 #define COG_TYPE_VIEW (cog_view_get_type())
@@ -34,5 +35,8 @@ struct _CogViewClass {
 GType                    cog_view_get_impl_type(void);
 CogView                 *cog_view_new(const char *first_property_name, ...);
 struct wpe_view_backend *cog_view_get_backend(CogView *view);
+void                     cog_view_handle_key_event(CogView *self, const struct wpe_input_keyboard_event *event);
+void                     cog_view_set_use_key_bindings(CogView *self, gboolean enable);
+gboolean                 cog_view_get_use_key_bindings(CogView *self);
 
 G_END_DECLS

--- a/docs/platform-wl.md
+++ b/docs/platform-wl.md
@@ -80,20 +80,12 @@ there is only a single fullscreen surface being displayed.
 
 ## Key Bindings
 
-The following key bindings are available:
+On top of the [built-in keybindings][id@cog_view_set_use_key_bindings], the
+additional following key bindings are supported:
 
-| Binding           | Action                          |
-|:------------------|:--------------------------------|
-| `F11`             | Toggle fullscreen.              |
-| `Ctrl-W`          | Exit the application.           |
-| `Ctrl-+`          | Zoom in.                        |
-| `Ctrl--`          | Zoom out.                       |
-| `Ctrl-0`          | Restore default zoom level.     |
-| `Alt-Left`        | Go to previous page in history. |
-| `Alt-Right`       | Go to next page in history.     |
-| `Ctrl-R` / `F5`   | Reload current page.            |
-
-Currently there is no mechanism to modify or disable these key bindings.
+| Binding | Action             |
+|:--------|:-------------------|
+| `F11`   | Toggle fullscreen. |
 
 
 ## Troubleshooting

--- a/platform/gtk4/cog-platform-gtk4.c
+++ b/platform/gtk4/cog-platform-gtk4.c
@@ -359,9 +359,7 @@ dispatch_key_event(struct platform_window* win, guint keycode, guint hardware_ke
         .modifiers = modifiers,
     };
 
-    wpe_view_backend_dispatch_keyboard_event(
-        wpe_view_backend_exportable_fdo_get_view_backend(win->exportable),
-        &wpe_event);
+    cog_view_handle_key_event(COG_VIEW(win->web_view), &wpe_event);
     return TRUE;
 }
 


### PR DESCRIPTION
Pick the key binding handling from the Wayland platform plug-in, and move it into the core library. A new `cog_view_handle_key_event()` method takes care of detecting supported key bindings or actually sending the events to the view backend otherwise. In order to support cases where key bindings are not desirable (e.g. kiosks) it is possible to disable key binding support.

The only bit missing to move is the <kbd>F11</kbd> key binding to (un)fullscreen as the operation may need platform view specific actions, so for now the handling for this binding is left as it was in the Wayland platform plug-in. This can be improved later on in a follow-up patch.