### PR TITLE
check-style: Support reading a file with ignored paths

### DIFF
--- a/.check-style-ignore
+++ b/.check-style-ignore
@@ -1,3 +1,7 @@
 # File paths matching the regular expressions in this file (one per line)
 # will be skipped by data/check-style. Empty lines and lines starting with
 # a hash mark are ignored.
+
+platform/common/xdp-parent-private\.h$
+platform/drm/kms\.[hc]$
+platform/wayland/os-compatibility\.[hc]$

--- a/.check-style-ignore
+++ b/.check-style-ignore
@@ -1,0 +1,3 @@
+# File paths matching the regular expressions in this file (one per line)
+# will be skipped by data/check-style. Empty lines and lines starting with
+# a hash mark are ignored.

--- a/data/check-style
+++ b/data/check-style
@@ -121,8 +121,21 @@ else
     input_cmd=(git diff --no-color -U0 "${BASE}" "${HEAD}")
 fi
 
+declare -a ignore_iregex_flags=( )
+ignore_iregex_file="$(dirname "$0")/../.check-style-ignore"
+declare -r ignore_iregex_file
+
+if [[ -r ${ignore_iregex_file} ]] ; then
+    while read -r ignore_iregex_line ; do
+        if [[ -z ${ignore_iregex_line} || ${ignore_iregex_line} = \#* ]] ; then
+            continue
+        fi
+        ignore_iregex_flags+=(-iregex "${ignore_iregex_line}")
+    done < "${ignore_iregex_file}"
+fi
+
 "${input_cmd[@]}" \
-    | "${clang_format_diff}" -p1 -style=file -regex='.+\.(c|h)' \
+    | "${clang_format_diff}" -p1 -style=file -regex='.+\.(c|h)' "${ignore_iregex_flags[@]}" \
     | tee "${FILE}"
 
 [[ ! -s ${FILE} ]]


### PR DESCRIPTION
Add support for reading a `.check-style-ignore` file, with a regex in each line for ignored style checker paths.

Fixes #615