### PR TITLE
wl: Remove CogWlPlatform::init_web_view()

### DIFF
--- a/core/cog-platform.c
+++ b/core/cog-platform.c
@@ -128,6 +128,7 @@ cog_platform_init_web_view (CogPlatform   *platform,
             g_warning_once("%s: class %s defines both .get_view_type and .init_web_view, "
                            "the latter should be removed.",
                            G_STRFUNC, G_OBJECT_CLASS_NAME(platform));
+            return;
         }
 
         klass->init_web_view(platform, view);

--- a/platform/wayland/cog-platform-wl.c
+++ b/platform/wayland/cog-platform-wl.c
@@ -29,13 +29,10 @@
 /* for mmap */
 #include <sys/mman.h>
 
-#include <xkbcommon/xkbcommon.h>
-#include <xkbcommon/xkbcommon-compose.h>
 #include <locale.h>
+#include <xkbcommon/xkbcommon-compose.h>
+#include <xkbcommon/xkbcommon.h>
 
-#if COG_HAVE_LIBPORTAL
-#    include "../common/cog-file-chooser.h"
-#endif /* COG_HAVE_LIBPORTAL */
 #include "../common/cursors.h"
 #include "../common/egl-proc-address.h"
 #include "os-compatibility.h"
@@ -608,8 +605,8 @@ registry_on_global(void *data, struct wl_registry *registry, uint32_t name, cons
 }
 
 #ifdef COG_USE_WAYLAND_CURSOR
-static void
-set_cursor(CogWlPlatform *platform, enum cursor_type type)
+void
+cog_wl_platform_set_cursor(CogWlPlatform *platform, enum cursor_type type)
 {
     CogWlDisplay *display = platform->display;
 
@@ -659,7 +656,7 @@ pointer_on_enter(void              *data,
     display->seat.pointer.surface = surface;
 
 #ifdef COG_USE_WAYLAND_CURSOR
-    set_cursor(platform, CURSOR_LEFT_PTR);
+    cog_wl_platform_set_cursor(platform, CURSOR_LEFT_PTR);
 #endif /* COG_USE_WAYLAND_CURSOR */
 }
 
@@ -1974,55 +1971,6 @@ cog_wl_platform_finalize(GObject *object)
     G_OBJECT_CLASS(cog_wl_platform_parent_class)->finalize(object);
 }
 
-#if COG_HAVE_LIBPORTAL
-static void
-on_run_file_chooser(WebKitWebView *view, WebKitFileChooserRequest *request)
-{
-    g_autoptr(XdpParent) xdp_parent = NULL;
-
-    CogWlPlatform *platform = COG_WL_VIEW(view)->platform;
-
-    if (platform->window.xdp_parent_wl_data.zxdg_exporter && platform->window.xdp_parent_wl_data.wl_surface) {
-        xdp_parent = xdp_parent_new_wl(&COG_WL_VIEW(view)->platform->window.xdp_parent_wl_data);
-    }
-
-    run_file_chooser(view, request, xdp_parent);
-}
-#endif /* COG_HAVE_LIBPORTAL */
-
-static void
-on_mouse_target_changed(WebKitWebView *view, WebKitHitTestResult *hitTestResult, guint mouseModifiers)
-{
-#ifdef COG_USE_WAYLAND_CURSOR
-    CogWlPlatform *platform = COG_WL_VIEW(view)->platform;
-    if (webkit_hit_test_result_context_is_link(hitTestResult)) {
-        set_cursor(platform, CURSOR_HAND);
-    } else if (webkit_hit_test_result_context_is_editable(hitTestResult)) {
-        set_cursor(platform, CURSOR_TEXT);
-    } else if (webkit_hit_test_result_context_is_selection(hitTestResult)) {
-        set_cursor(platform, CURSOR_TEXT);
-    } else {
-        set_cursor(platform, CURSOR_LEFT_PTR);
-    }
-#endif /* COG_USE_WAYLAND_CURSOR */
-}
-
-static void
-cog_wl_platform_init_web_view(CogPlatform *platform, WebKitWebView *view)
-{
-    CogWlPlatform *cog_wl_platform = COG_WL_PLATFORM(platform);
-    CogWlView     *cog_wl_view = COG_WL_VIEW(view);
-
-    cog_wl_platform->view = cog_wl_view;
-    cog_wl_view->should_update_opaque_region = true;
-    cog_wl_view->platform = cog_wl_platform;
-
-#if COG_HAVE_LIBPORTAL
-    g_signal_connect(view, "run-file-chooser", G_CALLBACK(on_run_file_chooser), NULL);
-#endif /* COG_HAVE_LIBPORTAL */
-    g_signal_connect(view, "mouse-target-changed", G_CALLBACK(on_mouse_target_changed), NULL);
-}
-
 static WebKitInputMethodContext *
 cog_wl_platform_create_im_context(CogPlatform *platform)
 {
@@ -2045,7 +1993,6 @@ cog_wl_platform_class_init(CogWlPlatformClass *klass)
     platform_class->is_supported = cog_wl_platform_is_supported;
     platform_class->get_view_type = cog_wl_view_get_type;
     platform_class->setup = cog_wl_platform_setup;
-    platform_class->init_web_view = cog_wl_platform_init_web_view;
     platform_class->create_im_context = cog_wl_platform_create_im_context;
 }
 

--- a/platform/wayland/cog-platform-wl.h
+++ b/platform/wayland/cog-platform-wl.h
@@ -37,5 +37,6 @@ struct _CogWlPlatform {
 void cog_wl_platform_popup_create(CogWlPlatform *platform, WebKitOptionMenu *);
 
 bool cog_wl_platform_set_fullscreen(CogWlPlatform *platform, bool fullscreen);
+void cog_wl_platform_set_cursor(CogWlPlatform *, enum cursor_type);
 
 G_END_DECLS

--- a/platform/wayland/cog-view-wl.c
+++ b/platform/wayland/cog-view-wl.c
@@ -11,6 +11,7 @@
 #include <wpe/fdo-egl.h>
 #include <wpe/fdo.h>
 
+#include "../common/cursors.h"
 #include "../common/egl-proc-address.h"
 
 #include <EGL/egl.h>
@@ -19,13 +20,24 @@
 /* for mmap */
 #include <sys/mman.h>
 
+#ifdef COG_USE_WAYLAND_CURSOR
+#    include <wayland-cursor.h>
+#endif
+
 #include "presentation-time-client.h"
 #include "xdg-shell-client.h"
+
+#if COG_HAVE_LIBPORTAL
+#    include "../common/cog-file-chooser.h"
+#endif /* COG_HAVE_LIBPORTAL */
 
 #include "cog-im-context-wl-v1.h"
 #include "cog-im-context-wl.h"
 #include "cog-utils-wl.h"
 #include "cog-view-wl.h"
+#if COG_HAVE_LIBPORTAL
+#    include "cog-xdp-parent-wl.h"
+#endif /* COG_HAVE_LIBPORTAL */
 
 #include "os-compatibility.h"
 
@@ -55,6 +67,12 @@ static void presentation_feedback_on_sync_output(void *, struct wp_presentation_
 static void on_export_shm_buffer(void *, struct wpe_fdo_shm_exported_buffer *);
 #endif
 static void on_export_wl_egl_image(void *data, struct wpe_fdo_egl_exported_image *image);
+#if COG_USE_WAYLAND_CURSOR
+static void on_mouse_target_changed(WebKitWebView *, WebKitHitTestResult *hitTestResult, guint mouseModifiers);
+#endif
+#if COG_HAVE_LIBPORTAL
+static void on_run_file_chooser(WebKitWebView *, WebKitFileChooserRequest *);
+#endif
 static void on_show_option_menu(WebKitWebView *, WebKitOptionMenu *, WebKitRectangle *, gpointer *);
 static void on_wl_surface_frame(void *, struct wl_callback *, uint32_t);
 
@@ -87,12 +105,20 @@ cog_wl_view_init(CogWlView *self)
     self->should_update_opaque_region = true;
 
     self->scale_factor = 1;
+    self->should_update_opaque_region = true;
     self->image = NULL;
     self->frame_callback = NULL;
     self->platform = COG_WL_PLATFORM(cog_platform_get_default());
 
+    // Only one view is managed by the Wayland Platform nowadays.
+    self->platform->view = self;
+
     wl_list_init(&self->shm_buffer_list);
 
+    g_signal_connect(self, "mouse-target-changed", G_CALLBACK(on_mouse_target_changed), NULL);
+#if COG_HAVE_LIBPORTAL
+    g_signal_connect(self, "run-file-chooser", G_CALLBACK(on_run_file_chooser), NULL);
+#endif /* COG_HAVE_LIBPORTAL */
     g_signal_connect(self, "show-option-menu", G_CALLBACK(on_show_option_menu), NULL);
 }
 
@@ -423,6 +449,39 @@ on_export_wl_egl_image(void *data, struct wpe_fdo_egl_exported_image *image)
 
     cog_wl_view_update_surface_contents(self);
 }
+
+static void
+on_mouse_target_changed(WebKitWebView *view, WebKitHitTestResult *hitTestResult, guint mouseModifiers)
+{
+#ifdef COG_USE_WAYLAND_CURSOR
+    CogWlPlatform *platform = COG_WL_VIEW(view)->platform;
+    if (webkit_hit_test_result_context_is_link(hitTestResult)) {
+        cog_wl_platform_set_cursor(platform, CURSOR_HAND);
+    } else if (webkit_hit_test_result_context_is_editable(hitTestResult)) {
+        cog_wl_platform_set_cursor(platform, CURSOR_TEXT);
+    } else if (webkit_hit_test_result_context_is_selection(hitTestResult)) {
+        cog_wl_platform_set_cursor(platform, CURSOR_TEXT);
+    } else {
+        cog_wl_platform_set_cursor(platform, CURSOR_LEFT_PTR);
+    }
+#endif /* COG_USE_WAYLAND_CURSOR */
+}
+
+#if COG_HAVE_LIBPORTAL
+static void
+on_run_file_chooser(WebKitWebView *view, WebKitFileChooserRequest *request)
+{
+    g_autoptr(XdpParent) xdp_parent = NULL;
+
+    CogWlPlatform *platform = COG_WL_VIEW(view)->platform;
+
+    if (platform->window.xdp_parent_wl_data.zxdg_exporter && platform->window.xdp_parent_wl_data.wl_surface) {
+        xdp_parent = xdp_parent_new_wl(&COG_WL_VIEW(view)->platform->window.xdp_parent_wl_data);
+    }
+
+    run_file_chooser(view, request, xdp_parent);
+}
+#endif /* COG_HAVE_LIBPORTAL */
 
 static void
 on_show_option_menu(WebKitWebView *view, WebKitOptionMenu *menu, WebKitRectangle *rectangle, gpointer *data)


### PR DESCRIPTION
All the initialization done in the init_web_view() is now relocated  inside of the cog_wl_view_init(). To make this possible all the code     related to the "run-file-chooser" and "mouse-target-changed" signals     have be moved from the cog-platform-wl to the cog-view-wl.

This change makes the Wayland platform compatible with the check  implemented in the cog_platform_init_web_view(): "CogWlPlatform class    defines both .get_view_type and .init_web_view the latter should be   removed."

Also adds again the early return in cog_platform_init_web_view() if class defines both .get_view_type and .init_web_view.
