### PR TITLE
wl: Fix the validation of the exported image in outputs with scale factor

### DIFF
--- a/platform/wayland/cog-platform-wl.c
+++ b/platform/wayland/cog-platform-wl.c
@@ -452,6 +452,11 @@ output_handle_done(void *data, struct wl_output *output)
     if (!display->current_output) {
         g_debug("%s: Using %p as initial output", G_STRFUNC, output);
         display->current_output = metrics;
+
+        // Forces a View resize since the output changed so the device
+        // scale factor could be different and the scale of the exported
+        // image should be also updated.
+        cog_wl_view_resize(platform->view);
     }
 
     if (platform->window.should_resize_to_largest_output) {


### PR DESCRIPTION
The patch fixes a basic logic bug inside of the `on_export_wl_egl_image()`. The error is in the incorrect use of scale_factor (actually defined for the WebPage zooming) instead of the `current_output->scale` for validating the exported image geometry.

The change also unifies inside of the new `validate_exported_geometry()` function the shared code used for validating the sizes of the exported images.

**This fixes regression added in e533fce.**

**Thanks** to Adrian Perez de Castro <aperez@igalia.com> for reporting the issue.