### PR TITLE
wl: Remove wl_surface_frame as part of wpe_view_data

### DIFF
--- a/platform/wayland/cog-platform-wl.c
+++ b/platform/wayland/cog-platform-wl.c
@@ -9,29 +9,29 @@
 #include "../../core/cog.h"
 
 #include <errno.h>
+#include <glib-object.h>
+#include <glib.h>
 #include <stdbool.h>
 #include <stdint.h>
-#include <wpe/webkit.h>
-#include <wpe/fdo.h>
-#include <wpe/fdo-egl.h>
-#include <stdlib.h>
 #include <stdio.h>
-#include <glib.h>
-#include <glib-object.h>
+#include <stdlib.h>
 #include <string.h>
+#include <wpe/fdo-egl.h>
+#include <wpe/fdo.h>
+#include <wpe/webkit.h>
 
-#include <wayland-client.h>
-#include <wayland-server.h>
-#include <wayland-egl.h>
 #include <EGL/egl.h>
 #include <EGL/eglext.h>
+#include <wayland-client.h>
+#include <wayland-egl.h>
+#include <wayland-server.h>
 
 /* for mmap */
 #include <sys/mman.h>
 
-#include <xkbcommon/xkbcommon.h>
-#include <xkbcommon/xkbcommon-compose.h>
 #include <locale.h>
+#include <xkbcommon/xkbcommon-compose.h>
+#include <xkbcommon/xkbcommon.h>
 
 #include "../common/egl-proc-address.h"
 #include "os-compatibility.h"
@@ -58,11 +58,11 @@
 #endif
 
 #ifdef COG_USE_WAYLAND_CURSOR
-#include <wayland-cursor.h>
+#    include <wayland-cursor.h>
 #endif
 
 #define DEFAULT_WIDTH  1024
-#define DEFAULT_HEIGHT  768
+#define DEFAULT_HEIGHT 768
 
 #if defined(WPE_CHECK_VERSION)
 #    define HAVE_REFRESH_RATE_HANDLING WPE_CHECK_VERSION(1, 13, 2)
@@ -105,32 +105,32 @@ struct video_buffer {
     int32_t y;
     int32_t width;
     int32_t height;
-    int fd;
+    int     fd;
 
-    struct wpe_video_plane_display_dmabuf_export* dmabuf_export;
+    struct wpe_video_plane_display_dmabuf_export *dmabuf_export;
 };
 
 struct video_surface {
 #    if COG_ENABLE_WESTON_CONTENT_PROTECTION
     struct weston_protected_surface *protected_surface;
 #    endif
-    struct wl_surface *wl_surface;
+    struct wl_surface    *wl_surface;
     struct wl_subsurface *wl_subsurface;
 };
 #endif
 
 #if HAVE_SHM_EXPORTED_BUFFER
 struct shm_buffer {
-    struct wl_list link;
+    struct wl_list     link;
     struct wl_listener destroy_listener;
 
-    struct wl_resource *buffer_resource;
+    struct wl_resource                 *buffer_resource;
     struct wpe_fdo_shm_exported_buffer *exported_buffer;
 
     struct wl_shm_pool *shm_pool;
-    void *data;
-    size_t size;
-    struct wl_buffer *buffer;
+    void               *data;
+    size_t              size;
+    struct wl_buffer   *buffer;
 };
 #endif
 
@@ -148,21 +148,21 @@ typedef struct output_metrics {
 } output_metrics;
 
 static struct {
-    struct wl_display *display;
-    struct wl_registry *registry;
-    struct wl_compositor *compositor;
+    struct wl_display       *display;
+    struct wl_registry      *registry;
+    struct wl_compositor    *compositor;
     struct wl_subcompositor *subcompositor;
-    struct wl_shm *shm;
+    struct wl_shm           *shm;
 
-    struct xdg_wm_base *xdg_shell;
+    struct xdg_wm_base             *xdg_shell;
     struct zwp_fullscreen_shell_v1 *fshell;
-    struct wl_shell *shell;
+    struct wl_shell                *shell;
 
     struct wl_seat *seat;
-    uint32_t event_serial;
+    uint32_t        event_serial;
 
 #if COG_ENABLE_WESTON_DIRECT_DISPLAY
-    struct zwp_linux_dmabuf_v1 *dmabuf;
+    struct zwp_linux_dmabuf_v1      *dmabuf;
     struct weston_direct_display_v1 *direct_display;
 #endif
 
@@ -176,7 +176,7 @@ static struct {
     struct wl_surface      *cursor_left_ptr_surface;
 #endif /* COG_USE_WAYLAND_CURSOR */
 
-    struct output_metrics metrics[16];
+    struct output_metrics  metrics[16];
     struct output_metrics *current_output;
 
     struct zwp_text_input_manager_v3 *text_input_manager;
@@ -187,15 +187,15 @@ static struct {
     struct {
         struct wl_pointer *obj;
         struct wl_surface *surface;
-        int32_t x;
-        int32_t y;
-        uint32_t button;
-        uint32_t state;
+        int32_t            x;
+        int32_t            y;
+        uint32_t           button;
+        uint32_t           state;
     } pointer;
 
     struct {
-        bool has_delta;
-        uint32_t time;
+        bool       has_delta;
+        uint32_t   time;
         wl_fixed_t x_delta;
         wl_fixed_t y_delta;
     } axis;
@@ -217,8 +217,8 @@ static struct {
     } keyboard;
 
     struct {
-        struct wl_touch *obj;
-        struct wl_surface *surface;
+        struct wl_touch                 *obj;
+        struct wl_surface               *surface;
         struct wpe_input_touch_event_raw points[10];
     } touch;
 
@@ -238,8 +238,8 @@ static struct {
     GHashTable *video_surfaces;
 #endif
 
-    struct xdg_surface *xdg_surface;
-    struct xdg_toplevel *xdg_toplevel;
+    struct xdg_surface      *xdg_surface;
+    struct xdg_toplevel     *xdg_toplevel;
     struct wl_shell_surface *shell_surface;
 
     uint32_t width;
@@ -265,15 +265,15 @@ static struct {
     struct wl_surface *wl_surface;
 
     struct xdg_positioner *xdg_positioner;
-    struct xdg_surface *xdg_surface;
-    struct xdg_popup *xdg_popup;
+    struct xdg_surface    *xdg_surface;
+    struct xdg_popup      *xdg_popup;
 
     struct wl_shell_surface *shell_surface;
 
     uint32_t width;
     uint32_t height;
 
-    CogPopupMenu *popup_menu;
+    CogPopupMenu     *popup_menu;
     WebKitOptionMenu *option_menu;
 
     bool configured;
@@ -281,14 +281,13 @@ static struct {
     .configured = false,
 };
 
-
 static struct {
-    struct xkb_context* context;
-    struct xkb_keymap* keymap;
-    struct xkb_state* state;
+    struct xkb_context *context;
+    struct xkb_keymap  *keymap;
+    struct xkb_state   *state;
 
-    struct xkb_compose_table* compose_table;
-    struct xkb_compose_state* compose_state;
+    struct xkb_compose_table *compose_table;
+    struct xkb_compose_state *compose_state;
 
     struct {
         xkb_mod_index_t control;
@@ -296,26 +295,27 @@ static struct {
         xkb_mod_index_t shift;
     } indexes;
     uint8_t modifiers;
-} xkb_data = {NULL, };
+} xkb_data = {
+    NULL,
+};
 
 static struct {
     struct wpe_view_backend_exportable_fdo *exportable;
 } wpe_host_data;
 
 static struct {
-    struct wpe_view_backend *backend;
+    struct wpe_view_backend           *backend;
     struct wpe_fdo_egl_exported_image *image;
-    struct wl_buffer *buffer;
-    struct wl_callback *frame_callback;
-    bool should_update_opaque_region;
+    struct wl_buffer                  *buffer;
+    struct wl_callback                *frame_callback;
+    bool                               should_update_opaque_region;
 } wpe_view_data = {
     .should_update_opaque_region = true, /* Force initial update. */
 };
 
-
 struct wl_event_source {
-    GSource source;
-    GPollFD pfd;
+    GSource            source;
+    GPollFD            pfd;
     struct wl_display *display;
 };
 
@@ -451,11 +451,11 @@ shell_surface_ping(void *data, struct wl_shell_surface *shell_surface, uint32_t 
 }
 
 static void
-shell_surface_configure(void *data,
+shell_surface_configure(void                    *data,
                         struct wl_shell_surface *shell_surface,
-                        uint32_t edges,
-                        int32_t width,
-                        int32_t height)
+                        uint32_t                 edges,
+                        int32_t                  width,
+                        int32_t                  height)
 {
     configure_surface_geometry(width, height);
 
@@ -476,17 +476,16 @@ shell_popup_surface_ping(void *data, struct wl_shell_surface *shell_surface, uin
 }
 
 static void
-shell_popup_surface_configure(void *data,
+shell_popup_surface_configure(void                    *data,
                               struct wl_shell_surface *shell_surface,
-                              uint32_t edges,
-                              int32_t width,
-                              int32_t height)
+                              uint32_t                 edges,
+                              int32_t                  width,
+                              int32_t                  height)
 {
 }
 
 static void
-shell_popup_surface_popup_done (void *data,
-                                struct wl_shell_surface *shell_surface)
+shell_popup_surface_popup_done(void *data, struct wl_shell_surface *shell_surface)
 {
 }
 
@@ -520,11 +519,11 @@ xdg_surface_on_configure(void *data, struct xdg_surface *surface, uint32_t seria
 static const struct xdg_surface_listener xdg_surface_listener = {.configure = xdg_surface_on_configure};
 
 static void
-xdg_toplevel_on_configure(void *data,
+xdg_toplevel_on_configure(void                *data,
                           struct xdg_toplevel *toplevel,
-                          int32_t width,
-                          int32_t height,
-                          struct wl_array *states)
+                          int32_t              width,
+                          int32_t              height,
+                          struct wl_array     *states)
 {
     configure_surface_geometry(width, height);
 
@@ -772,11 +771,7 @@ static const struct wl_surface_listener surface_listener = {
 };
 
 static void
-registry_global (void               *data,
-                 struct wl_registry *registry,
-                 uint32_t            name,
-                 const char         *interface,
-                 uint32_t            version)
+registry_global(void *data, struct wl_registry *registry, uint32_t name, const char *interface, uint32_t version)
 {
     gboolean interface_used = TRUE;
 
@@ -840,12 +835,12 @@ registry_global (void               *data,
 }
 
 static void
-pointer_on_enter(void *data,
+pointer_on_enter(void              *data,
                  struct wl_pointer *pointer,
-                 uint32_t serial,
+                 uint32_t           serial,
                  struct wl_surface *surface,
-                 wl_fixed_t fixed_x,
-                 wl_fixed_t fixed_y)
+                 wl_fixed_t         fixed_x,
+                 wl_fixed_t         fixed_y)
 {
     wl_data.event_serial = serial;
     wl_data.pointer.surface = surface;
@@ -900,12 +895,12 @@ pointer_on_motion(void *data, struct wl_pointer *pointer, uint32_t time, wl_fixe
 }
 
 static void
-pointer_on_button(void *data,
+pointer_on_button(void              *data,
                   struct wl_pointer *pointer,
-                  uint32_t serial,
-                  uint32_t time,
-                  uint32_t button,
-                  uint32_t state)
+                  uint32_t           serial,
+                  uint32_t           time,
+                  uint32_t           button,
+                  uint32_t           state)
 {
     wl_data.event_serial = serial;
 
@@ -950,7 +945,9 @@ dispatch_axis_event()
     if (!wl_data.axis.has_delta)
         return;
 
-    struct wpe_input_axis_2d_event event = { 0, };
+    struct wpe_input_axis_2d_event event = {
+        0,
+    };
     event.base.type = wpe_input_axis_event_type_mask_2d | wpe_input_axis_event_type_motion_smooth;
     event.base.time = wl_data.axis.time;
     event.base.x = wl_data.pointer.x * wl_data.current_output->scale;
@@ -1006,8 +1003,7 @@ pointer_on_axis(void *data, struct wl_pointer *pointer, uint32_t time, uint32_t 
 
 #ifdef WL_POINTER_FRAME_SINCE_VERSION
 static void
-pointer_on_frame (void* data,
-                  struct wl_pointer *pointer)
+pointer_on_frame(void *data, struct wl_pointer *pointer)
 {
     /* @FIXME: buffer pointer events and handle them in frame. That's the
      * recommended usage of this interface.
@@ -1033,62 +1029,51 @@ static const struct wl_pointer_listener pointer_listener = {
 };
 
 static void
-keyboard_on_keymap (void *data,
-                    struct wl_keyboard *wl_keyboard,
-                    uint32_t format,
-                    int32_t fd,
-                    uint32_t size)
+keyboard_on_keymap(void *data, struct wl_keyboard *wl_keyboard, uint32_t format, int32_t fd, uint32_t size)
 {
     if (format != WL_KEYBOARD_KEYMAP_FORMAT_XKB_V1) {
-        close (fd);
+        close(fd);
         return;
     }
 
     const int map_mode = wl_seat_get_version(wl_data.seat) > 6 ? MAP_PRIVATE : MAP_SHARED;
-    void* mapping = mmap (NULL, size, PROT_READ, map_mode, fd, 0);
+    void     *mapping = mmap(NULL, size, PROT_READ, map_mode, fd, 0);
     if (mapping == MAP_FAILED) {
-        close (fd);
+        close(fd);
         return;
     }
 
-    xkb_data.keymap =
-        xkb_keymap_new_from_string (xkb_data.context,
-                                    (char *) mapping,
-                                    XKB_KEYMAP_FORMAT_TEXT_V1,
-                                    XKB_KEYMAP_COMPILE_NO_FLAGS);
-    munmap (mapping, size);
-    close (fd);
+    xkb_data.keymap = xkb_keymap_new_from_string(xkb_data.context,
+                                                 (char *) mapping,
+                                                 XKB_KEYMAP_FORMAT_TEXT_V1,
+                                                 XKB_KEYMAP_COMPILE_NO_FLAGS);
+    munmap(mapping, size);
+    close(fd);
 
     if (xkb_data.keymap == NULL)
         return;
 
-    xkb_data.state = xkb_state_new (xkb_data.keymap);
+    xkb_data.state = xkb_state_new(xkb_data.keymap);
     if (xkb_data.state == NULL)
         return;
 
-    xkb_data.indexes.control = xkb_keymap_mod_get_index (xkb_data.keymap,
-                                                         XKB_MOD_NAME_CTRL);
-    xkb_data.indexes.alt = xkb_keymap_mod_get_index (xkb_data.keymap,
-                                                     XKB_MOD_NAME_ALT);
-    xkb_data.indexes.shift = xkb_keymap_mod_get_index (xkb_data.keymap,
-                                                       XKB_MOD_NAME_SHIFT);
+    xkb_data.indexes.control = xkb_keymap_mod_get_index(xkb_data.keymap, XKB_MOD_NAME_CTRL);
+    xkb_data.indexes.alt = xkb_keymap_mod_get_index(xkb_data.keymap, XKB_MOD_NAME_ALT);
+    xkb_data.indexes.shift = xkb_keymap_mod_get_index(xkb_data.keymap, XKB_MOD_NAME_SHIFT);
 }
 
 static void
-keyboard_on_enter (void *data,
-                   struct wl_keyboard *wl_keyboard,
-                   uint32_t serial,
-                   struct wl_surface *surface,
-                   struct wl_array *keys)
+keyboard_on_enter(void               *data,
+                  struct wl_keyboard *wl_keyboard,
+                  uint32_t            serial,
+                  struct wl_surface  *surface,
+                  struct wl_array    *keys)
 {
     wl_data.event_serial = serial;
 }
 
 static void
-keyboard_on_leave (void *data,
-                   struct wl_keyboard *wl_keyboard,
-                   uint32_t serial,
-                   struct wl_surface *surface)
+keyboard_on_leave(void *data, struct wl_keyboard *wl_keyboard, uint32_t serial, struct wl_surface *surface)
 {
     wl_data.event_serial = serial;
 }
@@ -1099,8 +1084,8 @@ handle_key_event(CogWlPlatform *self, uint32_t key, uint32_t state, uint32_t tim
     if (xkb_data.state == NULL)
         return;
 
-    uint32_t keysym = xkb_state_key_get_one_sym (xkb_data.state, key);
-    uint32_t unicode = xkb_state_key_get_utf32 (xkb_data.state, key);
+    uint32_t keysym = xkb_state_key_get_one_sym(xkb_data.state, key);
+    uint32_t unicode = xkb_state_key_get_utf32(xkb_data.state, key);
 
     /* TODO: Move as much as possible from fullscreen handling to common code. */
     if (cog_view_get_use_key_bindings(COG_VIEW(self->web_view)) && state == WL_KEYBOARD_KEY_STATE_PRESSED &&
@@ -1115,13 +1100,10 @@ handle_key_event(CogWlPlatform *self, uint32_t key, uint32_t state, uint32_t tim
         return;
     }
 
-    if (xkb_data.compose_state != NULL
-            && state == WL_KEYBOARD_KEY_STATE_PRESSED
-            && xkb_compose_state_feed (xkb_data.compose_state, keysym)
-            == XKB_COMPOSE_FEED_ACCEPTED
-            && xkb_compose_state_get_status (xkb_data.compose_state)
-            == XKB_COMPOSE_COMPOSED) {
-        keysym = xkb_compose_state_get_one_sym (xkb_data.compose_state);
+    if (xkb_data.compose_state != NULL && state == WL_KEYBOARD_KEY_STATE_PRESSED &&
+        xkb_compose_state_feed(xkb_data.compose_state, keysym) == XKB_COMPOSE_FEED_ACCEPTED &&
+        xkb_compose_state_get_status(xkb_data.compose_state) == XKB_COMPOSE_COMPOSED) {
+        keysym = xkb_compose_state_get_one_sym(xkb_data.compose_state);
     }
 
     struct wpe_input_keyboard_event event = {time, keysym, key, state == true, xkb_data.modifiers};
@@ -1144,12 +1126,12 @@ repeat_delay_timeout(CogWlPlatform *self)
 }
 
 static void
-keyboard_on_key (void *data,
-                 struct wl_keyboard *wl_keyboard,
-                 uint32_t serial,
-                 uint32_t time,
-                 uint32_t key,
-                 uint32_t state)
+keyboard_on_key(void               *data,
+                struct wl_keyboard *wl_keyboard,
+                uint32_t            serial,
+                uint32_t            time,
+                uint32_t            key,
+                uint32_t            state)
 {
     CogWlPlatform *self = data;
 
@@ -1170,19 +1152,15 @@ keyboard_on_key (void *data,
     if (wl_data.keyboard.repeat_info.rate == 0)
         return;
 
-    if (state == WL_KEYBOARD_KEY_STATE_RELEASED
-        && wl_data.keyboard.repeat_data.key == key) {
+    if (state == WL_KEYBOARD_KEY_STATE_RELEASED && wl_data.keyboard.repeat_data.key == key) {
         if (wl_data.keyboard.repeat_data.event_source)
-            g_source_remove (wl_data.keyboard.repeat_data.event_source);
+            g_source_remove(wl_data.keyboard.repeat_data.event_source);
 
-        memset (&wl_data.keyboard.repeat_data,
-                0x00,
-                sizeof (wl_data.keyboard.repeat_data));
-    } else if (xkb_data.keymap != NULL
-               && state == WL_KEYBOARD_KEY_STATE_PRESSED
-               && xkb_keymap_key_repeats (xkb_data.keymap, key)) {
+        memset(&wl_data.keyboard.repeat_data, 0x00, sizeof(wl_data.keyboard.repeat_data));
+    } else if (xkb_data.keymap != NULL && state == WL_KEYBOARD_KEY_STATE_PRESSED &&
+               xkb_keymap_key_repeats(xkb_data.keymap, key)) {
         if (wl_data.keyboard.repeat_data.event_source)
-            g_source_remove (wl_data.keyboard.repeat_data.event_source);
+            g_source_remove(wl_data.keyboard.repeat_data.event_source);
 
         wl_data.keyboard.repeat_data.key = key;
         wl_data.keyboard.repeat_data.time = time;
@@ -1193,52 +1171,36 @@ keyboard_on_key (void *data,
 }
 
 static void
-keyboard_on_modifiers (void *data,
-                       struct wl_keyboard *wl_keyboard,
-                       uint32_t serial,
-                       uint32_t mods_depressed,
-                       uint32_t mods_latched,
-                       uint32_t mods_locked,
-                       uint32_t group)
+keyboard_on_modifiers(void               *data,
+                      struct wl_keyboard *wl_keyboard,
+                      uint32_t            serial,
+                      uint32_t            mods_depressed,
+                      uint32_t            mods_latched,
+                      uint32_t            mods_locked,
+                      uint32_t            group)
 {
     if (xkb_data.state == NULL)
         return;
     wl_data.event_serial = serial;
 
-    xkb_state_update_mask (xkb_data.state,
-                           mods_depressed,
-                           mods_latched,
-                           mods_locked,
-                           0,
-                           0,
-                           group);
+    xkb_state_update_mask(xkb_data.state, mods_depressed, mods_latched, mods_locked, 0, 0, group);
 
     xkb_data.modifiers = 0;
-    uint32_t component
-        = (XKB_STATE_MODS_DEPRESSED | XKB_STATE_MODS_LATCHED);
+    uint32_t component = (XKB_STATE_MODS_DEPRESSED | XKB_STATE_MODS_LATCHED);
 
-    if (xkb_state_mod_index_is_active (xkb_data.state,
-                                       xkb_data.indexes.control,
-                                       component)) {
+    if (xkb_state_mod_index_is_active(xkb_data.state, xkb_data.indexes.control, component)) {
         xkb_data.modifiers |= wpe_input_keyboard_modifier_control;
     }
-    if (xkb_state_mod_index_is_active (xkb_data.state,
-                                       xkb_data.indexes.alt,
-                                       component)) {
+    if (xkb_state_mod_index_is_active(xkb_data.state, xkb_data.indexes.alt, component)) {
         xkb_data.modifiers |= wpe_input_keyboard_modifier_alt;
     }
-    if (xkb_state_mod_index_is_active (xkb_data.state,
-                                       xkb_data.indexes.shift,
-                                       component)) {
+    if (xkb_state_mod_index_is_active(xkb_data.state, xkb_data.indexes.shift, component)) {
         xkb_data.modifiers |= wpe_input_keyboard_modifier_shift;
     }
 }
 
 static void
-keyboard_on_repeat_info (void *data,
-                         struct wl_keyboard *wl_keyboard,
-                         int32_t rate,
-                         int32_t delay)
+keyboard_on_repeat_info(void *data, struct wl_keyboard *wl_keyboard, int32_t rate, int32_t delay)
 {
     wl_data.keyboard.repeat_info.rate = rate;
     wl_data.keyboard.repeat_info.delay = delay;
@@ -1246,9 +1208,7 @@ keyboard_on_repeat_info (void *data,
     /* a rate of zero disables any repeating. */
     if (rate == 0 && wl_data.keyboard.repeat_data.event_source > 0) {
         g_source_remove(wl_data.keyboard.repeat_data.event_source);
-        memset (&wl_data.keyboard.repeat_data,
-                0x00,
-                sizeof (wl_data.keyboard.repeat_data));
+        memset(&wl_data.keyboard.repeat_data, 0x00, sizeof(wl_data.keyboard.repeat_data));
     }
 }
 
@@ -1262,14 +1222,14 @@ static const struct wl_keyboard_listener keyboard_listener = {
 };
 
 static void
-touch_on_down (void *data,
-               struct wl_touch *touch,
-               uint32_t serial,
-               uint32_t time,
-               struct wl_surface *surface,
-               int32_t id,
-               wl_fixed_t x,
-               wl_fixed_t y)
+touch_on_down(void              *data,
+              struct wl_touch   *touch,
+              uint32_t           serial,
+              uint32_t           time,
+              struct wl_surface *surface,
+              int32_t            id,
+              wl_fixed_t         x,
+              wl_fixed_t         y)
 {
     wl_data.touch.surface = surface;
     wl_data.event_serial = serial;
@@ -1285,38 +1245,25 @@ touch_on_down (void *data,
         wl_fixed_to_int(y) * wl_data.current_output->scale,
     };
 
-    memcpy (&wl_data.touch.points[id],
-            &raw_event,
-            sizeof (struct wpe_input_touch_event_raw));
+    memcpy(&wl_data.touch.points[id], &raw_event, sizeof(struct wpe_input_touch_event_raw));
 
     if (popup_data.wl_surface) {
         if (wl_data.touch.surface == popup_data.wl_surface) {
-            cog_popup_menu_handle_event (popup_data.popup_menu,
-                                         COG_POPUP_MENU_EVENT_STATE_PRESSED,
-                                         raw_event.x, raw_event.y);
-            update_popup ();
+            cog_popup_menu_handle_event(popup_data.popup_menu, COG_POPUP_MENU_EVENT_STATE_PRESSED, raw_event.x,
+                                        raw_event.y);
+            update_popup();
             return;
         } else
-            destroy_popup ();
+            destroy_popup();
     }
 
-    struct wpe_input_touch_event event = {
-        wl_data.touch.points,
-        10,
-        raw_event.type,
-        raw_event.id,
-        raw_event.time
-    };
+    struct wpe_input_touch_event event = {wl_data.touch.points, 10, raw_event.type, raw_event.id, raw_event.time};
 
-    wpe_view_backend_dispatch_touch_event (wpe_view_data.backend, &event);
+    wpe_view_backend_dispatch_touch_event(wpe_view_data.backend, &event);
 }
 
 static void
-touch_on_up (void *data,
-             struct wl_touch *touch,
-             uint32_t serial,
-             uint32_t time,
-             int32_t id)
+touch_on_up(void *data, struct wl_touch *touch, uint32_t serial, uint32_t time, int32_t id)
 {
     struct wl_surface *target_surface = wl_data.touch.surface;
     wl_data.touch.surface = NULL;
@@ -1326,53 +1273,31 @@ touch_on_up (void *data,
         return;
 
     struct wpe_input_touch_event_raw raw_event = {
-        wpe_input_touch_event_type_up,
-        time,
-        id,
-        wl_data.touch.points[id].x,
-        wl_data.touch.points[id].y,
+        wpe_input_touch_event_type_up, time, id, wl_data.touch.points[id].x, wl_data.touch.points[id].y,
     };
 
     if (popup_data.wl_surface) {
         if (target_surface == popup_data.wl_surface) {
-            cog_popup_menu_handle_event (popup_data.popup_menu,
-                                         COG_POPUP_MENU_EVENT_STATE_RELEASED,
-                                         raw_event.x, raw_event.y);
-            update_popup ();
+            cog_popup_menu_handle_event(popup_data.popup_menu, COG_POPUP_MENU_EVENT_STATE_RELEASED, raw_event.x,
+                                        raw_event.y);
+            update_popup();
 
-            memset (&wl_data.touch.points[id],
-                    0x00,
-                    sizeof (struct wpe_input_touch_event_raw));
+            memset(&wl_data.touch.points[id], 0x00, sizeof(struct wpe_input_touch_event_raw));
             return;
         }
     }
 
-    memcpy (&wl_data.touch.points[id],
-            &raw_event,
-            sizeof (struct wpe_input_touch_event_raw));
+    memcpy(&wl_data.touch.points[id], &raw_event, sizeof(struct wpe_input_touch_event_raw));
 
-    struct wpe_input_touch_event event = {
-        wl_data.touch.points,
-        10,
-        raw_event.type,
-        raw_event.id,
-        raw_event.time
-    };
+    struct wpe_input_touch_event event = {wl_data.touch.points, 10, raw_event.type, raw_event.id, raw_event.time};
 
-    wpe_view_backend_dispatch_touch_event (wpe_view_data.backend, &event);
+    wpe_view_backend_dispatch_touch_event(wpe_view_data.backend, &event);
 
-    memset (&wl_data.touch.points[id],
-            0x00,
-            sizeof (struct wpe_input_touch_event_raw));
+    memset(&wl_data.touch.points[id], 0x00, sizeof(struct wpe_input_touch_event_raw));
 }
 
 static void
-touch_on_motion (void *data,
-                 struct wl_touch *touch,
-                 uint32_t time,
-                 int32_t id,
-                 wl_fixed_t x,
-                 wl_fixed_t y)
+touch_on_motion(void *data, struct wl_touch *touch, uint32_t time, int32_t id, wl_fixed_t x, wl_fixed_t y)
 {
     if (id < 0 || id >= 10)
         return;
@@ -1385,29 +1310,21 @@ touch_on_motion (void *data,
         wl_fixed_to_int(y) * wl_data.current_output->scale,
     };
 
-    memcpy (&wl_data.touch.points[id],
-            &raw_event,
-            sizeof (struct wpe_input_touch_event_raw));
+    memcpy(&wl_data.touch.points[id], &raw_event, sizeof(struct wpe_input_touch_event_raw));
 
-    struct wpe_input_touch_event event = {
-        wl_data.touch.points,
-        10,
-        raw_event.type,
-        raw_event.id,
-        raw_event.time
-    };
+    struct wpe_input_touch_event event = {wl_data.touch.points, 10, raw_event.type, raw_event.id, raw_event.time};
 
-    wpe_view_backend_dispatch_touch_event (wpe_view_data.backend, &event);
+    wpe_view_backend_dispatch_touch_event(wpe_view_data.backend, &event);
 }
 
 static void
-touch_on_frame (void *data, struct wl_touch *touch)
+touch_on_frame(void *data, struct wl_touch *touch)
 {
     /* @FIXME: buffer touch events and handle them here */
 }
 
 static void
-touch_on_cancel (void *data, struct wl_touch *touch)
+touch_on_cancel(void *data, struct wl_touch *touch)
 {
 }
 
@@ -1420,54 +1337,54 @@ static const struct wl_touch_listener touch_listener = {
 };
 
 static void
-seat_on_capabilities (void* data, struct wl_seat* seat, uint32_t capabilities)
+seat_on_capabilities(void *data, struct wl_seat *seat, uint32_t capabilities)
 {
-    g_debug ("Enumerating seat capabilities:");
+    g_debug("Enumerating seat capabilities:");
 
     /* Pointer */
     const bool has_pointer = capabilities & WL_SEAT_CAPABILITY_POINTER;
     if (has_pointer && wl_data.pointer.obj == NULL) {
-        wl_data.pointer.obj = wl_seat_get_pointer (wl_data.seat);
-        g_assert (wl_data.pointer.obj);
-        wl_pointer_add_listener (wl_data.pointer.obj, &pointer_listener, NULL);
-        g_debug ("  - Pointer");
-    } else if (! has_pointer && wl_data.pointer.obj != NULL) {
-        wl_pointer_release (wl_data.pointer.obj);
+        wl_data.pointer.obj = wl_seat_get_pointer(wl_data.seat);
+        g_assert(wl_data.pointer.obj);
+        wl_pointer_add_listener(wl_data.pointer.obj, &pointer_listener, NULL);
+        g_debug("  - Pointer");
+    } else if (!has_pointer && wl_data.pointer.obj != NULL) {
+        wl_pointer_release(wl_data.pointer.obj);
         wl_data.pointer.obj = NULL;
     }
 
     /* Keyboard */
     const bool has_keyboard = capabilities & WL_SEAT_CAPABILITY_KEYBOARD;
     if (has_keyboard && wl_data.keyboard.obj == NULL) {
-        wl_data.keyboard.obj = wl_seat_get_keyboard (wl_data.seat);
-        g_assert (wl_data.keyboard.obj);
+        wl_data.keyboard.obj = wl_seat_get_keyboard(wl_data.seat);
+        g_assert(wl_data.keyboard.obj);
         wl_keyboard_add_listener(wl_data.keyboard.obj, &keyboard_listener, data);
-        g_debug ("  - Keyboard");
-    } else if (! has_keyboard && wl_data.keyboard.obj != NULL) {
-        wl_keyboard_release (wl_data.keyboard.obj);
+        g_debug("  - Keyboard");
+    } else if (!has_keyboard && wl_data.keyboard.obj != NULL) {
+        wl_keyboard_release(wl_data.keyboard.obj);
         wl_data.keyboard.obj = NULL;
     }
 
     /* Touch */
     const bool has_touch = capabilities & WL_SEAT_CAPABILITY_TOUCH;
     if (has_touch && wl_data.touch.obj == NULL) {
-        wl_data.touch.obj = wl_seat_get_touch (wl_data.seat);
-        g_assert (wl_data.touch.obj);
-        wl_touch_add_listener (wl_data.touch.obj, &touch_listener, NULL);
-        g_debug ("  - Touch");
-    } else if (! has_touch && wl_data.touch.obj != NULL) {
-        wl_touch_release (wl_data.touch.obj);
+        wl_data.touch.obj = wl_seat_get_touch(wl_data.seat);
+        g_assert(wl_data.touch.obj);
+        wl_touch_add_listener(wl_data.touch.obj, &touch_listener, NULL);
+        g_debug("  - Touch");
+    } else if (!has_touch && wl_data.touch.obj != NULL) {
+        wl_touch_release(wl_data.touch.obj);
         wl_data.touch.obj = NULL;
     }
 
-    g_debug ("Done enumerating seat capabilities.");
+    g_debug("Done enumerating seat capabilities.");
 }
 
 #ifdef WL_SEAT_NAME_SINCE_VERSION
 static void
-seat_on_name (void *data, struct wl_seat *seat, const char *name)
+seat_on_name(void *data, struct wl_seat *seat, const char *name)
 {
-    g_debug ("Seat name: '%s'", name);
+    g_debug("Seat name: '%s'", name);
 }
 #endif /* WL_SEAT_NAME_SINCE_VERSION */
 
@@ -1479,92 +1396,88 @@ static const struct wl_seat_listener seat_listener = {
 };
 
 static void
-registry_global_remove (void *data, struct wl_registry *registry, uint32_t name)
+registry_global_remove(void *data, struct wl_registry *registry, uint32_t name)
 {
-    for (int i = 0; i < G_N_ELEMENTS (wl_data.metrics); i++)
-    {
+    for (int i = 0; i < G_N_ELEMENTS(wl_data.metrics); i++) {
         if (wl_data.metrics[i].name == name) {
             wl_data.metrics[i].output = NULL;
             wl_data.metrics[i].name = 0;
-            g_debug ("Removed output %i\n", name);
+            g_debug("Removed output %i\n", name);
             break;
         }
     }
 }
 
-static const struct wl_registry_listener registry_listener = {
-    .global = registry_global,
-    .global_remove = registry_global_remove
-};
+static const struct wl_registry_listener registry_listener = {.global = registry_global,
+                                                              .global_remove = registry_global_remove};
 
 static void
-on_surface_frame (void *data, struct wl_callback *callback, uint32_t time)
+on_surface_frame(void *data, struct wl_callback *callback, uint32_t time)
 {
     if (wpe_view_data.frame_callback != NULL) {
-        g_assert (wpe_view_data.frame_callback == callback);
-        wl_callback_destroy (wpe_view_data.frame_callback);
+        g_assert(wpe_view_data.frame_callback == callback);
+        wl_callback_destroy(wpe_view_data.frame_callback);
         wpe_view_data.frame_callback = NULL;
     }
 
-    wpe_view_backend_exportable_fdo_dispatch_frame_complete
-        (wpe_host_data.exportable);
+    wpe_view_backend_exportable_fdo_dispatch_frame_complete(wpe_host_data.exportable);
 }
 
-static const struct wl_callback_listener frame_listener = {
-    .done = on_surface_frame
-};
+static const struct wl_callback_listener frame_listener = {.done = on_surface_frame};
 
 static void
-on_presentation_feedback_sync_output (void *data, struct wp_presentation_feedback *presentation_feedback, struct wl_output *output)
+on_presentation_feedback_sync_output(void                            *data,
+                                     struct wp_presentation_feedback *presentation_feedback,
+                                     struct wl_output                *output)
 {
 }
 
 static void
-on_presentation_feedback_presented (void *data, struct wp_presentation_feedback *presentation_feedback,
-    uint32_t tv_sec_hi, uint32_t tv_sec_lo, uint32_t tv_nsec, uint32_t refresh,
-    uint32_t seq_hi, uint32_t seq_lo, uint32_t flags)
+on_presentation_feedback_presented(void                            *data,
+                                   struct wp_presentation_feedback *presentation_feedback,
+                                   uint32_t                         tv_sec_hi,
+                                   uint32_t                         tv_sec_lo,
+                                   uint32_t                         tv_nsec,
+                                   uint32_t                         refresh,
+                                   uint32_t                         seq_hi,
+                                   uint32_t                         seq_lo,
+                                   uint32_t                         flags)
 {
-    wp_presentation_feedback_destroy (presentation_feedback);
+    wp_presentation_feedback_destroy(presentation_feedback);
 }
 
 static void
-on_presentation_feedback_discarded (void *data, struct wp_presentation_feedback *presentation_feedback)
+on_presentation_feedback_discarded(void *data, struct wp_presentation_feedback *presentation_feedback)
 {
-    wp_presentation_feedback_destroy (presentation_feedback);
+    wp_presentation_feedback_destroy(presentation_feedback);
 }
 
 static const struct wp_presentation_feedback_listener presentation_feedback_listener = {
     .sync_output = on_presentation_feedback_sync_output,
     .presented = on_presentation_feedback_presented,
-    .discarded = on_presentation_feedback_discarded
-};
+    .discarded = on_presentation_feedback_discarded};
 
 static void
-request_frame (void)
+request_frame(void)
 {
     if (wpe_view_data.frame_callback == NULL) {
-        wpe_view_data.frame_callback = wl_surface_frame (win_data.wl_surface);
-        wl_callback_add_listener (wpe_view_data.frame_callback,
-                                  &frame_listener,
-                                  NULL);
+        wpe_view_data.frame_callback = wl_surface_frame(win_data.wl_surface);
+        wl_callback_add_listener(wpe_view_data.frame_callback, &frame_listener, NULL);
     }
 
     if (wl_data.presentation != NULL) {
-        struct wp_presentation_feedback *presentation_feedback = wp_presentation_feedback (wl_data.presentation,
-                                                                        win_data.wl_surface);
-        wp_presentation_feedback_add_listener (presentation_feedback,
-                                               &presentation_feedback_listener,
-                                               NULL);
+        struct wp_presentation_feedback *presentation_feedback =
+            wp_presentation_feedback(wl_data.presentation, win_data.wl_surface);
+        wp_presentation_feedback_add_listener(presentation_feedback, &presentation_feedback_listener, NULL);
     }
 }
 
 static void
-on_buffer_release (void* data, struct wl_buffer* buffer)
+on_buffer_release(void *data, struct wl_buffer *buffer)
 {
-    struct wpe_fdo_egl_exported_image * image = data;
-    wpe_view_backend_exportable_fdo_egl_dispatch_release_exported_image (wpe_host_data.exportable,
-                                                                         image);
-    g_clear_pointer (&buffer, wl_buffer_destroy);
+    struct wpe_fdo_egl_exported_image *image = data;
+    wpe_view_backend_exportable_fdo_egl_dispatch_release_exported_image(wpe_host_data.exportable, image);
+    g_clear_pointer(&buffer, wl_buffer_destroy);
 }
 
 static const struct wl_buffer_listener buffer_listener = {
@@ -1573,10 +1486,10 @@ static const struct wl_buffer_listener buffer_listener = {
 
 #if COG_ENABLE_WESTON_DIRECT_DISPLAY
 static void
-on_dmabuf_surface_frame (void *data, struct wl_callback *callback, uint32_t time)
+on_dmabuf_surface_frame(void *data, struct wl_callback *callback, uint32_t time)
 {
     // for WAYLAND_DEBUG=1 purposes only
-    wl_callback_destroy (callback);
+    wl_callback_destroy(callback);
 }
 
 static const struct wl_callback_listener dmabuf_frame_listener = {
@@ -1584,7 +1497,7 @@ static const struct wl_callback_listener dmabuf_frame_listener = {
 };
 
 static void
-on_dmabuf_buffer_release (void* data, struct wl_buffer* buffer)
+on_dmabuf_buffer_release(void *data, struct wl_buffer *buffer)
 {
     struct video_buffer *data_buffer = data;
     if (data_buffer->fd >= 0)
@@ -1593,8 +1506,8 @@ on_dmabuf_buffer_release (void* data, struct wl_buffer* buffer)
     if (data_buffer->dmabuf_export)
         wpe_video_plane_display_dmabuf_export_release(data_buffer->dmabuf_export);
 
-    g_slice_free (struct video_buffer, data_buffer);
-    g_clear_pointer (&buffer, wl_buffer_destroy);
+    g_slice_free(struct video_buffer, data_buffer);
+    g_clear_pointer(&buffer, wl_buffer_destroy);
 }
 
 static const struct wl_buffer_listener dmabuf_buffer_listener = {
@@ -1624,34 +1537,33 @@ on_export_wl_egl_image(void *data, struct wpe_fdo_egl_exported_image *image)
     if (wpe_view_data.should_update_opaque_region) {
         wpe_view_data.should_update_opaque_region = false;
         if (win_data.is_fullscreen) {
-          struct wl_region *region =
-              wl_compositor_create_region (wl_data.compositor);
-          wl_region_add (region, 0, 0, win_data.width, win_data.height);
-          wl_surface_set_opaque_region (win_data.wl_surface, region);
-          wl_region_destroy (region);
+            struct wl_region *region = wl_compositor_create_region(wl_data.compositor);
+            wl_region_add(region, 0, 0, win_data.width, win_data.height);
+            wl_surface_set_opaque_region(win_data.wl_surface, region);
+            wl_region_destroy(region);
         } else {
-          wl_surface_set_opaque_region (win_data.wl_surface, NULL);
+            wl_surface_set_opaque_region(win_data.wl_surface, NULL);
         }
     }
 
-    static PFNEGLCREATEWAYLANDBUFFERFROMIMAGEWL
-        s_eglCreateWaylandBufferFromImageWL;
+    static PFNEGLCREATEWAYLANDBUFFERFROMIMAGEWL s_eglCreateWaylandBufferFromImageWL;
     if (s_eglCreateWaylandBufferFromImageWL == NULL) {
-        s_eglCreateWaylandBufferFromImageWL = (PFNEGLCREATEWAYLANDBUFFERFROMIMAGEWL)
-            load_egl_proc_address ("eglCreateWaylandBufferFromImageWL");
-        g_assert (s_eglCreateWaylandBufferFromImageWL);
+        s_eglCreateWaylandBufferFromImageWL =
+            (PFNEGLCREATEWAYLANDBUFFERFROMIMAGEWL) load_egl_proc_address("eglCreateWaylandBufferFromImageWL");
+        g_assert(s_eglCreateWaylandBufferFromImageWL);
     }
 
-    wpe_view_data.buffer = s_eglCreateWaylandBufferFromImageWL (egl_data.display, wpe_fdo_egl_exported_image_get_egl_image (wpe_view_data.image));
-    g_assert (wpe_view_data.buffer);
+    wpe_view_data.buffer = s_eglCreateWaylandBufferFromImageWL(
+        egl_data.display, wpe_fdo_egl_exported_image_get_egl_image(wpe_view_data.image));
+    g_assert(wpe_view_data.buffer);
     wl_buffer_add_listener(wpe_view_data.buffer, &buffer_listener, image);
 
-    wl_surface_attach (win_data.wl_surface, wpe_view_data.buffer, 0, 0);
+    wl_surface_attach(win_data.wl_surface, wpe_view_data.buffer, 0, 0);
     wl_surface_damage(win_data.wl_surface, 0, 0, surface_pixel_width, surface_pixel_height);
 
-    request_frame ();
+    request_frame();
 
-    wl_surface_commit (win_data.wl_surface);
+    wl_surface_commit(win_data.wl_surface);
 
     if (win_data.is_resizing_fullscreen && cog_wl_does_image_match_win_size(image))
         cog_wl_fullscreen_image_ready();
@@ -1659,10 +1571,10 @@ on_export_wl_egl_image(void *data, struct wpe_fdo_egl_exported_image *image)
 
 #if HAVE_SHM_EXPORTED_BUFFER
 static struct shm_buffer *
-shm_buffer_for_resource (struct wl_resource *buffer_resource)
+shm_buffer_for_resource(struct wl_resource *buffer_resource)
 {
     struct shm_buffer *buffer;
-    wl_list_for_each (buffer, &wl_data.shm_buffer_list, link) {
+    wl_list_for_each(buffer, &wl_data.shm_buffer_list, link) {
         if (buffer->buffer_resource == buffer_resource)
             return buffer;
     }
@@ -1670,17 +1582,16 @@ shm_buffer_for_resource (struct wl_resource *buffer_resource)
     return NULL;
 }
 
-static void
-shm_buffer_destroy_notify (struct wl_listener *listener, void *data);
+static void shm_buffer_destroy_notify(struct wl_listener *listener, void *data);
 
 static struct shm_buffer *
-shm_buffer_create (struct wl_resource *buffer_resource, size_t size)
+shm_buffer_create(struct wl_resource *buffer_resource, size_t size)
 {
-    int fd = os_create_anonymous_file (size);
+    int fd = os_create_anonymous_file(size);
     if (fd < 0)
         return NULL;
 
-    void* data = mmap (NULL, size, PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0);
+    void *data = mmap(NULL, size, PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0);
     if (data == MAP_FAILED) {
         close(fd);
         return NULL;
@@ -1689,13 +1600,13 @@ shm_buffer_create (struct wl_resource *buffer_resource, size_t size)
     struct shm_buffer *buffer = g_new0(struct shm_buffer, 1);
     buffer->destroy_listener.notify = shm_buffer_destroy_notify;
     buffer->buffer_resource = buffer_resource;
-    wl_resource_add_destroy_listener (buffer_resource, &buffer->destroy_listener);
+    wl_resource_add_destroy_listener(buffer_resource, &buffer->destroy_listener);
 
-    buffer->shm_pool = wl_shm_create_pool (wl_data.shm, fd, size);
+    buffer->shm_pool = wl_shm_create_pool(wl_data.shm, fd, size);
     buffer->data = data;
     buffer->size = size;
 
-    close (fd);
+    close(fd);
     return buffer;
 }
 
@@ -1728,8 +1639,8 @@ on_shm_buffer_release(void *data, struct wl_buffer *wl_buffer)
 {
     struct shm_buffer *buffer = data;
     if (buffer->exported_buffer) {
-        wpe_view_backend_exportable_fdo_egl_dispatch_release_shm_exported_buffer (wpe_host_data.exportable,
-                                                                                  buffer->exported_buffer);
+        wpe_view_backend_exportable_fdo_egl_dispatch_release_shm_exported_buffer(wpe_host_data.exportable,
+                                                                                 buffer->exported_buffer);
         buffer->exported_buffer = NULL;
     }
 }
@@ -1739,26 +1650,26 @@ static const struct wl_buffer_listener shm_buffer_listener = {
 };
 
 static void
-shm_buffer_copy_contents (struct shm_buffer *buffer, struct wl_shm_buffer *exported_shm_buffer)
+shm_buffer_copy_contents(struct shm_buffer *buffer, struct wl_shm_buffer *exported_shm_buffer)
 {
-    int32_t height = wl_shm_buffer_get_height (exported_shm_buffer);
-    int32_t stride = wl_shm_buffer_get_stride (exported_shm_buffer);
+    int32_t height = wl_shm_buffer_get_height(exported_shm_buffer);
+    int32_t stride = wl_shm_buffer_get_stride(exported_shm_buffer);
 
     size_t data_size = height * stride;
 
-    wl_shm_buffer_begin_access (exported_shm_buffer);
-    void* exported_data = wl_shm_buffer_get_data (exported_shm_buffer);
+    wl_shm_buffer_begin_access(exported_shm_buffer);
+    void *exported_data = wl_shm_buffer_get_data(exported_shm_buffer);
 
-    memcpy (buffer->data, exported_data, data_size);
+    memcpy(buffer->data, exported_data, data_size);
 
-    wl_shm_buffer_end_access (exported_shm_buffer);
+    wl_shm_buffer_end_access(exported_shm_buffer);
 }
 
 static void
-on_export_shm_buffer (void* data, struct wpe_fdo_shm_exported_buffer* exported_buffer)
+on_export_shm_buffer(void *data, struct wpe_fdo_shm_exported_buffer *exported_buffer)
 {
-    struct wl_resource *exported_resource = wpe_fdo_shm_exported_buffer_get_resource (exported_buffer);
-    struct wl_shm_buffer *exported_shm_buffer = wpe_fdo_shm_exported_buffer_get_shm_buffer (exported_buffer);
+    struct wl_resource   *exported_resource = wpe_fdo_shm_exported_buffer_get_resource(exported_buffer);
+    struct wl_shm_buffer *exported_shm_buffer = wpe_fdo_shm_exported_buffer_get_shm_buffer(exported_buffer);
 
     const uint32_t surface_pixel_width = wl_data.current_output->scale * win_data.width;
     const uint32_t surface_pixel_height = wl_data.current_output->scale * win_data.height;
@@ -1775,7 +1686,7 @@ on_export_shm_buffer (void* data, struct wpe_fdo_shm_exported_buffer* exported_b
         return;
     }
 
-    struct shm_buffer *buffer = shm_buffer_for_resource (exported_resource);
+    struct shm_buffer *buffer = shm_buffer_for_resource(exported_resource);
     if (!buffer) {
         int32_t width;
         int32_t height;
@@ -1786,26 +1697,26 @@ on_export_shm_buffer (void* data, struct wpe_fdo_shm_exported_buffer* exported_b
             width = wl_shm_buffer_get_width(exported_shm_buffer);
             height = wl_shm_buffer_get_height(exported_shm_buffer);
         }
-        int32_t stride = wl_shm_buffer_get_stride (exported_shm_buffer);
-        uint32_t format = wl_shm_buffer_get_format (exported_shm_buffer);
+        int32_t  stride = wl_shm_buffer_get_stride(exported_shm_buffer);
+        uint32_t format = wl_shm_buffer_get_format(exported_shm_buffer);
 
         size_t size = stride * height;
-        buffer = shm_buffer_create (exported_resource, size);
+        buffer = shm_buffer_create(exported_resource, size);
         if (!buffer)
             return;
-        wl_list_insert (&wl_data.shm_buffer_list, &buffer->link);
+        wl_list_insert(&wl_data.shm_buffer_list, &buffer->link);
 
-        buffer->buffer = wl_shm_pool_create_buffer (buffer->shm_pool, 0, width, height, stride, format);
-        wl_buffer_add_listener (buffer->buffer, &shm_buffer_listener, buffer);
+        buffer->buffer = wl_shm_pool_create_buffer(buffer->shm_pool, 0, width, height, stride, format);
+        wl_buffer_add_listener(buffer->buffer, &shm_buffer_listener, buffer);
     }
 
     buffer->exported_buffer = exported_buffer;
-    shm_buffer_copy_contents (buffer, exported_shm_buffer);
+    shm_buffer_copy_contents(buffer, exported_shm_buffer);
 
-    wl_surface_attach (win_data.wl_surface, buffer->buffer, 0, 0);
+    wl_surface_attach(win_data.wl_surface, buffer->buffer, 0, 0);
     wl_surface_damage(win_data.wl_surface, 0, 0, INT32_MAX, INT32_MAX);
-    request_frame ();
-    wl_surface_commit (win_data.wl_surface);
+    request_frame();
+    wl_surface_commit(win_data.wl_surface);
 }
 #endif
 
@@ -1813,41 +1724,47 @@ on_export_shm_buffer (void* data, struct wpe_fdo_shm_exported_buffer* exported_b
 static void
 create_succeeded(void *data, struct zwp_linux_buffer_params_v1 *params, struct wl_buffer *new_buffer)
 {
-	zwp_linux_buffer_params_v1_destroy (params);
+    zwp_linux_buffer_params_v1_destroy(params);
 
-	struct video_buffer *buffer = data;
-	buffer->buffer = new_buffer;
+    struct video_buffer *buffer = data;
+    buffer->buffer = new_buffer;
 }
 
 static void
 create_failed(void *data, struct zwp_linux_buffer_params_v1 *params)
 {
-	zwp_linux_buffer_params_v1_destroy (params);
+    zwp_linux_buffer_params_v1_destroy(params);
 
     struct video_buffer *buffer = data;
     buffer->buffer = NULL;
 }
 
-static const struct zwp_linux_buffer_params_v1_listener params_listener = {
-	.created = create_succeeded,
-	.failed = create_failed
-};
+static const struct zwp_linux_buffer_params_v1_listener params_listener = {.created = create_succeeded,
+                                                                           .failed = create_failed};
 
 static void
-destroy_video_surface (gpointer data)
+destroy_video_surface(gpointer data)
 {
-    struct video_surface *surface = (struct video_surface*) data;
+    struct video_surface *surface = (struct video_surface *) data;
 
 #    if COG_ENABLE_WESTON_CONTENT_PROTECTION
-    g_clear_pointer (&surface->protected_surface, weston_protected_surface_destroy);
+    g_clear_pointer(&surface->protected_surface, weston_protected_surface_destroy);
 #    endif
-    g_clear_pointer (&surface->wl_subsurface, wl_subsurface_destroy);
-    g_clear_pointer (&surface->wl_surface, wl_surface_destroy);
-    g_slice_free (struct video_surface, surface);
+    g_clear_pointer(&surface->wl_subsurface, wl_subsurface_destroy);
+    g_clear_pointer(&surface->wl_surface, wl_surface_destroy);
+    g_slice_free(struct video_surface, surface);
 }
 
 static void
-on_video_plane_display_dmabuf_receiver_handle_dmabuf (void* data, struct wpe_video_plane_display_dmabuf_export* dmabuf_export, uint32_t id, int fd, int32_t x, int32_t y, int32_t width, int32_t height, uint32_t stride)
+on_video_plane_display_dmabuf_receiver_handle_dmabuf(void                                         *data,
+                                                     struct wpe_video_plane_display_dmabuf_export *dmabuf_export,
+                                                     uint32_t                                      id,
+                                                     int                                           fd,
+                                                     int32_t                                       x,
+                                                     int32_t                                       y,
+                                                     int32_t                                       width,
+                                                     int32_t                                       height,
+                                                     uint32_t                                      stride)
 {
     if (fd < 0)
         return;
@@ -1856,35 +1773,36 @@ on_video_plane_display_dmabuf_receiver_handle_dmabuf (void* data, struct wpe_vid
         // TODO: Replace with g_warning_once() after bumping our GLib requirement.
         static bool warning_emitted = false;
         if (!warning_emitted) {
-            g_warning ("DMABuf not supported by the compositor. Video won't be rendered");
+            g_warning("DMABuf not supported by the compositor. Video won't be rendered");
             warning_emitted = true;
         }
         return;
     }
 
-    uint64_t modifier = DRM_FORMAT_MOD_INVALID;
-    struct zwp_linux_buffer_params_v1 *params = zwp_linux_dmabuf_v1_create_params (wl_data.dmabuf);
+    uint64_t                           modifier = DRM_FORMAT_MOD_INVALID;
+    struct zwp_linux_buffer_params_v1 *params = zwp_linux_dmabuf_v1_create_params(wl_data.dmabuf);
     if (wl_data.direct_display != NULL)
-        weston_direct_display_v1_enable (wl_data.direct_display, params);
+        weston_direct_display_v1_enable(wl_data.direct_display, params);
 
-    struct video_surface *surf = (struct video_surface*) g_hash_table_lookup (win_data.video_surfaces, GUINT_TO_POINTER(id));
+    struct video_surface *surf =
+        (struct video_surface *) g_hash_table_lookup(win_data.video_surfaces, GUINT_TO_POINTER(id));
     if (!surf) {
-        surf = g_slice_new0 (struct video_surface);
+        surf = g_slice_new0(struct video_surface);
         surf->wl_subsurface = NULL;
-        surf->wl_surface = wl_compositor_create_surface (wl_data.compositor);
+        surf->wl_surface = wl_compositor_create_surface(wl_data.compositor);
 
 #    if COG_ENABLE_WESTON_CONTENT_PROTECTION
         if (wl_data.protection) {
-            surf->protected_surface = weston_content_protection_get_protection (wl_data.protection, surf->wl_surface);
+            surf->protected_surface = weston_content_protection_get_protection(wl_data.protection, surf->wl_surface);
             //weston_protected_surface_set_type(surf->protected_surface, WESTON_PROTECTED_SURFACE_TYPE_DC_ONLY);
 
-            weston_protected_surface_enforce (surf->protected_surface);
+            weston_protected_surface_enforce(surf->protected_surface);
         }
 #    endif
-        g_hash_table_insert (win_data.video_surfaces, GUINT_TO_POINTER (id), surf);
+        g_hash_table_insert(win_data.video_surfaces, GUINT_TO_POINTER(id), surf);
     }
 
-    zwp_linux_buffer_params_v1_add (params, fd, 0, 0, stride, modifier >> 32, modifier & 0xffffffff);
+    zwp_linux_buffer_params_v1_add(params, fd, 0, 0, stride, modifier >> 32, modifier & 0xffffffff);
 
     if ((x + width) > win_data.width)
         width -= x;
@@ -1892,41 +1810,41 @@ on_video_plane_display_dmabuf_receiver_handle_dmabuf (void* data, struct wpe_vid
     if ((y + height) > win_data.height)
         height -= y;
 
-    struct video_buffer *buffer = g_slice_new0 (struct video_buffer);
+    struct video_buffer *buffer = g_slice_new0(struct video_buffer);
     buffer->fd = fd;
     buffer->x = x;
     buffer->y = y;
     buffer->width = width;
     buffer->height = height;
-	zwp_linux_buffer_params_v1_add_listener (params, &params_listener, buffer);
+    zwp_linux_buffer_params_v1_add_listener(params, &params_listener, buffer);
 
-    buffer->buffer = zwp_linux_buffer_params_v1_create_immed (params, buffer->width, buffer->height, VIDEO_BUFFER_FORMAT, 0);
-    zwp_linux_buffer_params_v1_destroy (params);
+    buffer->buffer =
+        zwp_linux_buffer_params_v1_create_immed(params, buffer->width, buffer->height, VIDEO_BUFFER_FORMAT, 0);
+    zwp_linux_buffer_params_v1_destroy(params);
 
     buffer->dmabuf_export = dmabuf_export;
-    wl_buffer_add_listener (buffer->buffer, &dmabuf_buffer_listener, buffer);
+    wl_buffer_add_listener(buffer->buffer, &dmabuf_buffer_listener, buffer);
 
-    wl_surface_attach (surf->wl_surface, buffer->buffer, 0, 0);
-    wl_surface_damage (surf->wl_surface, 0, 0, buffer->width, buffer->height);
+    wl_surface_attach(surf->wl_surface, buffer->buffer, 0, 0);
+    wl_surface_damage(surf->wl_surface, 0, 0, buffer->width, buffer->height);
 
-    struct wl_callback *callback = wl_surface_frame (surf->wl_surface);
-    wl_callback_add_listener (callback, &dmabuf_frame_listener, NULL);
+    struct wl_callback *callback = wl_surface_frame(surf->wl_surface);
+    wl_callback_add_listener(callback, &dmabuf_frame_listener, NULL);
 
     if (!surf->wl_subsurface) {
-        surf->wl_subsurface = wl_subcompositor_get_subsurface (wl_data.subcompositor,
-                                                               surf->wl_surface,
-                                                               win_data.wl_surface);
-        wl_subsurface_set_sync (surf->wl_subsurface);
+        surf->wl_subsurface =
+            wl_subcompositor_get_subsurface(wl_data.subcompositor, surf->wl_surface, win_data.wl_surface);
+        wl_subsurface_set_sync(surf->wl_subsurface);
     }
 
-    wl_subsurface_set_position (surf->wl_subsurface, buffer->x, buffer->y);
-    wl_surface_commit (surf->wl_surface);
+    wl_subsurface_set_position(surf->wl_subsurface, buffer->x, buffer->y);
+    wl_surface_commit(surf->wl_surface);
 }
 
 static void
-on_video_plane_display_dmabuf_receiver_end_of_stream (void* data, uint32_t id)
+on_video_plane_display_dmabuf_receiver_end_of_stream(void *data, uint32_t id)
 {
-    g_hash_table_remove (win_data.video_surfaces, GUINT_TO_POINTER (id));
+    g_hash_table_remove(win_data.video_surfaces, GUINT_TO_POINTER(id));
 }
 
 static const struct wpe_video_plane_display_dmabuf_receiver video_plane_display_dmabuf_receiver = {
@@ -1936,24 +1854,19 @@ static const struct wpe_video_plane_display_dmabuf_receiver video_plane_display_
 #endif
 
 static gboolean
-init_wayland (GError **error)
+init_wayland(GError **error)
 {
-    g_debug ("Initializing Wayland...");
+    g_debug("Initializing Wayland...");
 
-    if (!(wl_data.display = wl_display_connect (NULL))) {
-        g_set_error (error,
-                     G_FILE_ERROR,
-                     g_file_error_from_errno (errno),
-                     "Could not open Wayland display");
+    if (!(wl_data.display = wl_display_connect(NULL))) {
+        g_set_error(error, G_FILE_ERROR, g_file_error_from_errno(errno), "Could not open Wayland display");
         return FALSE;
     }
 
-    wl_data.registry = wl_display_get_registry (wl_data.display);
-    g_assert (wl_data.registry);
-    wl_registry_add_listener (wl_data.registry,
-                              &registry_listener,
-                              NULL);
-    wl_display_roundtrip (wl_data.display);
+    wl_data.registry = wl_display_get_registry(wl_data.display);
+    g_assert(wl_data.registry);
+    wl_registry_add_listener(wl_data.registry, &registry_listener, NULL);
+    wl_display_roundtrip(wl_data.display);
 
 #if COG_USE_WAYLAND_CURSOR
     if (wl_data.shm) {
@@ -1965,47 +1878,45 @@ init_wayland (GError **error)
     }
 #endif /* COG_USE_WAYLAND_CURSOR */
 
-    g_assert (wl_data.compositor);
-    g_assert (wl_data.xdg_shell != NULL ||
-              wl_data.shell != NULL ||
-              wl_data.fshell != NULL);
+    g_assert(wl_data.compositor);
+    g_assert(wl_data.xdg_shell != NULL || wl_data.shell != NULL || wl_data.fshell != NULL);
 
-    wl_list_init (&wl_data.shm_buffer_list);
+    wl_list_init(&wl_data.shm_buffer_list);
     return TRUE;
 }
 
 static void
-clear_wayland (void)
+clear_wayland(void)
 {
     g_clear_pointer(&wl_data.event_src, g_source_destroy);
 
     if (wl_data.xdg_shell != NULL)
-        xdg_wm_base_destroy (wl_data.xdg_shell);
+        xdg_wm_base_destroy(wl_data.xdg_shell);
     if (wl_data.fshell != NULL)
-        zwp_fullscreen_shell_v1_destroy (wl_data.fshell);
+        zwp_fullscreen_shell_v1_destroy(wl_data.fshell);
     if (wl_data.shell != NULL)
-        wl_shell_destroy (wl_data.shell);
+        wl_shell_destroy(wl_data.shell);
 
-    g_clear_pointer (&wl_data.shm, wl_shm_destroy);
-    g_clear_pointer (&wl_data.subcompositor, wl_subcompositor_destroy);
-    g_clear_pointer (&wl_data.compositor, wl_compositor_destroy);
+    g_clear_pointer(&wl_data.shm, wl_shm_destroy);
+    g_clear_pointer(&wl_data.subcompositor, wl_subcompositor_destroy);
+    g_clear_pointer(&wl_data.compositor, wl_compositor_destroy);
 
 #if COG_ENABLE_WESTON_CONTENT_PROTECTION
-    g_clear_pointer (&wl_data.protection, weston_content_protection_destroy);
+    g_clear_pointer(&wl_data.protection, weston_content_protection_destroy);
 #endif
 
 #if COG_ENABLE_WESTON_DIRECT_DISPLAY
-    g_clear_pointer (&wl_data.direct_display, weston_direct_display_v1_destroy);
+    g_clear_pointer(&wl_data.direct_display, weston_direct_display_v1_destroy);
 #endif
 
 #ifdef COG_USE_WAYLAND_CURSOR
-    g_clear_pointer (&wl_data.cursor_left_ptr_surface, wl_surface_destroy);
-    g_clear_pointer (&wl_data.cursor_theme, wl_cursor_theme_destroy);
+    g_clear_pointer(&wl_data.cursor_left_ptr_surface, wl_surface_destroy);
+    g_clear_pointer(&wl_data.cursor_theme, wl_cursor_theme_destroy);
 #endif /* COG_USE_WAYLAND_CURSOR */
 
-    wl_registry_destroy (wl_data.registry);
-    wl_display_flush (wl_data.display);
-    wl_display_disconnect (wl_data.display);
+    wl_registry_destroy(wl_data.registry);
+    wl_display_flush(wl_data.display);
+    wl_display_disconnect(wl_data.display);
 }
 
 // clang-format off
@@ -2022,11 +1933,11 @@ struct check_supported_protocols {
 #undef DECLARE_PROTOCOL_ENTRY
 
 static void
-on_registry_global_is_supported_check(void *data,
+on_registry_global_is_supported_check(void               *data,
                                       struct wl_registry *registry,
-                                      uint32_t name,
-                                      const char *interface,
-                                      uint32_t version)
+                                      uint32_t            name,
+                                      const char         *interface,
+                                      uint32_t            version)
 {
     struct check_supported_protocols *protocols = data;
 
@@ -2057,7 +1968,7 @@ check_supported(void *data G_GNUC_UNUSED)
     struct wl_display *display = wl_display_connect(NULL);
     if (display) {
         struct check_supported_protocols protocols = {};
-        struct wl_registry *registry = wl_display_get_registry(display);
+        struct wl_registry              *registry = wl_display_get_registry(display);
         wl_registry_add_listener(registry,
                                  &((const struct wl_registry_listener){
                                      .global = on_registry_global_is_supported_check,
@@ -2086,98 +1997,87 @@ cog_wl_platform_is_supported(void)
     return GPOINTER_TO_INT(once.retval);
 }
 
-#define ERR_EGL(_err, _msg)                              \
-    do {                                                 \
-        EGLint error_code_ ## __LINE__ = eglGetError (); \
-        g_set_error ((_err),                             \
-                     COG_PLATFORM_EGL_ERROR,             \
-                     error_code_ ## __LINE__,            \
-                     _msg " (%#06x)",                    \
-                     error_code_ ## __LINE__);           \
+#define ERR_EGL(_err, _msg)                                                                                         \
+    do {                                                                                                            \
+        EGLint error_code_##__LINE__ = eglGetError();                                                               \
+        g_set_error((_err), COG_PLATFORM_EGL_ERROR, error_code_##__LINE__, _msg " (%#06x)", error_code_##__LINE__); \
     } while (0)
 
-
-static void clear_egl (void);
-static void destroy_window (void);
-
+static void clear_egl(void);
+static void destroy_window(void);
 
 static gboolean
-init_egl (GError **error)
+init_egl(GError **error)
 {
-    g_debug ("Initializing EGL...");
+    g_debug("Initializing EGL...");
 
-    egl_data.display = eglGetDisplay ((EGLNativeDisplayType) wl_data.display);
+    egl_data.display = eglGetDisplay((EGLNativeDisplayType) wl_data.display);
     if (egl_data.display == EGL_NO_DISPLAY) {
-        ERR_EGL (error, "Could not open EGL display");
+        ERR_EGL(error, "Could not open EGL display");
         return FALSE;
     }
 
     EGLint major, minor;
-    if (!eglInitialize (egl_data.display, &major, &minor)) {
-        ERR_EGL (error, "Could not initialize  EGL");
-        clear_egl ();
+    if (!eglInitialize(egl_data.display, &major, &minor)) {
+        ERR_EGL(error, "Could not initialize  EGL");
+        clear_egl();
         return FALSE;
     }
-    g_info ("EGL version %d.%d initialized.", major, minor);
+    g_info("EGL version %d.%d initialized.", major, minor);
 
     return TRUE;
 }
 
 static void
-clear_egl (void)
+clear_egl(void)
 {
     if (egl_data.display != EGL_NO_DISPLAY) {
-        eglTerminate (egl_data.display);
+        eglTerminate(egl_data.display);
         egl_data.display = EGL_NO_DISPLAY;
     }
-    eglReleaseThread ();
+    eglReleaseThread();
 }
 
 static gboolean
-create_window (GError **error)
+create_window(GError **error)
 {
-    g_debug ("Creating Wayland surface...");
+    g_debug("Creating Wayland surface...");
 
-    win_data.wl_surface = wl_compositor_create_surface (wl_data.compositor);
-    g_assert (win_data.wl_surface);
+    win_data.wl_surface = wl_compositor_create_surface(wl_data.compositor);
+    g_assert(win_data.wl_surface);
 
 #if COG_ENABLE_WESTON_DIRECT_DISPLAY
-    win_data.video_surfaces = g_hash_table_new_full (g_direct_hash, g_direct_equal, NULL, destroy_video_surface);
+    win_data.video_surfaces = g_hash_table_new_full(g_direct_hash, g_direct_equal, NULL, destroy_video_surface);
 #endif
 
-    wl_surface_add_listener (win_data.wl_surface, &surface_listener, NULL);
+    wl_surface_add_listener(win_data.wl_surface, &surface_listener, NULL);
 
     if (wl_data.xdg_shell != NULL) {
-        win_data.xdg_surface =
-            xdg_wm_base_get_xdg_surface (wl_data.xdg_shell,
-                                         win_data.wl_surface);
+        win_data.xdg_surface = xdg_wm_base_get_xdg_surface(wl_data.xdg_shell, win_data.wl_surface);
         g_assert(win_data.xdg_surface);
 
-        xdg_surface_add_listener (win_data.xdg_surface, &xdg_surface_listener,
-                                  NULL);
-        win_data.xdg_toplevel =
-            xdg_surface_get_toplevel (win_data.xdg_surface);
+        xdg_surface_add_listener(win_data.xdg_surface, &xdg_surface_listener, NULL);
+        win_data.xdg_toplevel = xdg_surface_get_toplevel(win_data.xdg_surface);
         g_assert(win_data.xdg_toplevel);
 
-        xdg_toplevel_add_listener (win_data.xdg_toplevel,
-                                   &xdg_toplevel_listener, NULL);
-        xdg_toplevel_set_title (win_data.xdg_toplevel, COG_DEFAULT_APPNAME);
+        xdg_toplevel_add_listener(win_data.xdg_toplevel, &xdg_toplevel_listener, NULL);
+        xdg_toplevel_set_title(win_data.xdg_toplevel, COG_DEFAULT_APPNAME);
 
-        const char *app_id = NULL;
-        GApplication *app = g_application_get_default ();
+        const char   *app_id = NULL;
+        GApplication *app = g_application_get_default();
         if (app) {
-            app_id = g_application_get_application_id (app);
+            app_id = g_application_get_application_id(app);
         }
         if (!app_id) {
             app_id = COG_DEFAULT_APPID;
         }
-        xdg_toplevel_set_app_id (win_data.xdg_toplevel, app_id);
+        xdg_toplevel_set_app_id(win_data.xdg_toplevel, app_id);
         wl_surface_commit(win_data.wl_surface);
     } else if (wl_data.fshell != NULL) {
-        zwp_fullscreen_shell_v1_present_surface (wl_data.fshell,
-                                                 win_data.wl_surface,
-                                                 ZWP_FULLSCREEN_SHELL_V1_PRESENT_METHOD_DEFAULT,
-                                                 NULL);
+        zwp_fullscreen_shell_v1_present_surface(wl_data.fshell,
+                                                win_data.wl_surface,
+                                                ZWP_FULLSCREEN_SHELL_V1_PRESENT_METHOD_DEFAULT,
+                                                NULL);
 
         /* Configure the surface so that it respects the width and height
          * environment variables */
@@ -2214,11 +2114,11 @@ create_window (GError **error)
         win_data.is_fullscreen = false;
 
         if (wl_data.xdg_shell != NULL) {
-            xdg_toplevel_set_maximized (win_data.xdg_toplevel);
+            xdg_toplevel_set_maximized(win_data.xdg_toplevel);
         } else if (wl_data.shell != NULL) {
-            wl_shell_surface_set_maximized (win_data.shell_surface, NULL);
+            wl_shell_surface_set_maximized(win_data.shell_surface, NULL);
         } else {
-            g_warning ("No available shell capable of maximizing.");
+            g_warning("No available shell capable of maximizing.");
             win_data.is_maximized = false;
         }
     }
@@ -2227,31 +2127,31 @@ create_window (GError **error)
 }
 
 static void
-destroy_window (void)
+destroy_window(void)
 {
-    g_clear_pointer (&win_data.xdg_toplevel, xdg_toplevel_destroy);
-    g_clear_pointer (&win_data.xdg_surface, xdg_surface_destroy);
-    g_clear_pointer (&win_data.shell_surface, wl_shell_surface_destroy);
-    g_clear_pointer (&win_data.wl_surface, wl_surface_destroy);
+    g_clear_pointer(&win_data.xdg_toplevel, xdg_toplevel_destroy);
+    g_clear_pointer(&win_data.xdg_surface, xdg_surface_destroy);
+    g_clear_pointer(&win_data.shell_surface, wl_shell_surface_destroy);
+    g_clear_pointer(&win_data.wl_surface, wl_surface_destroy);
 
 #if COG_ENABLE_WESTON_DIRECT_DISPLAY
-    g_clear_pointer (&win_data.video_surfaces, g_hash_table_destroy);
+    g_clear_pointer(&win_data.video_surfaces, g_hash_table_destroy);
 #endif
 }
 
 static void
-create_popup (WebKitOptionMenu *option_menu)
+create_popup(WebKitOptionMenu *option_menu)
 {
     popup_data.option_menu = option_menu;
 
     popup_data.width = win_data.width;
-    popup_data.height = cog_popup_menu_get_height_for_option_menu (option_menu);
+    popup_data.height = cog_popup_menu_get_height_for_option_menu(option_menu);
 
     popup_data.popup_menu = cog_popup_menu_create(option_menu, wl_data.shm, popup_data.width, popup_data.height,
                                                   wl_data.current_output->scale);
 
-    popup_data.wl_surface = wl_compositor_create_surface (wl_data.compositor);
-    g_assert (popup_data.wl_surface);
+    popup_data.wl_surface = wl_compositor_create_surface(wl_data.compositor);
+    g_assert(popup_data.wl_surface);
 
 #ifdef WL_SURFACE_SET_BUFFER_SCALE_SINCE_VERSION
     if (wl_surface_get_version(popup_data.wl_surface) >= WL_SURFACE_SET_BUFFER_SCALE_SINCE_VERSION)
@@ -2259,94 +2159,80 @@ create_popup (WebKitOptionMenu *option_menu)
 #endif /* WL_SURFACE_SET_BUFFER_SCALE_SINCE_VERSION */
 
     if (wl_data.xdg_shell != NULL) {
-        popup_data.xdg_positioner = xdg_wm_base_create_positioner (wl_data.xdg_shell);
+        popup_data.xdg_positioner = xdg_wm_base_create_positioner(wl_data.xdg_shell);
         g_assert(popup_data.xdg_positioner);
 
-        xdg_positioner_set_size (popup_data.xdg_positioner,
-                                 popup_data.width,
-                                 popup_data.height);
+        xdg_positioner_set_size(popup_data.xdg_positioner, popup_data.width, popup_data.height);
         xdg_positioner_set_anchor_rect(popup_data.xdg_positioner, 0, (win_data.height - popup_data.height),
                                        popup_data.width, popup_data.height);
 
-        popup_data.xdg_surface = xdg_wm_base_get_xdg_surface (wl_data.xdg_shell,
-                                                              popup_data.wl_surface);
-        g_assert (popup_data.xdg_surface);
+        popup_data.xdg_surface = xdg_wm_base_get_xdg_surface(wl_data.xdg_shell, popup_data.wl_surface);
+        g_assert(popup_data.xdg_surface);
 
-        xdg_surface_add_listener (popup_data.xdg_surface,
-                                  &xdg_surface_listener,
-                                  NULL);
-        popup_data.xdg_popup = xdg_surface_get_popup (popup_data.xdg_surface,
-                                                      win_data.xdg_surface,
-                                                      popup_data.xdg_positioner);
-        g_assert (popup_data.xdg_popup);
+        xdg_surface_add_listener(popup_data.xdg_surface, &xdg_surface_listener, NULL);
+        popup_data.xdg_popup =
+            xdg_surface_get_popup(popup_data.xdg_surface, win_data.xdg_surface, popup_data.xdg_positioner);
+        g_assert(popup_data.xdg_popup);
 
-        xdg_popup_add_listener (popup_data.xdg_popup,
-                                &xdg_popup_listener,
-                                NULL);
-        xdg_popup_grab (popup_data.xdg_popup, wl_data.seat, wl_data.event_serial);
-        wl_surface_commit (popup_data.wl_surface);
+        xdg_popup_add_listener(popup_data.xdg_popup, &xdg_popup_listener, NULL);
+        xdg_popup_grab(popup_data.xdg_popup, wl_data.seat, wl_data.event_serial);
+        wl_surface_commit(popup_data.wl_surface);
     } else if (wl_data.shell != NULL) {
-        popup_data.shell_surface = wl_shell_get_shell_surface (wl_data.shell,
-                                                               popup_data.wl_surface);
+        popup_data.shell_surface = wl_shell_get_shell_surface(wl_data.shell, popup_data.wl_surface);
         g_assert(popup_data.shell_surface);
 
-        wl_shell_surface_add_listener (popup_data.shell_surface,
-                                       &shell_popup_surface_listener,
-                                       NULL);
-        wl_shell_surface_set_popup (popup_data.shell_surface,
-                                    wl_data.seat, wl_data.event_serial,
-                                    win_data.wl_surface,
-                                    0, (win_data.height - popup_data.height), 0);
+        wl_shell_surface_add_listener(popup_data.shell_surface, &shell_popup_surface_listener, NULL);
+        wl_shell_surface_set_popup(popup_data.shell_surface, wl_data.seat, wl_data.event_serial, win_data.wl_surface, 0,
+                                   (win_data.height - popup_data.height), 0);
 
         display_popup();
     }
 }
 
 static void
-destroy_popup (void)
+destroy_popup(void)
 {
     if (popup_data.option_menu == NULL)
         return;
 
-    webkit_option_menu_close (popup_data.option_menu);
-    g_clear_pointer (&popup_data.popup_menu, cog_popup_menu_destroy);
-    g_clear_object (&popup_data.option_menu);
+    webkit_option_menu_close(popup_data.option_menu);
+    g_clear_pointer(&popup_data.popup_menu, cog_popup_menu_destroy);
+    g_clear_object(&popup_data.option_menu);
 
-    g_clear_pointer (&popup_data.xdg_popup, xdg_popup_destroy);
-    g_clear_pointer (&popup_data.xdg_surface, xdg_surface_destroy);
-    g_clear_pointer (&popup_data.xdg_positioner, xdg_positioner_destroy);
-    g_clear_pointer (&popup_data.shell_surface, wl_shell_surface_destroy);
-    g_clear_pointer (&popup_data.wl_surface, wl_surface_destroy);
+    g_clear_pointer(&popup_data.xdg_popup, xdg_popup_destroy);
+    g_clear_pointer(&popup_data.xdg_surface, xdg_surface_destroy);
+    g_clear_pointer(&popup_data.xdg_positioner, xdg_positioner_destroy);
+    g_clear_pointer(&popup_data.shell_surface, wl_shell_surface_destroy);
+    g_clear_pointer(&popup_data.wl_surface, wl_surface_destroy);
 
     popup_data.configured = false;
 }
 
 static void
-display_popup (void)
+display_popup(void)
 {
-    struct wl_buffer *buffer = cog_popup_menu_get_buffer (popup_data.popup_menu);
-    wl_surface_attach (popup_data.wl_surface, buffer, 0, 0);
-    wl_surface_damage (popup_data.wl_surface, 0, 0, INT32_MAX, INT32_MAX);
-    wl_surface_commit (popup_data.wl_surface);
+    struct wl_buffer *buffer = cog_popup_menu_get_buffer(popup_data.popup_menu);
+    wl_surface_attach(popup_data.wl_surface, buffer, 0, 0);
+    wl_surface_damage(popup_data.wl_surface, 0, 0, INT32_MAX, INT32_MAX);
+    wl_surface_commit(popup_data.wl_surface);
 }
 
 static void
-update_popup (void)
+update_popup(void)
 {
-    int selected_index;
-    bool has_final_selection = cog_popup_menu_has_final_selection (popup_data.popup_menu,
-                                                                   &selected_index);
+    int  selected_index;
+    bool has_final_selection = cog_popup_menu_has_final_selection(popup_data.popup_menu, &selected_index);
     if (has_final_selection) {
         if (selected_index != -1)
-            webkit_option_menu_activate_item (popup_data.option_menu, selected_index);
-        destroy_popup ();
+            webkit_option_menu_activate_item(popup_data.option_menu, selected_index);
+        destroy_popup();
         return;
     }
 
-    struct wl_buffer *buffer = cog_popup_menu_get_buffer (popup_data.popup_menu);
-    wl_surface_attach (popup_data.wl_surface, buffer, 0, 0);
-    wl_surface_damage (popup_data.wl_surface, 0, 0, INT32_MAX, INT32_MAX);
-    wl_surface_commit (popup_data.wl_surface);
+    struct wl_buffer *buffer = cog_popup_menu_get_buffer(popup_data.popup_menu);
+    wl_surface_attach(popup_data.wl_surface, buffer, 0, 0);
+    wl_surface_damage(popup_data.wl_surface, 0, 0, INT32_MAX, INT32_MAX);
+    wl_surface_commit(popup_data.wl_surface);
 }
 
 static gboolean
@@ -2355,16 +2241,13 @@ init_input(CogWlPlatform *self, GError **error)
     if (wl_data.seat != NULL) {
         wl_seat_add_listener(wl_data.seat, &seat_listener, self);
 
-        xkb_data.context = xkb_context_new (XKB_CONTEXT_NO_FLAGS);
-        g_assert (xkb_data.context);
-        xkb_data.compose_table =
-            xkb_compose_table_new_from_locale (xkb_data.context,
-                                               setlocale (LC_CTYPE, NULL),
-                                               XKB_COMPOSE_COMPILE_NO_FLAGS);
+        xkb_data.context = xkb_context_new(XKB_CONTEXT_NO_FLAGS);
+        g_assert(xkb_data.context);
+        xkb_data.compose_table = xkb_compose_table_new_from_locale(xkb_data.context,
+                                                                   setlocale(LC_CTYPE, NULL),
+                                                                   XKB_COMPOSE_COMPILE_NO_FLAGS);
         if (xkb_data.compose_table != NULL) {
-            xkb_data.compose_state =
-                xkb_compose_state_new (xkb_data.compose_table,
-                                       XKB_COMPOSE_STATE_NO_FLAGS);
+            xkb_data.compose_state = xkb_compose_state_new(xkb_data.compose_table, XKB_COMPOSE_STATE_NO_FLAGS);
         }
 
         if (wl_data.text_input_manager != NULL) {
@@ -2405,14 +2288,14 @@ clear_buffers(void)
 {
 #if HAVE_SHM_EXPORTED_BUFFER
     struct shm_buffer *buffer, *tmp;
-    wl_list_for_each_safe (buffer, tmp, &wl_data.shm_buffer_list, link) {
+    wl_list_for_each_safe(buffer, tmp, &wl_data.shm_buffer_list, link) {
 
-        wl_list_remove (&buffer->link);
-        wl_list_remove (&buffer->destroy_listener.link);
+        wl_list_remove(&buffer->link);
+        wl_list_remove(&buffer->destroy_listener.link);
 
-        shm_buffer_destroy (buffer);
+        shm_buffer_destroy(buffer);
     }
-    wl_list_init (&wl_data.shm_buffer_list);
+    wl_list_init(&wl_data.shm_buffer_list);
 #endif
 }
 
@@ -2427,42 +2310,42 @@ gamepad_provider_get_view_backend_for_gamepad(void *provider G_GNUC_UNUSED, void
 static gboolean
 cog_wl_platform_setup(CogPlatform *platform, CogShell *shell G_GNUC_UNUSED, const char *params, GError **error)
 {
-    g_return_val_if_fail (COG_IS_SHELL (shell), FALSE);
+    g_return_val_if_fail(COG_IS_SHELL(shell), FALSE);
 
-    if (!wpe_loader_init ("libWPEBackend-fdo-1.0.so")) {
-        g_set_error_literal (error,
-                             COG_PLATFORM_WPE_ERROR,
-                             COG_PLATFORM_WPE_ERROR_INIT,
-                             "Failed to set backend library name");
+    if (!wpe_loader_init("libWPEBackend-fdo-1.0.so")) {
+        g_set_error_literal(error,
+                            COG_PLATFORM_WPE_ERROR,
+                            COG_PLATFORM_WPE_ERROR_INIT,
+                            "Failed to set backend library name");
         return FALSE;
     }
 
-    if (!init_wayland (error))
+    if (!init_wayland(error))
         return FALSE;
 
-    if (!init_egl (error)) {
-        clear_wayland ();
+    if (!init_egl(error)) {
+        clear_wayland();
         return FALSE;
     }
 
-    if (!create_window (error)) {
-        clear_egl ();
+    if (!create_window(error)) {
+        clear_egl();
         clear_wayland();
         return FALSE;
     }
 
     if (!init_input(COG_WL_PLATFORM(platform), error)) {
-        destroy_window ();
+        destroy_window();
         clear_egl();
-        clear_wayland ();
+        clear_wayland();
         return FALSE;
     }
 
     /* init WPE host data */
-    wpe_fdo_initialize_for_egl_display (egl_data.display);
+    wpe_fdo_initialize_for_egl_display(egl_data.display);
 
 #if COG_ENABLE_WESTON_DIRECT_DISPLAY
-    wpe_video_plane_display_dmabuf_register_receiver (&video_plane_display_dmabuf_receiver, NULL);
+    wpe_video_plane_display_dmabuf_register_receiver(&video_plane_display_dmabuf_receiver, NULL);
 #endif
 
     cog_gamepad_setup(gamepad_provider_get_view_backend_for_gamepad);
@@ -2480,7 +2363,7 @@ cog_wl_platform_finalize(GObject *object)
         wpe_view_backend_exportable_fdo_egl_dispatch_release_exported_image(wpe_host_data.exportable,
                                                                             wpe_view_data.image);
     }
-    g_clear_pointer (&wpe_view_data.buffer, wl_buffer_destroy);
+    g_clear_pointer(&wpe_view_data.buffer, wl_buffer_destroy);
 
     /* @FIXME: check why this segfaults
     wpe_view_backend_destroy (wpe_view_data.backend);
@@ -2493,11 +2376,11 @@ cog_wl_platform_finalize(GObject *object)
 
     clear_buffers();
 
-    clear_input ();
-    destroy_popup ();
-    destroy_window ();
+    clear_input();
+    destroy_popup();
+    destroy_window();
     clear_egl();
-    clear_wayland ();
+    clear_wayland();
 
     G_OBJECT_CLASS(cog_wl_platform_parent_class)->finalize(object);
 }
@@ -2534,9 +2417,7 @@ cog_wl_platform_get_view_backend(CogPlatform *platform, WebKitWebView *related_v
 #endif
 
     if (!wl_data.event_src) {
-        wl_data.event_src =
-            setup_wayland_event_source (g_main_context_get_thread_default (),
-                                        wl_data.display);
+        wl_data.event_src = setup_wayland_event_source(g_main_context_get_thread_default(), wl_data.display);
     }
 
     return wk_view_backend;
@@ -2545,13 +2426,13 @@ cog_wl_platform_get_view_backend(CogPlatform *platform, WebKitWebView *related_v
 static void
 on_show_option_menu(WebKitWebView *view, WebKitOptionMenu *menu, WebKitRectangle *rectangle, gpointer *data)
 {
-    create_popup (g_object_ref (menu));
+    create_popup(g_object_ref(menu));
 }
 
 static void
 cog_wl_platform_init_web_view(CogPlatform *platform, WebKitWebView *view)
 {
-    g_signal_connect (view, "show-option-menu", G_CALLBACK (on_show_option_menu), NULL);
+    g_signal_connect(view, "show-option-menu", G_CALLBACK(on_show_option_menu), NULL);
     COG_WL_PLATFORM(platform)->web_view = view;
 }
 


### PR DESCRIPTION
The wl_surface_frame callback has all that it needs from the context. It also doesn't requires a reference in wpe_view_data since it is auto destroyed during the callback action.

Also formatting fixes.