### PR TITLE
drm: Fix crash on imx6 when no current encoder+crtc is bound

### DIFF
--- a/platform/drm/cog-platform-drm.c
+++ b/platform/drm/cog-platform-drm.c
@@ -353,7 +353,8 @@ check_drm(void)
 }
 
 static int32_t
-find_crtc_for_encoder(const drmModeRes *resources, const drmModeEncoder *encoder) {
+find_crtc_for_encoder(const drmModeRes *resources, const drmModeEncoder *encoder)
+{
     for (int i = 0; i < resources->count_crtcs; i++) {
         const uint32_t crtc_mask = 1 << i;
         const uint32_t crtc_id = resources->crtcs[i];

--- a/platform/drm/cog-platform-drm.c
+++ b/platform/drm/cog-platform-drm.c
@@ -354,9 +354,7 @@ check_drm(void)
 
 static int32_t
 find_crtc_for_encoder(const drmModeRes *resources, const drmModeEncoder *encoder) {
-    int i;
-
-    for (i = 0; i < resources->count_crtcs; i++) {
+    for (int i = 0; i < resources->count_crtcs; i++) {
         const uint32_t crtc_mask = 1 << i;
         const uint32_t crtc_id = resources->crtcs[i];
         if (encoder->possible_crtcs & crtc_mask) {

--- a/platform/drm/cog-platform-drm.c
+++ b/platform/drm/cog-platform-drm.c
@@ -518,7 +518,7 @@ init_drm(void)
         }
 
         const int32_t crtc_id = find_crtc_for_encoder(drm_data.base_resources, drm_data.encoder);
-        if (crtc_id != 0) {
+        if (crtc_id != -1) {
             drm_data.crtc.obj_id = crtc_id;
             break;
         }


### PR DESCRIPTION
imx6 crashes when trying drm backend. This depends heavily on board used and this fix is generic. Doesn't affect existing configs but just fixed edge case for specific board when no default endoder+crtc was found