### PR TITLE
core: Declare public symbol visibilities

### DIFF
--- a/core/cog-directory-files-handler.h
+++ b/core/cog-directory-files-handler.h
@@ -12,16 +12,15 @@
 # error "Do not include this header directly, use <cog.h> instead"
 #endif
 
+#include "cog-export.h"
 #include "cog-request-handler.h"
 
 G_BEGIN_DECLS
 
 #define COG_TYPE_DIRECTORY_FILES_HANDLER  (cog_directory_files_handler_get_type ())
 
-G_DECLARE_FINAL_TYPE (CogDirectoryFilesHandler,
-                      cog_directory_files_handler,
-                      COG, DIRECTORY_FILES_HANDLER,
-                      GObject)
+COG_API
+G_DECLARE_FINAL_TYPE(CogDirectoryFilesHandler, cog_directory_files_handler, COG, DIRECTORY_FILES_HANDLER, GObject)
 
 struct _CogDirectoryFilesHandlerClass {
     GObjectClass parent_class;
@@ -34,17 +33,28 @@ enum {
     COG_DIRECTORY_FILES_HANDLER_ERROR_CANNOT_RESOLVE,
 };
 
-
+COG_API
 GQuark             cog_directory_files_handler_error_quark      (void);
+
+COG_API
 CogRequestHandler* cog_directory_files_handler_new              (GFile   *base_path);
+
+COG_API
 gboolean           cog_directory_files_handler_is_suitable_path (GFile   *file,
                                                                  GError **error);
+
+COG_API
 gboolean           cog_directory_files_handler_get_use_host     (CogDirectoryFilesHandler *self);
+
+COG_API
 void               cog_directory_files_handler_set_use_host     (CogDirectoryFilesHandler *self,
                                                                  gboolean                  use_host);
 
+COG_API
 unsigned           cog_directory_files_handler_get_strip_components
                                                                 (CogDirectoryFilesHandler *self);
+
+COG_API
 void               cog_directory_files_handler_set_strip_components
                                                                 (CogDirectoryFilesHandler *self,
                                                                  unsigned                  count);

--- a/core/cog-export.h
+++ b/core/cog-export.h
@@ -1,0 +1,16 @@
+/*
+ * cog-export.h
+ * Copyright (C) 2021 Igalia S.L.
+ *
+ * Distributed under terms of the MIT license.
+ */
+
+#pragma once
+
+#if !(defined(COG_INSIDE_COG__) && COG_INSIDE_COG__)
+#    error "Do not include this header directly, use <cog.h> instead"
+#endif
+
+#include <gmodule.h>
+
+#define COG_API G_MODULE_EXPORT

--- a/core/cog-gamepad.h
+++ b/core/cog-gamepad.h
@@ -11,8 +11,10 @@
 #    error "Do not include this header directly, use <cog.h> instead" +
 #endif
 
+#include "cog-export.h"
+
 typedef struct wpe_view_backend *(GamepadProviderGetViewBackend) (void *, void *);
 
-gboolean cog_gamepad_parse_backend(const char *name, GError **error);
-void     cog_gamepad_set_backend(const char *name);
-void     cog_gamepad_setup(GamepadProviderGetViewBackend *gamepad_get_view);
+COG_API gboolean cog_gamepad_parse_backend(const char *name, GError **error);
+COG_API void     cog_gamepad_set_backend(const char *name);
+COG_API void     cog_gamepad_setup(GamepadProviderGetViewBackend *gamepad_get_view);

--- a/core/cog-host-routes-handler.h
+++ b/core/cog-host-routes-handler.h
@@ -17,20 +17,21 @@ G_BEGIN_DECLS
 
 #define COG_TYPE_HOST_ROUTES_HANDLER (cog_host_routes_handler_get_type())
 
+COG_API
 G_DECLARE_FINAL_TYPE(CogHostRoutesHandler, cog_host_routes_handler, COG, HOST_ROUTES_HANDLER, GObject)
 
 struct _CogHostRoutesHandlerClass {
     GObjectClass parent_class;
 };
 
-CogRequestHandler *cog_host_routes_handler_new(CogRequestHandler *fallback_handler);
+COG_API CogRequestHandler *cog_host_routes_handler_new(CogRequestHandler *fallback_handler);
 
-gboolean cog_host_routes_handler_contains(CogHostRoutesHandler *self, const char *host);
+COG_API gboolean cog_host_routes_handler_contains(CogHostRoutesHandler *self, const char *host);
 
-gboolean cog_host_routes_handler_add(CogHostRoutesHandler *self, const char *host, CogRequestHandler *handler);
+COG_API gboolean cog_host_routes_handler_add(CogHostRoutesHandler *self, const char *host, CogRequestHandler *handler);
 
-gboolean cog_host_routes_handler_remove(CogHostRoutesHandler *self, const char *host);
+COG_API gboolean cog_host_routes_handler_remove(CogHostRoutesHandler *self, const char *host);
 
-gboolean cog_host_routes_handler_add_path(CogHostRoutesHandler *self, const char *host, const char *base_path);
+COG_API gboolean cog_host_routes_handler_add_path(CogHostRoutesHandler *self, const char *host, const char *base_path);
 
 G_END_DECLS

--- a/core/cog-modules.h
+++ b/core/cog-modules.h
@@ -11,6 +11,7 @@
 #    error "Do not include this header directly, use <cog.h> instead"
 #endif
 
+#include "cog-export.h"
 #include <gio/gio.h>
 
 G_BEGIN_DECLS
@@ -19,13 +20,17 @@ G_BEGIN_DECLS
 
 #define COG_MODULES_PLATFORM (cog_modules_get_platform_extension_point())
 
+COG_API
 GIOExtensionPoint *cog_modules_get_platform_extension_point(void);
 
-GType
-cog_modules_get_preferred(GIOExtensionPoint *extension_point, const char *preferred_module, size_t is_supported_offset);
+COG_API GType cog_modules_get_preferred(GIOExtensionPoint *extension_point,
+                                        const char        *preferred_module,
+                                        size_t             is_supported_offset);
 
+COG_API
 void cog_modules_foreach(GIOExtensionPoint *extension_point, void (*callback)(GIOExtension *, void *), void *userdata);
 
+COG_API
 void cog_modules_add_directory(const char *directory_path);
 
 G_END_DECLS

--- a/core/cog-platform.h
+++ b/core/cog-platform.h
@@ -25,10 +25,10 @@ typedef enum {
 } CogPlatformError;
 
 #define COG_PLATFORM_EGL_ERROR  (cog_platform_egl_error_quark ())
-GQuark cog_platform_egl_error_quark (void);
+COG_API GQuark cog_platform_egl_error_quark(void);
 
 #define COG_PLATFORM_WPE_ERROR  (cog_platform_wpe_error_quark ())
-GQuark cog_platform_wpe_error_quark (void);
+COG_API GQuark cog_platform_wpe_error_quark(void);
 
 typedef enum {
     COG_PLATFORM_WPE_ERROR_INIT,
@@ -36,6 +36,7 @@ typedef enum {
 
 #define COG_TYPE_PLATFORM (cog_platform_get_type())
 
+COG_API
 G_DECLARE_DERIVABLE_TYPE(CogPlatform, cog_platform, COG, PLATFORM, GObject)
 
 struct _CogPlatformClass {
@@ -51,22 +52,25 @@ struct _CogPlatformClass {
     GType (*get_view_type)(void);
 };
 
-void cog_platform_set_default(CogPlatform *);
-CogPlatform *cog_platform_get_default(void);
-CogPlatform *cog_platform_new(const char *name, GError **);
+COG_API void         cog_platform_set_default(CogPlatform *);
+COG_API CogPlatform *cog_platform_get_default(void);
+COG_API CogPlatform *cog_platform_new(const char *name, GError **);
 
-gboolean cog_platform_setup(CogPlatform *platform, CogShell *shell, const char *params, GError **error);
+COG_API gboolean cog_platform_setup(CogPlatform *platform, CogShell *shell, const char *params, GError **error);
 
+COG_API
 WebKitWebViewBackend     *cog_platform_get_view_backend  (CogPlatform   *platform,
                                                           WebKitWebView *related_view,
                                                           GError       **error);
 
+COG_API
 void                      cog_platform_init_web_view     (CogPlatform   *platform,
                                                           WebKitWebView *view);
 
+COG_API
 WebKitInputMethodContext *cog_platform_create_im_context (CogPlatform   *platform);
 
-CogPlatform *
+COG_API CogPlatform *
 cog_platform_configure(const char *name, const char *params, const char *env_prefix, CogShell *shell, GError **error);
 
 G_END_DECLS

--- a/core/cog-prefix-routes-handler.h
+++ b/core/cog-prefix-routes-handler.h
@@ -17,24 +17,26 @@ G_BEGIN_DECLS
 
 #define COG_TYPE_PREFIX_ROUTES_HANDLER  (cog_prefix_routes_handler_get_type ())
 
-G_DECLARE_FINAL_TYPE (CogPrefixRoutesHandler,
-                      cog_prefix_routes_handler,
-                      COG, PREFIX_ROUTES_HANDLER,
-                      GObject)
+COG_API
+G_DECLARE_FINAL_TYPE(CogPrefixRoutesHandler, cog_prefix_routes_handler, COG, PREFIX_ROUTES_HANDLER, GObject)
 
 struct _CogPrefixRoutesHandlerClass {
     GObjectClass parent_class;
 };
 
+COG_API
 CogRequestHandler* cog_prefix_routes_handler_new     (CogRequestHandler      *fallback_handler);
 
+COG_API
 gboolean           cog_prefix_routes_handler_mount   (CogPrefixRoutesHandler *self,
                                                       const char             *path_prefix,
                                                       CogRequestHandler      *handler);
 
+COG_API
 gboolean           cog_prefix_routes_handler_unmount (CogPrefixRoutesHandler *self,
                                                       const char             *path_prefix);
 
+COG_API
 gboolean           cog_prefix_routes_handler_mount_path
                                                      (CogPrefixRoutesHandler *self,
                                                       const char             *path_prefix,

--- a/core/cog-request-handler.h
+++ b/core/cog-request-handler.h
@@ -18,7 +18,8 @@ G_BEGIN_DECLS
 
 #define COG_TYPE_REQUEST_HANDLER  (cog_request_handler_get_type ())
 
-G_DECLARE_INTERFACE (CogRequestHandler, cog_request_handler, COG, REQUEST_HANDLER, GObject)
+COG_API
+G_DECLARE_INTERFACE(CogRequestHandler, cog_request_handler, COG, REQUEST_HANDLER, GObject)
 
 struct _CogRequestHandlerInterface {
     GTypeInterface g_iface;
@@ -27,9 +28,8 @@ struct _CogRequestHandlerInterface {
     void (*run) (CogRequestHandler *handler, WebKitURISchemeRequest *request);
 };
 
-
+COG_API
 void cog_request_handler_run (CogRequestHandler *handler, WebKitURISchemeRequest *request);
-
 
 G_END_DECLS
 

--- a/core/cog-shell.h
+++ b/core/cog-shell.h
@@ -11,6 +11,7 @@
 # error "Do not include this header directly, use <cog.h> instead"
 #endif
 
+#include "cog-export.h"
 #include "cog-request-handler.h"
 #include "cog-webkit-utils.h"
 
@@ -18,8 +19,8 @@ G_BEGIN_DECLS
 
 #define COG_TYPE_SHELL  (cog_shell_get_type ())
 
-G_DECLARE_DERIVABLE_TYPE (CogShell, cog_shell, COG, SHELL, GObject)
-
+COG_API
+G_DECLARE_DERIVABLE_TYPE(CogShell, cog_shell, COG, SHELL, GObject)
 
 struct _CogShellClass {
     GObjectClass parent_class;
@@ -30,17 +31,17 @@ struct _CogShellClass {
     void           (*shutdown)    (CogShell*);
 };
 
-CogShell *        cog_shell_new(const char *name, gboolean automated);
-const char *      cog_shell_get_name(CogShell *shell);
-WebKitWebContext *cog_shell_get_web_context(CogShell *shell);
-WebKitSettings   *cog_shell_get_web_settings        (CogShell          *shell);
-WebKitWebView    *cog_shell_get_web_view            (CogShell          *shell);
-GKeyFile         *cog_shell_get_config_file         (CogShell          *shell);
-gdouble           cog_shell_get_device_scale_factor (CogShell          *shell);
-gboolean          cog_shell_is_automated(CogShell *shell);
-void              cog_shell_set_request_handler(CogShell *shell, const char *scheme, CogRequestHandler *handler);
+COG_API CogShell         *cog_shell_new(const char *name, gboolean automated);
+COG_API const char       *cog_shell_get_name(CogShell *shell);
+COG_API WebKitWebContext *cog_shell_get_web_context(CogShell *shell);
+COG_API WebKitSettings   *cog_shell_get_web_settings(CogShell *shell);
+COG_API WebKitWebView    *cog_shell_get_web_view(CogShell *shell);
+COG_API GKeyFile         *cog_shell_get_config_file(CogShell *shell);
+COG_API gdouble           cog_shell_get_device_scale_factor(CogShell *shell);
+COG_API gboolean          cog_shell_is_automated(CogShell *shell);
+COG_API void cog_shell_set_request_handler(CogShell *shell, const char *scheme, CogRequestHandler *handler);
 
-void              cog_shell_startup                 (CogShell          *shell);
-void              cog_shell_shutdown                (CogShell          *shell);
+COG_API void cog_shell_startup(CogShell *shell);
+COG_API void cog_shell_shutdown(CogShell *shell);
 
 G_END_DECLS

--- a/core/cog-utils.h
+++ b/core/cog-utils.h
@@ -11,6 +11,7 @@
 # error "Do not include this header directly, use <cog.h> instead"
 #endif
 
+#include "cog-export.h"
 #include <glib-object.h>
 
 G_BEGIN_DECLS
@@ -19,14 +20,16 @@ G_BEGIN_DECLS
 G_DEFINE_AUTOPTR_CLEANUP_FUNC (GEnumClass, g_type_class_unref)
 #endif // !GLIB_CHECK_VERSION
 
-
+COG_API
 char* cog_appid_to_dbus_object_path (const char *appid)
     G_GNUC_WARN_UNUSED_RESULT;
 
+COG_API
 char* cog_uri_guess_from_user_input (const char *uri_like,
                                      gboolean    is_cli_arg,
                                      GError    **error);
 
+COG_API
 GOptionEntry* cog_option_entries_from_class (GObjectClass *klass);
 
 

--- a/core/cog-view.h
+++ b/core/cog-view.h
@@ -21,6 +21,7 @@ struct wpe_view_backend;
 
 #define COG_TYPE_VIEW (cog_view_get_type())
 
+COG_API
 G_DECLARE_DERIVABLE_TYPE(CogView, cog_view, COG, VIEW, WebKitWebView)
 
 struct _CogViewClass {
@@ -32,11 +33,22 @@ struct _CogViewClass {
 
 #define COG_TYPE_VIEW_IMPL (cog_view_get_impl_type())
 
+COG_API
 GType                    cog_view_get_impl_type(void);
+
+COG_API
 CogView                 *cog_view_new(const char *first_property_name, ...);
+
+COG_API
 struct wpe_view_backend *cog_view_get_backend(CogView *view);
+
+COG_API
 void                     cog_view_handle_key_event(CogView *self, const struct wpe_input_keyboard_event *event);
+
+COG_API
 void                     cog_view_set_use_key_bindings(CogView *self, gboolean enable);
+
+COG_API
 gboolean                 cog_view_get_use_key_bindings(CogView *self);
 
 G_END_DECLS

--- a/core/cog-webkit-utils.h
+++ b/core/cog-webkit-utils.h
@@ -13,27 +13,32 @@
 #endif
 
 #include "cog-config.h"
+#include "cog-export.h"
 
 #include <glib.h>
 #include <wpe/webkit.h>
 
 G_BEGIN_DECLS
 
+COG_API
 gboolean cog_handle_web_view_load_failed (WebKitWebView  *web_view,
                                           WebKitLoadEvent load_event,
                                           char           *failing_uri,
                                           GError         *error,
                                           void           *userdata);
 
+COG_API
 gboolean cog_handle_web_view_load_failed_with_tls_errors (WebKitWebView       *web_view,
                                                           char                *failing_uri,
                                                           GTlsCertificate     *certificate,
                                                           GTlsCertificateFlags errors,
                                                           void                *user_data);
 
+COG_API
 gboolean cog_handle_web_view_web_process_terminated (WebKitWebView                     *web_view,
                                                      WebKitWebProcessTerminationReason  reason,
                                                      void                              *userdata);
+COG_API
 gboolean cog_handle_web_view_web_process_terminated_exit (WebKitWebView                     *web_view,
                                                           WebKitWebProcessTerminationReason  reason,
                                                           void                              *userdata);
@@ -49,20 +54,23 @@ cog_web_view_connect_web_process_terminated_exit_handler (WebKitWebView* web_vie
                              GINT_TO_POINTER (exit_code));
 }
 
+COG_API
 gulong cog_web_view_connect_web_process_terminated_restart_handler (WebKitWebView *web_view,
                                                                     unsigned       max_tries,
                                                                     unsigned       try_window_ms);
 
+COG_API
 void cog_web_view_connect_default_error_handlers (WebKitWebView *web_view);
 
-
+COG_API
 void cog_handle_web_view_load_changed (WebKitWebView  *web_view,
                                        WebKitLoadEvent load_event,
                                        void           *userdata);
 
+COG_API
 void cog_web_view_connect_default_progress_handlers (WebKitWebView *web_view);
 
-
+COG_API
 gboolean cog_webkit_settings_apply_from_key_file (WebKitSettings *settings,
                                                   GKeyFile       *key_file,
                                                   const char     *group,

--- a/core/meson.build
+++ b/core/meson.build
@@ -68,6 +68,7 @@ cogcore_lib = shared_library('cogcore',
     dependencies: cogcore_dependencies,
     version: cogcore_soversion,
     soversion: cogcore_soversion_major,
+    gnu_symbol_visibility: 'hidden',
     install: true,
 )
 


### PR DESCRIPTION
Change the build options to use “hidden” visibility by default, and mark only the symbols that are part of the public API with the COG_API macro. This prevents library private symbols from leaking to the global symbol namespace even if they are not declared as “static”, and also makes the ELF PLT smaller which prevents accidental symbol overriding and improves load times.