### PR TITLE
Add support for weston 13 protocols

### DIFF
--- a/platform/wayland/meson.build
+++ b/platform/wayland/meson.build
@@ -48,6 +48,7 @@ wayland_protocols_path = wayland_protocols_dep.get_variable(pkgconfig: 'pkgdatad
 
 if wayland_platform_weston_protocols.length() > 0
     foreach weston_dep_name : [
+            'libweston-13-protocols',
             'libweston-12-protocols',
             'libweston-11-protocols',
             'libweston-10-protocols',


### PR DESCRIPTION
Weston 12 was released recently and the weston development branch is now using libweston-13-protocols.