### PR TITLE
Change source headers to use SPDX license identifiers

### DIFF
--- a/core/cog-directory-files-handler.c
+++ b/core/cog-directory-files-handler.c
@@ -2,7 +2,7 @@
  * cog-directory-files-handler.c
  * Copyright (C) 2017-2018 Adrian Perez <aperez@igalia.com>
  *
- * Distributed under terms of the MIT license.
+ * SPDX-License-Identifier: MIT
  */
 
 #include "cog-directory-files-handler.h"

--- a/core/cog-directory-files-handler.h
+++ b/core/cog-directory-files-handler.h
@@ -2,7 +2,7 @@
  * cog-directory-files-handler.h
  * Copyright (C) 2017-2018 Adrian Perez <aperez@igalia.com>
  *
- * Distributed under terms of the MIT license.
+ * SPDX-License-Identifier: MIT
  */
 
 #ifndef COG_DIRECTORY_FILES_HANDLER_H

--- a/core/cog-gamepad-manette.c
+++ b/core/cog-gamepad-manette.c
@@ -2,7 +2,7 @@
  * cog-gamepad-manette.c
  * Copyright (C) 2022 Igalia S.L.
  *
- * Distributed under terms of the MIT license.
+ * SPDX-License-Identifier: MIT
  */
 
 #include "cog.h"

--- a/core/cog-gamepad.c
+++ b/core/cog-gamepad.c
@@ -2,7 +2,7 @@
  * cog-gamepad.c
  * Copyright (C) 2022 Igalia S.L.
  *
- * Distributed under terms of the MIT license.
+ * SPDX-License-Identifier: MIT
  */
 
 #include "cog.h"

--- a/core/cog-gamepad.h
+++ b/core/cog-gamepad.h
@@ -2,7 +2,7 @@
  * cog-gamepad.h
  * Copyright (C) 2022 Igalia S.L.
  *
- * Distributed under terms of the MIT license.
+ * SPDX-License-Identifier: MIT
  */
 
 #pragma once

--- a/core/cog-host-routes-handler.c
+++ b/core/cog-host-routes-handler.c
@@ -2,7 +2,7 @@
  * cog-host-routes-handler.c
  * Copyright (C) 2021 Igalia S.L.
  *
- * Distributed under terms of the MIT license.
+ * SPDX-License-Identifier: MIT
  */
 
 #include "cog-host-routes-handler.h"

--- a/core/cog-host-routes-handler.h
+++ b/core/cog-host-routes-handler.h
@@ -2,7 +2,7 @@
  * cog-host-routes-handler.h
  * Copyright (C) 2021 Igalia S.L.
  *
- * Distributed under terms of the MIT license.
+ * SPDX-License-Identifier: MIT
  */
 
 #pragma once

--- a/core/cog-modules.c
+++ b/core/cog-modules.c
@@ -2,7 +2,7 @@
  * cog-modules.c
  * Copyright (C) 2021 Adrian Perez de Castro <aperez@igalia.com>
  *
- * Distributed under terms of the MIT license.
+ * SPDX-License-Identifier: MIT
  */
 
 #include "cog-modules.h"

--- a/core/cog-modules.h
+++ b/core/cog-modules.h
@@ -2,7 +2,7 @@
  * cog-modules.h
  * Copyright (C) 2021 Adrian Perez de Castro <aperez@igalia.com>
  *
- * Distributed under terms of the MIT license.
+ * SPDX-License-Identifier: MIT
  */
 
 #pragma once

--- a/core/cog-platform.c
+++ b/core/cog-platform.c
@@ -3,7 +3,7 @@
  * Copyright (C) 2018 Adrian Perez <aperez@igalia.com>
  * Copyright (C) 2018 Eduardo Lima <elima@igalia.com>
  *
- * Distributed under terms of the MIT license.
+ * SPDX-License-Identifier: MIT
  */
 
 #include "cog-platform.h"

--- a/core/cog-platform.h
+++ b/core/cog-platform.h
@@ -3,7 +3,7 @@
  * Copyright (C) 2018 Adrian Perez <aperez@igalia.com>
  * Copyright (C) 2018 Eduardo Lima <elima@igalia.com>
  *
- * Distributed under terms of the MIT license.
+ * SPDX-License-Identifier: MIT
  */
 
 #ifndef COG_PLATFORM_H

--- a/core/cog-prefix-routes-handler.c
+++ b/core/cog-prefix-routes-handler.c
@@ -2,7 +2,7 @@
  * cog-prefix-routes-handler.c
  * Copyright (C) 2021 Igalia S.L.
  *
- * Distributed under terms of the MIT license.
+ * SPDX-License-Identifier: MIT
  */
 
 #include "cog-prefix-routes-handler.h"

--- a/core/cog-prefix-routes-handler.h
+++ b/core/cog-prefix-routes-handler.h
@@ -2,7 +2,7 @@
  * cog-prefix-routes-handler.h
  * Copyright (C) 2021 Igalia S.L.
  *
- * Distributed under terms of the MIT license.
+ * SPDX-License-Identifier: MIT
  */
 
 #pragma once

--- a/core/cog-request-handler.c
+++ b/core/cog-request-handler.c
@@ -2,7 +2,7 @@
  * cog-request-handler.c
  * Copyright (C) 2017-2018 Adrian Perez <aperez@igalia.com>
  *
- * Distributed under terms of the MIT license.
+ * SPDX-License-Identifier: MIT
  */
 
 #include "cog-request-handler.h"

--- a/core/cog-request-handler.h
+++ b/core/cog-request-handler.h
@@ -2,7 +2,7 @@
  * cog-request-handler.h
  * Copyright (C) 2017-2018 Adrian Perez <aperez@igalia.com>
  *
- * Distributed under terms of the MIT license.
+ * SPDX-License-Identifier: MIT
  */
 
 #ifndef COG_REQUEST_HANDLER_H

--- a/core/cog-shell.c
+++ b/core/cog-shell.c
@@ -2,7 +2,7 @@
  * cog-shell.c
  * Copyright (C) 2018 Adrian Perez <aperez@igalia.com>
  *
- * Distributed under terms of the MIT license.
+ * SPDX-License-Identifier: MIT
  */
 
 #include "cog-shell.h"

--- a/core/cog-shell.h
+++ b/core/cog-shell.h
@@ -2,7 +2,7 @@
  * cog-shell.h
  * Copyright (C) 2018 Adrian Perez <aperez@igalia.com>
  *
- * Distributed under terms of the MIT license.
+ * SPDX-License-Identifier: MIT
  */
 
 #pragma once

--- a/core/cog-utils.c
+++ b/core/cog-utils.c
@@ -2,7 +2,7 @@
  * cog-utils.c
  * Copyright (C) 2018 Adrian Perez <aperez@igalia.com>
  *
- * Distributed under terms of the MIT license.
+ * SPDX-License-Identifier: MIT
  */
 
 #include "cog-utils.h"

--- a/core/cog-utils.h
+++ b/core/cog-utils.h
@@ -2,7 +2,7 @@
  * cog-utils.h
  * Copyright (C) 2018 Adrian Perez <aperez@igalia.com>
  *
- * Distributed under terms of the MIT license.
+ * SPDX-License-Identifier: MIT
  */
 
 #pragma once

--- a/core/cog-webkit-utils.c
+++ b/core/cog-webkit-utils.c
@@ -2,7 +2,7 @@
  * cog-webkit-utils.c
  * Copyright (C) 2018 Adrian Perez <aperez@igalia.com>
  *
- * Distributed under terms of the MIT license.
+ * SPDX-License-Identifier: MIT
  */
 
 #include "cog-webkit-utils.h"

--- a/core/cog-webkit-utils.h
+++ b/core/cog-webkit-utils.h
@@ -3,7 +3,7 @@
  * Copyright (C) 2021 Igalia S.L.
  * Copyright (C) 2017-2018 Adrian Perez <aperez@igalia.com>
  *
- * Distributed under terms of the MIT license.
+ * SPDX-License-Identifier: MIT
  */
 
 #pragma once

--- a/core/cog.h
+++ b/core/cog.h
@@ -4,7 +4,7 @@
  * Copyright (C) 2018 Eduardo Lima <elima@igalia.com>
  * Copyright (C) 2017-2018 Adrian Perez <aperez@igalia.com>
  *
- * Distributed under terms of the MIT license.
+ * SPDX-License-Identifier: MIT
  */
 
 #ifndef COG_H

--- a/launcher/cog-launcher.c
+++ b/launcher/cog-launcher.c
@@ -3,7 +3,7 @@
  * Copyright (C) 2021 Igalia S.L.
  * Copyright (C) 2017-2018 Adrian Perez <aperez@igalia.com>
  *
- * Distributed under terms of the MIT license.
+ * SPDX-License-Identifier: MIT
  */
 
 #include "cog-launcher.h"

--- a/launcher/cog-launcher.h
+++ b/launcher/cog-launcher.h
@@ -3,7 +3,7 @@
  * Copyright (C) 2021 Igalia S.L.
  * Copyright (C) 2017 Adrian Perez <aperez@igalia.com>
  *
- * Distributed under terms of the MIT license.
+ * SPDX-License-Identifier: MIT
  */
 
 #pragma once

--- a/launcher/cog.c
+++ b/launcher/cog.c
@@ -4,7 +4,7 @@
  * Copyright (C) 2018 Eduardo Lima <elima@igalia.com>
  * Copyright (C) 2017-2018 Adrian Perez <aperez@igalia.com>
  *
- * Distributed under terms of the MIT license.
+ * SPDX-License-Identifier: MIT
  */
 
 #include "cog-launcher.h"

--- a/launcher/cogctl.c
+++ b/launcher/cogctl.c
@@ -3,7 +3,7 @@
  * Copyright (C) 2021 Igalia S.L.
  * Copyright (C) 2018 Adrian Perez <aperez@igalia.com>
  *
- * Distributed under terms of the MIT license.
+ * SPDX-License-Identifier: MIT
  */
 
 #define COG_INSIDE_COG__ 1

--- a/platform/common/cog-file-chooser.c
+++ b/platform/common/cog-file-chooser.c
@@ -2,7 +2,7 @@
  * cog-file-chooser.c
  * Copyright (C) 2023 SUSE Software Solutions Germany GmbH
  *
- * Distributed under terms of the MIT license.
+ * SPDX-License-Identifier: MIT
  */
 
 #include "cog-file-chooser.h"

--- a/platform/common/cog-file-chooser.h
+++ b/platform/common/cog-file-chooser.h
@@ -2,7 +2,7 @@
  * cog-file-chooser.h
  * Copyright (C) 2023 SUSE Software Solutions Germany GmbH
  *
- * Distributed under terms of the MIT license.
+ * SPDX-License-Identifier: MIT
  */
 
 #pragma once

--- a/platform/common/cog-gl-utils.c
+++ b/platform/common/cog-gl-utils.c
@@ -2,7 +2,7 @@
  * cog-gl-utils.c
  * Copyright (C) 2021-2022 Igalia S.L.
  *
- * Distributed under terms of the MIT license.
+ * SPDX-License-Identifier: MIT
  */
 
 #include "cog-gl-utils.h"

--- a/platform/common/cog-gl-utils.h
+++ b/platform/common/cog-gl-utils.h
@@ -2,7 +2,7 @@
  * cog-gl-utils.h
  * Copyright (C) 2021-2022 Igalia S.L.
  *
- * Distributed under terms of the MIT license.
+ * SPDX-License-Identifier: MIT
  */
 
 #pragma once

--- a/platform/common/cursors.h
+++ b/platform/common/cursors.h
@@ -2,7 +2,7 @@
  * cursors.h
  * Copyright (C) 2023 SUSE Software Solutions Germany GmbH
  *
- * Distributed under terms of the MIT license.
+ * SPDX-License-Identifier: MIT
  */
 
 #pragma once

--- a/platform/common/egl-proc-address.h
+++ b/platform/common/egl-proc-address.h
@@ -2,7 +2,7 @@
  * egl-proc-address.h
  * Copyright (C) 2020 Igalia S.L.
  *
- * Distributed under terms of the MIT license.
+ * SPDX-License-Identifier: MIT
  */
 
 #pragma once

--- a/platform/drm/cog-drm-gles-renderer.c
+++ b/platform/drm/cog-drm-gles-renderer.c
@@ -2,7 +2,7 @@
  * cog-drm-gles-renderer.c
  * Copyright (C) 2021-2022 Igalia S.L.
  *
- * Distributed under terms of the MIT license.
+ * SPDX-License-Identifier: MIT
  */
 
 #include "../../core/cog.h"

--- a/platform/drm/cog-drm-modeset-renderer.c
+++ b/platform/drm/cog-drm-modeset-renderer.c
@@ -2,7 +2,7 @@
  * cog-drm-modeset-renderer.c
  * Copyright (C) 2021 Igalia S.L.
  *
- * Distributed under terms of the MIT license.
+ * SPDX-License-Identifier: MIT
  */
 
 #include "../../core/cog.h"

--- a/platform/drm/cog-drm-renderer.c
+++ b/platform/drm/cog-drm-renderer.c
@@ -2,7 +2,7 @@
  * cog-drm-renderer.c
  * Copyright (C) 2021 Igalia S.L.
  *
- * Distributed under terms of the MIT license.
+ * SPDX-License-Identifier: MIT
  */
 
 #include "cog-drm-renderer.h"

--- a/platform/drm/cog-drm-renderer.h
+++ b/platform/drm/cog-drm-renderer.h
@@ -2,7 +2,7 @@
  * cog-drm-renderer.h
  * Copyright (C) 2021-2022 Igalia S.L.
  *
- * Distributed under terms of the MIT license.
+ * SPDX-License-Identifier: MIT
  */
 
 #pragma once

--- a/platform/drm/cog-platform-drm.c
+++ b/platform/drm/cog-platform-drm.c
@@ -3,7 +3,7 @@
  * Copyright (C) 2019-2022 Igalia S.L.
  * Copyright (C) 2020 Michal Artazov <michal@artazov.cz>
  *
- * Distributed under terms of the MIT license.
+ * SPDX-License-Identifier: MIT
  */
 
 #include "../../core/cog.h"

--- a/platform/drm/cursor-drm.c
+++ b/platform/drm/cursor-drm.c
@@ -1,3 +1,9 @@
+/*
+ * Copyright (C) 2021 Michal Artazov
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
 #include <drm_fourcc.h>
 #include "cursor-drm.h"
 

--- a/platform/drm/cursor-drm.h
+++ b/platform/drm/cursor-drm.h
@@ -1,3 +1,8 @@
+/*
+ * Copyright (C) 2021 Michal Artazov
+ *
+ * SPDX-License-Identifier: MIT
+ */
 
 #ifndef COG_CURSOR_DRM_H
 #define COG_CURSOR_DRM_H

--- a/platform/gtk4/cog-platform-gtk4.c
+++ b/platform/gtk4/cog-platform-gtk4.c
@@ -2,7 +2,7 @@
  * cog-platform-gtk4.c
  * Copyright (C) 2021-2022 Igalia S.L.
  *
- * Distributed under terms of the MIT license.
+ * SPDX-License-Identifier: MIT
  */
 
 #include "../../core/cog.h"

--- a/platform/headless/cog-platform-headless.c
+++ b/platform/headless/cog-platform-headless.c
@@ -2,7 +2,7 @@
  * cog-platform-headless.c
  * Copyright (C) 2021 Igalia S.L
  *
- * Distributed under terms of the MIT license.
+ * SPDX-License-Identifier: MIT
  */
 
 #include "../../core/cog.h"

--- a/platform/wayland/cog-im-context-wl-v1.c
+++ b/platform/wayland/cog-im-context-wl-v1.c
@@ -2,7 +2,7 @@
  * cog-im-context-wl-v1.c
  * Copyright (C) 2020 Igalia S.L.
  *
- * Distributed under terms of the MIT license.
+ * SPDX-License-Identifier: MIT
  */
 
 #include "cog-im-context-wl-v1.h"

--- a/platform/wayland/cog-im-context-wl-v1.h
+++ b/platform/wayland/cog-im-context-wl-v1.h
@@ -2,7 +2,7 @@
  * cog-platform-wl-v1.h
  * Copyright (C) 2020 Igalia S.L.
  *
- * Distributed under terms of the MIT license.
+ * SPDX-License-Identifier: MIT
  */
 
 #pragma once

--- a/platform/wayland/cog-im-context-wl.c
+++ b/platform/wayland/cog-im-context-wl.c
@@ -2,7 +2,7 @@
  * cog-im-context-wl.c
  * Copyright (C) 2020 Igalia S.L.
  *
- * Distributed under terms of the MIT license.
+ * SPDX-License-Identifier: MIT
  */
 
 #include "cog-im-context-wl.h"

--- a/platform/wayland/cog-im-context-wl.h
+++ b/platform/wayland/cog-im-context-wl.h
@@ -2,7 +2,7 @@
  * cog-platform-wl.h
  * Copyright (C) 2020 Igalia S.L.
  *
- * Distributed under terms of the MIT license.
+ * SPDX-License-Identifier: MIT
  */
 
 #pragma once

--- a/platform/wayland/cog-platform-wl.c
+++ b/platform/wayland/cog-platform-wl.c
@@ -3,7 +3,7 @@
  * Copyright (C) 2018 Eduardo Lima <elima@igalia.com>
  * Copyright (C) 2018 Adrian Perez de Castro <aperez@igalia.com>
  *
- * Distributed under terms of the MIT license.
+ * SPDX-License-Identifier: MIT
  */
 
 #include "../../core/cog.h"

--- a/platform/wayland/cog-platform-wl.h
+++ b/platform/wayland/cog-platform-wl.h
@@ -3,7 +3,7 @@
  * Copyright (C) 2023 Pablo Saavedra <psaavedra@igalia.com>
  * Copyright (C) 2023 Adrian Perez de Castro <aperez@igalia.com>
  *
- * Distributed under terms of the MIT license.
+ * SPDX-License-Identifier: MIT
  */
 
 #pragma once

--- a/platform/wayland/cog-popup-menu-wl.c
+++ b/platform/wayland/cog-popup-menu-wl.c
@@ -2,7 +2,7 @@
  * cog-popup-menu-wl.c
  * Copyright (C) 2020 Igalia S.L.
  *
- * Distributed under terms of the MIT license.
+ * SPDX-License-Identifier: MIT
  */
 
 #include "cog-popup-menu-wl.h"

--- a/platform/wayland/cog-popup-menu-wl.h
+++ b/platform/wayland/cog-popup-menu-wl.h
@@ -2,7 +2,7 @@
  * cog-popup-menu-wl.h
  * Copyright (C) 2020 Igalia S.L.
  *
- * Distributed under terms of the MIT license.
+ * SPDX-License-Identifier: MIT
  */
 
 #pragma once

--- a/platform/wayland/cog-utils-wl.h
+++ b/platform/wayland/cog-utils-wl.h
@@ -3,7 +3,7 @@
  * Copyright (C) 2023 Pablo Saavedra <psaavedra@igalia.com>
  * Copyright (C) 2023 Adrian Perez de Castro <aperez@igalia.com>
  *
- * Distributed under terms of the MIT license.
+ * SPDX-License-Identifier: MIT
  */
 
 #ifndef COG_PLATFORM_WL_UTILS_H

--- a/platform/wayland/cog-xdp-parent-wl.c
+++ b/platform/wayland/cog-xdp-parent-wl.c
@@ -2,7 +2,7 @@
  * cog-xdp-parent-wl.c
  * Copyright (C) 2023 SUSE Software Solutions Germany GmbH
  *
- * Distributed under terms of the MIT license.
+ * SPDX-License-Identifier: MIT
  */
 
 #include "cog-xdp-parent-wl.h"

--- a/platform/wayland/cog-xdp-parent-wl.h
+++ b/platform/wayland/cog-xdp-parent-wl.h
@@ -2,7 +2,7 @@
  * cog-xdp-parent-wl.h
  * Copyright (C) 2023 SUSE Software Solutions Germany GmbH
  *
- * Distributed under terms of the MIT license.
+ * SPDX-License-Identifier: MIT
  */
 
 #pragma once

--- a/platform/x11/cog-platform-x11.c
+++ b/platform/x11/cog-platform-x11.c
@@ -2,7 +2,7 @@
  * cog-platform-x11.c
  * Copyright (C) 2020-2022 Igalia S.L.
  *
- * Distributed under terms of the MIT license.
+ * SPDX-License-Identifier: MIT
  */
 
 #include "../../core/cog.h"

--- a/platform/x11/cog-xdp-parent-x11.c
+++ b/platform/x11/cog-xdp-parent-x11.c
@@ -2,7 +2,7 @@
  * cog-xdp-parent-x11.c
  * Copyright (C) 2023 SUSE Software Solutions Germany GmbH
  *
- * Distributed under terms of the MIT license.
+ * SPDX-License-Identifier: MIT
  */
 
 #include "cog-xdp-parent-x11.h"

--- a/platform/x11/cog-xdp-parent-x11.h
+++ b/platform/x11/cog-xdp-parent-x11.h
@@ -2,7 +2,7 @@
  * cog-xdp-parent-x11.h
  * Copyright (C) 2023 SUSE Software Solutions Germany GmbH
  *
- * Distributed under terms of the MIT license.
+ * SPDX-License-Identifier: MIT
  */
 
 #pragma once


### PR DESCRIPTION
SSIA. Note that there might be some cases in which the style checker trips because the intention is to only modify the license lines in file headers, and add the missing ones.

Fixes #357

----

Note that the style checker may complain in some cases and IMO for this patch which only touches file headers I think it would be reasonable to land the patch ignoring its complaints 😉 