### PR TITLE
[wip]  wl: Add CogWlPlatform fullscreen-enter and fullscreen-exit signals 

### DIFF
--- a/platform/wayland/cog-platform-wl.c
+++ b/platform/wayland/cog-platform-wl.c
@@ -70,6 +70,16 @@
 #    include <wayland-cursor.h>
 #endif
 
+enum {
+    FULLSCREEN_ENTER,
+    FULLSCREEN_EXIT,
+    N_SIGNALS,
+};
+
+static int s_signals[N_SIGNALS] = {
+    0,
+};
+
 G_DEFINE_DYNAMIC_TYPE_EXTENDED(
     CogWlPlatform,
     cog_wl_platform,
@@ -258,7 +268,7 @@ cog_wl_platform_enter_fullscreen(CogWlPlatform *platform)
     }
 
     // Wait until a new exported image is reveived. See cog_wl_view_enter_fullscreen().
-    cog_wl_view_enter_fullscreen(platform->view);
+    g_signal_emit(platform, s_signals[FULLSCREEN_ENTER], 0);
 }
 
 static void
@@ -282,7 +292,7 @@ cog_wl_platform_exit_fullscreen(CogWlPlatform *platform)
 
 #if HAVE_FULLSCREEN_HANDLING
     if (window->was_fullscreen_requested_from_dom) {
-        cog_wl_view_exit_fullscreen(platform->view);
+        g_signal_emit(platform, s_signals[FULLSCREEN_EXIT], 0);
     }
     window->was_fullscreen_requested_from_dom = false;
 #endif
@@ -2057,6 +2067,38 @@ cog_wl_platform_class_init(CogWlPlatformClass *klass)
     platform_class->setup = cog_wl_platform_setup;
     platform_class->init_web_view = cog_wl_platform_init_web_view;
     platform_class->create_im_context = cog_wl_platform_create_im_context;
+
+    /**
+￼    * CogWlPlatform::fullscreen-enter:
+￼    * @self: The platform.
+￼    * @user_data: User data.
+￼    *
+￼    * The `fullscreen-enter` signal is emitted when the window enters the
+￼    * fullscreen mode.
+￼    *
+￼    * Handling this signal allows to react when the window enter the
+￼    * fullscreen mode.
+￼    *
+￼    * Returns: (void)
+￼    */
+    s_signals[FULLSCREEN_ENTER] =
+        g_signal_new("fullscreen-enter", COG_WL_PLATFORM_TYPE, G_SIGNAL_RUN_LAST, 0, NULL, NULL, NULL, G_TYPE_NONE, 0);
+
+    /**
+￼    * CogWlPlatform::fullscreen-exit:
+￼    * @self: The platform.
+￼    * @user_data: User data.
+￼    *
+￼    * The `fullscreen-exit` signal is emitted when the window exits the
+￼    * fullscreen mode.
+￼    *
+￼    * Handling this signal allows to react when the window exit the
+￼    * fullscreen mode.
+￼    *
+￼    * Returns: (void)
+￼    */
+    s_signals[FULLSCREEN_EXIT] =
+        g_signal_new("fullscreen-exit", COG_WL_PLATFORM_TYPE, G_SIGNAL_RUN_LAST, 0, NULL, NULL, NULL, G_TYPE_NONE, 0);
 }
 
 static void

--- a/platform/wayland/cog-platform-wl.h
+++ b/platform/wayland/cog-platform-wl.h
@@ -17,6 +17,8 @@ G_BEGIN_DECLS
 
 typedef struct _CogWlView CogWlView;
 
+#define COG_WL_PLATFORM_TYPE cog_wl_platform_get_type()
+
 G_DECLARE_FINAL_TYPE(CogWlPlatform, cog_wl_platform, COG, WL_PLATFORM, CogPlatform)
 
 struct _CogWlPlatformClass {

--- a/platform/wayland/cog-utils-wl.h
+++ b/platform/wayland/cog-utils-wl.h
@@ -113,7 +113,6 @@ struct _CogWlWindow {
 #if HAVE_FULLSCREEN_HANDLING
     bool was_fullscreen_requested_from_dom;
 #endif
-    bool is_resizing_fullscreen;
     bool is_maximized;
     bool should_resize_to_largest_output;
 };

--- a/platform/wayland/cog-view-wl.c
+++ b/platform/wayland/cog-view-wl.c
@@ -34,6 +34,8 @@ G_DEFINE_DYNAMIC_TYPE(CogWlView, cog_wl_view, COG_TYPE_VIEW)
 static void                  cog_wl_view_clear_buffers(CogWlView *);
 static WebKitWebViewBackend *cog_wl_view_create_backend(CogView *);
 static void                  cog_wl_view_dispose(GObject *);
+void                         cog_wl_view_enter_fullscreen(CogWlView *);
+void                         cog_wl_view_exit_fullscreen(CogWlView *);
 #if HAVE_FULLSCREEN_HANDLING
 static bool cog_wl_view_handle_dom_fullscreen_request(void *, bool);
 #endif
@@ -94,6 +96,8 @@ cog_wl_view_init(CogWlView *self)
     wl_list_init(&self->shm_buffer_list);
 
     g_signal_connect(self, "show-option-menu", G_CALLBACK(on_show_option_menu), NULL);
+    g_signal_connect_swapped(self->platform, "fullscreen-enter", G_CALLBACK(cog_wl_view_enter_fullscreen), self);
+    g_signal_connect_swapped(self->platform, "fullscreen-exit", G_CALLBACK(cog_wl_view_exit_fullscreen), self);
 }
 
 /*

--- a/platform/wayland/cog-view-wl.h
+++ b/platform/wayland/cog-view-wl.h
@@ -46,7 +46,4 @@ G_DECLARE_FINAL_TYPE(CogWlView, cog_wl_view, COG, WL_VIEW, CogView)
 
 void cog_wl_view_register_type_exported(GTypeModule *type_module);
 
-void cog_wl_view_enter_fullscreen(CogWlView *);
-void cog_wl_view_exit_fullscreen(CogWlView *);
-
 G_END_DECLS

--- a/platform/wayland/cog-view-wl.h
+++ b/platform/wayland/cog-view-wl.h
@@ -28,6 +28,8 @@ struct _CogWlView {
     struct wpe_view_backend_exportable_fdo *exportable;
     struct wpe_fdo_egl_exported_image      *image;
 
+    bool is_resizing_fullscreen;
+
     struct wl_callback *frame_callback;
 
     bool    should_update_opaque_region;
@@ -42,8 +44,9 @@ G_DECLARE_FINAL_TYPE(CogWlView, cog_wl_view, COG, WL_VIEW, CogView)
  * Method declarations.
  */
 
-void cog_wl_view_enter_fullscreen(CogWlView *);
-
 void cog_wl_view_register_type_exported(GTypeModule *type_module);
+
+void cog_wl_view_enter_fullscreen(CogWlView *);
+void cog_wl_view_exit_fullscreen(CogWlView *);
 
 G_END_DECLS


### PR DESCRIPTION
Simply the code in CogWlPlatform by adding the "fullscreen-enter" and    "fullscreen-exit" signals to notify to the view that the window is being   entering or exiting from the fullscreen.
    
This change is motivated towards the progress of being able to have more than one view.

**DEPENDS ON:** https://github.com/Igalia/cog/pull/629