### PR TITLE
Introduce CogViewport, add support in the Wayland plug-in and example program

### DIFF
--- a/core/cog-shell.h
+++ b/core/cog-shell.h
@@ -13,9 +13,11 @@
 
 #include "cog-export.h"
 #include "cog-request-handler.h"
-#include "cog-webkit-utils.h"
 
 G_BEGIN_DECLS
+
+typedef struct _CogViewport   CogViewport;
+typedef struct _WebKitWebView WebKitWebView;
 
 #define COG_TYPE_SHELL  (cog_shell_get_type ())
 
@@ -43,5 +45,6 @@ COG_API void cog_shell_set_request_handler(CogShell *shell, const char *scheme, 
 
 COG_API void cog_shell_startup(CogShell *shell);
 COG_API void cog_shell_shutdown(CogShell *shell);
+COG_API CogViewport *cog_shell_get_viewport(CogShell *shell);
 
 G_END_DECLS

--- a/core/cog-viewport.h
+++ b/core/cog-viewport.h
@@ -1,0 +1,41 @@
+/*
+ * Copyright (C) 2023 Igalia S.L.
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#pragma once
+
+#if !(defined(COG_INSIDE_COG__) && COG_INSIDE_COG__)
+#    error "Do not include this header directly, use <cog.h> instead"
+#endif
+
+#include "cog-export.h"
+
+#include <glib-object.h>
+
+G_BEGIN_DECLS
+
+typedef struct _CogView CogView;
+
+#define COG_TYPE_VIEWPORT (cog_viewport_get_type())
+
+COG_API
+G_DECLARE_DERIVABLE_TYPE(CogViewport, cog_viewport, COG, VIEWPORT, GObject)
+
+struct _CogViewportClass {
+    GObjectClass parent_class;
+
+    void *_padding[8];
+};
+
+COG_API void     cog_viewport_add(CogViewport *self, CogView *view);
+COG_API void     cog_viewport_remove(CogViewport *self, CogView *view);
+COG_API gboolean cog_viewport_contains(CogViewport *self, CogView *view);
+COG_API void     cog_viewport_foreach(CogViewport *self, GFunc func, void *userdata);
+COG_API gsize    cog_viewport_get_n_views(CogViewport *self);
+COG_API CogView *cog_viewport_get_nth_view(CogViewport *self, gsize index);
+COG_API CogView *cog_viewport_get_visible_view(CogViewport *self);
+COG_API void     cog_viewport_set_visible_view(CogViewport *self, CogView *view);
+
+G_END_DECLS

--- a/core/cog.h
+++ b/core/cog.h
@@ -23,6 +23,7 @@
 #include "cog-shell.h"
 #include "cog-utils.h"
 #include "cog-view.h"
+#include "cog-viewport.h"
 #include "cog-webkit-utils.h"
 
 #undef COG_INSIDE_COG__

--- a/core/meson.build
+++ b/core/meson.build
@@ -34,6 +34,7 @@ cogcore_headers = files(
     'cog-modules.h',
     'cog-gamepad.h',
     'cog-view.h',
+    'cog-viewport.h',
 )
 cogcore_sources = files(
     'cog-directory-files-handler.c',
@@ -48,6 +49,7 @@ cogcore_sources = files(
     'cog-webkit-utils.c',
     'cog-gamepad.c',
     'cog-view.c',
+    'cog-viewport.c',
 )
 
 cogcore_dependencies = [

--- a/examples/meson.build
+++ b/examples/meson.build
@@ -1,0 +1,8 @@
+examples_c_args = ['-DG_LOG_DOMAIN="Cog-Example"']
+
+executable('viewport',
+    'viewport.c',
+    c_args: examples_c_args,
+    dependencies: cogcore_dep,
+    install: false,
+)

--- a/examples/viewport.c
+++ b/examples/viewport.c
@@ -1,0 +1,66 @@
+/*
+ * viewport.c
+ * Copyright (C) 2023 Igalia S.L.
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#include "../core/cog.h"
+
+typedef struct {
+    CogViewport *views;
+    gsize        current_index;
+} TimeoutData;
+
+static gboolean
+on_timeout_tick(TimeoutData *data)
+{
+    if (++data->current_index >= cog_viewport_get_n_views(data->views))
+        data->current_index = 0;
+
+    CogView *view = cog_viewport_get_nth_view(data->views, data->current_index);
+    g_message("Set visible view %zu <%p>", data->current_index, view);
+    cog_viewport_set_visible_view(data->views, view);
+
+    return G_SOURCE_CONTINUE;
+}
+
+int
+main(int argc, char *argv[])
+{
+    if (argc < 2) {
+        g_printerr("Usage: %s <URL> [URL...]\n", argv[0]);
+        return EXIT_FAILURE;
+    }
+
+    g_set_prgname("view-stack");
+    cog_modules_add_directory(g_getenv("COG_MODULEDIR") ?: COG_MODULEDIR);
+
+    g_autoptr(GError)      error = NULL;
+    g_autoptr(CogShell)    shell = cog_shell_new(g_get_prgname(), FALSE);
+    g_autoptr(CogPlatform) platform = cog_platform_configure(NULL, NULL, "COG", shell, &error);
+    if (!platform)
+        g_error("Cannot configure platform: %s", error->message);
+
+    g_autoptr(GMainLoop) loop = g_main_loop_new(NULL, FALSE);
+
+    CogViewport *viewport = cog_shell_get_viewport(shell);
+
+    for (int i = 1; i < argc; i++) {
+        g_autoptr(CogView) view = cog_view_new(NULL);
+        cog_platform_init_web_view(platform, WEBKIT_WEB_VIEW(view));
+        cog_viewport_add(viewport, view);
+        webkit_web_view_load_uri(WEBKIT_WEB_VIEW(view), argv[i]);
+        g_message("Created view %p, URI %s", view, argv[i]);
+    }
+
+    TimeoutData data = {
+        .views = viewport,
+        .current_index = SIZE_MAX,
+    };
+    g_timeout_add_seconds(3, (GSourceFunc) on_timeout_tick, &data);
+    on_timeout_tick(&data);
+
+    g_main_loop_run(loop);
+    return EXIT_SUCCESS;
+}

--- a/meson.build
+++ b/meson.build
@@ -164,6 +164,10 @@ if get_option('documentation')
     subdir('docs')
 endif
 
+if get_option('examples')
+    subdir('examples')
+endif
+
 if with_programs
     subdir('launcher')
     if get_option('manpages')

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -17,6 +17,12 @@ option(
     description: 'build and install programs (cog, cogctl)'
 )
 option(
+    'examples',
+    type: 'boolean',
+    value: true,
+    description: 'build example programs'
+)
+option(
     'wpe_api',
     type: 'combo',
     value: 'auto',

--- a/platform/wayland/cog-platform-wl.h
+++ b/platform/wayland/cog-platform-wl.h
@@ -27,7 +27,7 @@ struct _CogWlPlatform {
     CogPlatform   parent;
     CogWlDisplay *display;
     CogWlPopup   *popup;
-    CogWlView    *view;
+    CogViewport  *viewport; // TODO: Support multiple viewports.
     CogWlWindow   window;
 };
 

--- a/platform/wayland/cog-view-wl.h
+++ b/platform/wayland/cog-view-wl.h
@@ -23,8 +23,6 @@ typedef struct _CogWlPlatform CogWlPlatform;
 struct _CogWlView {
     CogView parent;
 
-    CogWlPlatform *platform;
-
     struct wpe_view_backend_exportable_fdo *exportable;
     struct wpe_fdo_egl_exported_image      *image;
 
@@ -44,9 +42,9 @@ G_DECLARE_FINAL_TYPE(CogWlView, cog_wl_view, COG, WL_VIEW, CogView)
  * Method declarations.
  */
 
+void cog_wl_view_update_surface_contents(CogWlView *);
 void cog_wl_view_enter_fullscreen(CogWlView *);
 void cog_wl_view_exit_fullscreen(CogWlView *);
-
 void cog_wl_view_resize(CogWlView *);
 
 void cog_wl_view_register_type_exported(GTypeModule *type_module);


### PR DESCRIPTION
This PR brings in the following:

- A new `CogViewport` class, which represents an “output” to display one of a set of view.
- Adapting `CogShell` to use a viewport instead of a single view. At some point we will want to uncouple the shell (see #634) but this replacement is enough for now.
- Add an `examples/viewport.c` example program which shows how to switch between among the views of a viewport.
- Adapt the Wayland platform plug-in to no longer assume that there is a single view. 

I would recommend reviewing each commit separately.