### PR TITLE
Fix deleting the view after signal close

### DIFF
--- a/core/cog-shell.c
+++ b/core/cog-shell.c
@@ -168,7 +168,6 @@ cog_shell_startup_base(CogShell *shell)
     }
 
     g_signal_emit (shell, s_signals[CREATE_VIEW], 0, &priv->web_view);
-    g_object_ref_sink (priv->web_view);
     g_object_notify_by_pspec (G_OBJECT (shell), s_properties[PROP_WEB_VIEW]);
 
     /*


### PR DESCRIPTION
WebKitWebView inherits from GObject so it is not needed to do g_object_ref_sink on it. It fixes the problem with deleting the view after receiving "close" signal.