### PR TITLE
wl: Move cog_wl_platform_resize_window() to View as cog_wl_view_resize()

### DIFF
--- a/platform/wayland/cog-platform-wl.c
+++ b/platform/wayland/cog-platform-wl.c
@@ -212,25 +212,9 @@ cog_wl_platform_configure_geometry(CogWlPlatform *platform, int32_t width, int32
         g_debug("Configuring new size: %" PRId32 "x%" PRId32, width, height);
         platform->window.width = width;
         platform->window.height = height;
-        platform->view->should_update_opaque_region = true;
+
+        cog_wl_view_resize(platform->view);
     }
-}
-
-static void
-cog_wl_platform_resize_window(CogWlPlatform *platform)
-{
-    CogWlDisplay *display = platform->display;
-    CogWlWindow  *window = &platform->window;
-
-    int32_t pixel_width = window->width * display->current_output->scale;
-    int32_t pixel_height = window->height * display->current_output->scale;
-
-    struct wpe_view_backend *backend = cog_view_get_backend(COG_VIEW(platform->view));
-    wpe_view_backend_dispatch_set_size(backend, window->width, window->height);
-    wpe_view_backend_dispatch_set_device_scale_factor(backend, display->current_output->scale);
-
-    g_debug("Resized EGL buffer to: (%" PRIi32 ", %" PRIi32 ") @%" PRIi32 "x", pixel_width, pixel_height,
-            display->current_output->scale);
 }
 
 static void resize_to_largest_output(CogWlPlatform *);
@@ -275,7 +259,6 @@ cog_wl_platform_exit_fullscreen(CogWlPlatform *platform)
     }
 
     cog_wl_platform_configure_geometry(platform, window->width_before_fullscreen, window->height_before_fullscreen);
-    cog_wl_platform_resize_window(platform);
 
 #if HAVE_FULLSCREEN_HANDLING
     if (window->was_fullscreen_requested_from_dom) {
@@ -303,8 +286,6 @@ shell_surface_on_configure(void                    *data,
     cog_wl_platform_configure_geometry(platform, width, height);
 
     g_debug("New wl_shell configuration: (%" PRIu32 ", %" PRIu32 ")", width, height);
-
-    cog_wl_platform_resize_window(platform);
 }
 
 static const struct wl_shell_surface_listener shell_surface_listener = {
@@ -418,11 +399,6 @@ resize_to_largest_output(CogWlPlatform *platform)
         }
     }
     cog_wl_platform_configure_geometry(platform, width, height);
-
-    struct wpe_view_backend *backend = cog_view_get_backend(COG_VIEW(platform->view));
-    if (backend != NULL) {
-        cog_wl_platform_resize_window(platform);
-    }
 }
 
 static CogWlOutput *

--- a/platform/wayland/cog-view-wl.c
+++ b/platform/wayland/cog-view-wl.c
@@ -305,6 +305,27 @@ cog_wl_view_request_frame(CogWlView *view)
 }
 
 void
+cog_wl_view_resize(CogWlView *view)
+{
+    g_assert(view->platform);
+    CogWlPlatform *platform = view->platform;
+    CogWlDisplay  *display = platform->display;
+    CogWlWindow   *window = &platform->window;
+
+    view->should_update_opaque_region = true;
+
+    int32_t pixel_width = window->width * display->current_output->scale;
+    int32_t pixel_height = window->height * display->current_output->scale;
+
+    struct wpe_view_backend *backend = cog_view_get_backend(COG_VIEW(view));
+    wpe_view_backend_dispatch_set_size(backend, window->width, window->height);
+    wpe_view_backend_dispatch_set_device_scale_factor(backend, display->current_output->scale);
+
+    g_debug("Resized EGL buffer to: (%" PRIi32 ", %" PRIi32 ") @%" PRIi32 "x", pixel_width, pixel_height,
+            display->current_output->scale);
+}
+
+void
 cog_wl_view_update_surface_contents(CogWlView *view)
 {
     g_assert(view);

--- a/platform/wayland/cog-view-wl.h
+++ b/platform/wayland/cog-view-wl.h
@@ -44,9 +44,11 @@ G_DECLARE_FINAL_TYPE(CogWlView, cog_wl_view, COG, WL_VIEW, CogView)
  * Method declarations.
  */
 
-void cog_wl_view_register_type_exported(GTypeModule *type_module);
-
 void cog_wl_view_enter_fullscreen(CogWlView *);
 void cog_wl_view_exit_fullscreen(CogWlView *);
+
+void cog_wl_view_resize(CogWlView *);
+
+void cog_wl_view_register_type_exported(GTypeModule *type_module);
 
 G_END_DECLS


### PR DESCRIPTION
The cog_wl_platform_resize_window() is moved to the View class as cog_wl_view_resize().

All the cog_wl_view_resize() are triggered inside of cog_wl_platform_configure_geometry() since the resize is a reaction to a change in the geometry of the Window.