### PR TITLE
wl: Fix build with libportal enabled after e533fce

### DIFF
--- a/platform/wayland/cog-platform-wl.c
+++ b/platform/wayland/cog-platform-wl.c
@@ -1980,8 +1980,9 @@ on_run_file_chooser(WebKitWebView *view, WebKitFileChooserRequest *request)
 {
     g_autoptr(XdpParent) xdp_parent = NULL;
 
-    if (COG_WL_VIEW(view)->platform->window.xdp_parent_wl_data.zxdg_exporter &&
-        platform->window.xdp_parent_wl_data.wl_surface) {
+    CogWlPlatform *platform = COG_WL_VIEW(view)->platform;
+
+    if (platform->window.xdp_parent_wl_data.zxdg_exporter && platform->window.xdp_parent_wl_data.wl_surface) {
         xdp_parent = xdp_parent_new_wl(&COG_WL_VIEW(view)->platform->window.xdp_parent_wl_data);
     }
 

--- a/platform/wayland/cog-utils-wl.h
+++ b/platform/wayland/cog-utils-wl.h
@@ -11,6 +11,10 @@
 
 #include "../../core/cog.h"
 
+#if COG_HAVE_LIBPORTAL
+#    include "cog-xdp-parent-wl.h"
+#endif
+
 #include <wayland-server.h>
 #include <wayland-util.h>
 #include <xkbcommon/xkbcommon.h>


### PR DESCRIPTION
Add missing include and fix access to the window through the view's associated `CogPlatform`.

----

The build with libportal got broken in #619