### PR TITLE
wl: Refactor popup_data as CogWlPopup

### DIFF
--- a/platform/wayland/cog-platform-wl.h
+++ b/platform/wayland/cog-platform-wl.h
@@ -26,6 +26,7 @@ struct _CogWlPlatformClass {
 struct _CogWlPlatform {
     CogPlatform   parent;
     CogWlDisplay *display;
+    CogWlPopup   *popup;
     CogWlView    *view;
     CogWlWindow   window;
 };
@@ -34,7 +35,21 @@ struct _CogWlPlatform {
  * Method declarations.
  */
 
-void cog_wl_platform_popup_create(CogWlPlatform *platform, WebKitOptionMenu *);
+/**
+ * CogWlPlatform::cog_wl_platform_popup_create
+ * @platform: Reference to the CogWlPlatform instance.
+ * @options: Reference to the WebKitOptionMenu.
+ *
+ * Creates the CogWlPopup and set this inside the @platform.
+ *
+ * This function will fail if it is called twice without a
+ * cog_wl_platform_popup_destroy() in between both calls.
+ *
+ * Returns: (void)
+ */
+void cog_wl_platform_popup_create(CogWlPlatform *, WebKitOptionMenu *);
+void cog_wl_platform_popup_destroy(CogWlPlatform *);
+void cog_wl_platform_popup_update(CogWlPlatform *);
 
 bool cog_wl_platform_set_fullscreen(CogWlPlatform *platform, bool fullscreen);
 

--- a/platform/wayland/cog-utils-wl.h
+++ b/platform/wayland/cog-utils-wl.h
@@ -18,6 +18,8 @@
 #include <wayland-util.h>
 #include <xkbcommon/xkbcommon.h>
 
+#include "cog-popup-menu-wl.h"
+
 G_BEGIN_DECLS
 
 #define DEFAULT_HEIGHT 768
@@ -42,6 +44,7 @@ typedef struct _CogWlDisplay  CogWlDisplay;
 typedef struct _CogWlKeyboard CogWlKeyboard;
 typedef struct _CogWlOutput   CogWlOutput;
 typedef struct _CogWlPointer  CogWlPointer;
+typedef struct _CogWlPopup    CogWlPopup;
 typedef struct _CogWlSeat     CogWlSeat;
 typedef struct _CogWlTouch    CogWlTouch;
 typedef struct _CogWlWindow   CogWlWindow;
@@ -89,6 +92,24 @@ struct _CogWlPointer {
     uint32_t           button;
     uint32_t           state;
     uint32_t           serial;
+};
+
+struct _CogWlPopup {
+    struct wl_surface *wl_surface;
+
+    struct xdg_positioner *xdg_positioner;
+    struct xdg_surface    *xdg_surface;
+    struct xdg_popup      *xdg_popup;
+
+    struct wl_shell_surface *shell_surface;
+
+    uint32_t width;
+    uint32_t height;
+
+    CogPopupMenu     *popup_menu;
+    WebKitOptionMenu *option_menu;
+
+    bool configured;
 };
 
 struct _CogWlTouch {
@@ -256,6 +277,11 @@ struct _CogWlDisplay {
 void          cog_wl_display_add_seat(CogWlDisplay *, CogWlSeat *);
 CogWlDisplay *cog_wl_display_create(const char *name, GError **error);
 void          cog_wl_display_destroy(CogWlDisplay *self);
+
+CogWlPopup *cog_wl_popup_create(CogWlPlatform *, WebKitOptionMenu *);
+void        cog_wl_popup_destroy(CogWlPopup *);
+void        cog_wl_popup_display(CogWlPopup *);
+void        cog_wl_popup_update(CogWlPopup *);
 
 CogWlSeat *cog_wl_seat_create(struct wl_seat *, uint32_t);
 void       cog_wl_seat_destroy(CogWlSeat *);

--- a/platform/wayland/cog-view-wl.c
+++ b/platform/wayland/cog-view-wl.c
@@ -274,12 +274,6 @@ cog_wl_view_on_buffer_release(void *data G_GNUC_UNUSED, struct wl_buffer *buffer
 }
 
 static void
-cog_wl_view_popup_create(CogWlView *view, WebKitOptionMenu *option_menu)
-{
-    cog_wl_platform_popup_create(view->platform, option_menu);
-}
-
-static void
 cog_wl_view_request_frame(CogWlView *view)
 {
     CogWlDisplay *display = view->platform->display;
@@ -511,7 +505,7 @@ on_run_file_chooser(WebKitWebView *view, WebKitFileChooserRequest *request)
 static void
 on_show_option_menu(WebKitWebView *view, WebKitOptionMenu *menu, WebKitRectangle *rectangle, gpointer *data)
 {
-    cog_wl_view_popup_create(COG_WL_VIEW(view), g_object_ref(menu));
+    cog_wl_platform_popup_create(COG_WL_VIEW(view)->platform, g_object_ref(menu));
 }
 
 static void


### PR DESCRIPTION
There is not longer a static global popup_data definition inside of the platform. Instead of this the Platform will have attached a CogWlPopup instance.

It is the handling of the CogWlPopup responsibility of the CogWlPlatform object. For example, the cog_wl_platform_popup_create() and the cog_wl_platform_popup_destroy() will deal with the set and unset of the reference to the popup object inside the CogWlPlatform.

Because this reason, the CogWlView just relies on the CogWlPlatform for the creation and the rest of the life-cycle of a CogWlPopup now. All this is simply triggered by the on_show_option_menu() handler.

There are also other trivial refactorings:

* The cog_wl_compositor_create_surface() is moved to the cog-utils-wl for convenience.
* The popup auxiliary structs and callback handlers are also moved to the cog-utils-wl.
* The CogWlPopup is now accesible from the CogWlPlatform object but we still try to avoid global access to the platform by passing the platform object, as much as possible, as contextual information to the handlers.