### PR TITLE
CI: Switch native builds to Ubuntu 22.04 LTS

### DIFF
--- a/.github/workflows/ci-native.yml
+++ b/.github/workflows/ci-native.yml
@@ -13,7 +13,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -34,14 +34,8 @@ jobs:
             libgirepository1.0-dev gir1.2-glib-2.0 gir1.2-soup-2.4 \
             libwayland-bin libwayland-dev wayland-protocols libepoxy-dev \
             libdrm-dev libinput-dev libudev-dev libgbm-dev \
-            libxkbcommon-x11-dev libx11-xcb-dev libxcb-cursor-dev
-      - name: Setup Python
-        uses: actions/setup-python@v4
-        with:
-          python-version: 3.8
-      - name: Install Python Packages
-        run: |
-          pip install --upgrade pip gi-docgen==2021.6 meson==0.55
+            libxkbcommon-x11-dev libx11-xcb-dev libxcb-cursor-dev \
+            libportal-dev gi-docgen meson
       - name: Fetch libwpe
         run: |
           if [[ -d ~/libwpe/.git ]] ; then


### PR DESCRIPTION
Change the base images for the native CI builds to Ubuntu 22.04 LTS. In turn, this allows to use system packages for gi-docgen, meson, and libportal, thus removing the need for manually-installed Python packages. The later makes the build faster to complete.