### PR TITLE
[wip] wl: Add CogWlPlatform::resized-window signal

### DIFF
--- a/platform/wayland/cog-platform-wl.c
+++ b/platform/wayland/cog-platform-wl.c
@@ -70,6 +70,15 @@
 #    include <wayland-cursor.h>
 #endif
 
+enum {
+    RESIZED_WINDOW,
+    N_SIGNALS,
+};
+
+static int s_signals[N_SIGNALS] = {
+    0,
+};
+
 G_DEFINE_DYNAMIC_TYPE_EXTENDED(
     CogWlPlatform,
     cog_wl_platform,
@@ -211,7 +220,7 @@ cog_wl_platform_configure_geometry(CogWlPlatform *platform, int32_t width, int32
         platform->window.width = width;
         platform->window.height = height;
 
-        cog_wl_view_resize(platform->view);
+        g_signal_emit(platform, s_signals[RESIZED_WINDOW], 0);
     }
 }
 
@@ -2020,6 +2029,21 @@ cog_wl_platform_class_init(CogWlPlatformClass *klass)
     platform_class->setup = cog_wl_platform_setup;
     platform_class->init_web_view = cog_wl_platform_init_web_view;
     platform_class->create_im_context = cog_wl_platform_create_im_context;
+
+    /**
+     * CogWlPlatform::resized-window:
+     * @self: The platform.
+     * @user_data: User data.
+     *
+     * The `resized-window` signal is emitted when the window is resized.
+     *
+     * Handling this signal allows to react to changes in the geometry of
+     * the window.
+     *
+     * Returns: (void)
+     */
+    s_signals[RESIZED_WINDOW] =
+        g_signal_new("resized-window", COG_WL_PLATFORM_TYPE, G_SIGNAL_RUN_LAST, 0, NULL, NULL, NULL, G_TYPE_NONE, 0);
 }
 
 static void

--- a/platform/wayland/cog-platform-wl.h
+++ b/platform/wayland/cog-platform-wl.h
@@ -17,6 +17,8 @@ G_BEGIN_DECLS
 
 typedef struct _CogWlView CogWlView;
 
+#define COG_WL_PLATFORM_TYPE cog_wl_platform_get_type()
+
 G_DECLARE_FINAL_TYPE(CogWlPlatform, cog_wl_platform, COG, WL_PLATFORM, CogPlatform)
 
 struct _CogWlPlatformClass {

--- a/platform/wayland/cog-view-wl.c
+++ b/platform/wayland/cog-view-wl.c
@@ -37,6 +37,7 @@ static void                  cog_wl_view_dispose(GObject *);
 #if HAVE_FULLSCREEN_HANDLING
 static bool cog_wl_view_handle_dom_fullscreen_request(void *, bool);
 #endif
+static void cog_wl_view_resize(CogWlView *, CogWlPlatform *);
 
 static void cog_wl_view_shm_buffer_destroy(CogWlView *, struct shm_buffer *);
 
@@ -95,6 +96,7 @@ cog_wl_view_init(CogWlView *self)
     wl_list_init(&self->shm_buffer_list);
 
     g_signal_connect(self, "show-option-menu", G_CALLBACK(on_show_option_menu), NULL);
+    g_signal_connect_swapped(self->platform, "resized-window", G_CALLBACK(cog_wl_view_resize), self);
 }
 
 /*
@@ -280,13 +282,11 @@ cog_wl_view_request_frame(CogWlView *view)
     }
 }
 
-void
-cog_wl_view_resize(CogWlView *view)
+static void
+cog_wl_view_resize(CogWlView *view, CogWlPlatform *platform)
 {
-    g_assert(view->platform);
-    CogWlPlatform *platform = view->platform;
-    CogWlDisplay  *display = platform->display;
-    CogWlWindow   *window = &platform->window;
+    CogWlDisplay *display = platform->display;
+    CogWlWindow  *window = &platform->window;
 
     view->should_update_opaque_region = true;
 

--- a/platform/wayland/cog-view-wl.h
+++ b/platform/wayland/cog-view-wl.h
@@ -43,6 +43,7 @@ G_DECLARE_FINAL_TYPE(CogWlView, cog_wl_view, COG, WL_VIEW, CogView)
  */
 
 void cog_wl_view_enter_fullscreen(CogWlView *);
+void cog_wl_view_resize(CogWlView *);
 
 void cog_wl_view_register_type_exported(GTypeModule *type_module);
 

--- a/platform/wayland/cog-view-wl.h
+++ b/platform/wayland/cog-view-wl.h
@@ -43,7 +43,6 @@ G_DECLARE_FINAL_TYPE(CogWlView, cog_wl_view, COG, WL_VIEW, CogView)
  */
 
 void cog_wl_view_enter_fullscreen(CogWlView *);
-void cog_wl_view_resize(CogWlView *);
 
 void cog_wl_view_register_type_exported(GTypeModule *type_module);
 


### PR DESCRIPTION
The `resized-window` signal is emitted when the window is resized.
    
Handling this signal allows to react to changes in the geometry of the window and decouples the CogWlView from the CogWlPlatform internal    logic.
    
The view (or the views in the future) is now connected to this signal and reacts according.
    
This change is motivated towards the progress of being able to have more than one view.


**DEPENDS ON:** https://github.com/Igalia/cog/pull/625