### PR TITLE
wl: Decouple the fullscreen logic in CogWlPlatform and CogWlView

### DIFF
--- a/platform/wayland/cog-utils-wl.h
+++ b/platform/wayland/cog-utils-wl.h
@@ -113,7 +113,6 @@ struct _CogWlWindow {
 #if HAVE_FULLSCREEN_HANDLING
     bool was_fullscreen_requested_from_dom;
 #endif
-    bool is_resizing_fullscreen;
     bool is_maximized;
     bool should_resize_to_largest_output;
 };

--- a/platform/wayland/cog-view-wl.h
+++ b/platform/wayland/cog-view-wl.h
@@ -28,6 +28,8 @@ struct _CogWlView {
     struct wpe_view_backend_exportable_fdo *exportable;
     struct wpe_fdo_egl_exported_image      *image;
 
+    bool is_resizing_fullscreen;
+
     struct wl_callback *frame_callback;
 
     bool    should_update_opaque_region;
@@ -42,8 +44,9 @@ G_DECLARE_FINAL_TYPE(CogWlView, cog_wl_view, COG, WL_VIEW, CogView)
  * Method declarations.
  */
 
-void cog_wl_view_enter_fullscreen(CogWlView *);
-
 void cog_wl_view_register_type_exported(GTypeModule *type_module);
+
+void cog_wl_view_enter_fullscreen(CogWlView *);
+void cog_wl_view_exit_fullscreen(CogWlView *);
 
 G_END_DECLS


### PR DESCRIPTION
In the **Platform** side the fullscreen enter/exit logic was cleaned up, simplified and encapsulated in the `cog_wl_platform_[enter|exit]_fullscreen` functions.

The `CogWlPlatform` is not responsible of having in consideration the state of the View. It is limited to do store the previous geometry, to set the new window geometry and to make the adjustments in the corresponding shell. Finally, the **View** associated to the **Platform** is notified using the new `cog_wl_view_[enter|exit]_fullscreen` functions and relies on the View to do the rest. The CogWlView reacts those notifications by sending the `wpe_view_backend_dispatch_did_enter_fullscreen` and `wpe_view_backend_dispatch_did_exit_fullscreen` according with the notification.