### PR TITLE
wl: Split cog_platform_configure in 2 stages (create and configure)

### DIFF
--- a/core/cog-platform.c
+++ b/core/cog-platform.c
@@ -148,22 +148,76 @@ cog_platform_create_im_context(CogPlatform *platform)
 }
 
 /**
- * cog_platform_configure: (constructor)
- * @name: (nullable): Name of the platform implementation to use.
+ * cog_platform_configure:
  * @params: (nullable): Parameters passed to the platform implementation.
  * @env_prefix: (nullable): Prefix for environment variables to check.
  * @shell: The shell that the platform will be configured for.
  * @error: Location where to store errors, if any.
  *
- * Creates and configures a platform implementation.
+ * Configures a platform implementation.
  *
- * Search and create a platform implementation with the given @name,
+ * Search a platform implementation with the given @name,
  * configuring it with the passed @params for use with a @shell.
  *
  * If the @env_prefix is non-%NULL, then the environment variable
- * `<env_prefix>_PLATFORM_NAME` can be used to set the platform name
- * when @name is %NULL, and the variable `<env_prefix>_PLATFORM_PARAMS`
+ * `<env_prefix>_PLATFORM_PARAMS`
  * can be used to set the configuration parameters when @params is %NULL.
+ * Environment variables will *not* be used if %NULL is passed as the
+ * prefix.
+ *
+ * Note that [id@cog_modules_add_directory] may be used beforehand to
+ * configure where to search for available platform plug-ins.
+ *
+ * Returns: (transfer full): The configured platform.
+ *
+ * Since: 0.18
+ */
+CogPlatform *
+cog_platform_configure(const char *params, const char *env_prefix, CogShell *shell, GError **error)
+{
+    CogPlatform *platform = cog_platform_get_default();
+    if (!platform) {
+        g_set_error_literal(error,
+                            COG_PLATFORM_WPE_ERROR,
+                            COG_PLATFORM_WPE_ERROR_INIT,
+                            "Failed to configure missing platform");
+        return NULL;
+    }
+
+    g_autofree char *platform_params = g_strdup(params);
+
+    if (env_prefix) {
+        if (!params) {
+            g_autofree char *params_var = g_strconcat(env_prefix, "_PLATFORM_PARAMS", NULL);
+            platform_params = g_strdup(g_getenv(params_var));
+        }
+    }
+    g_debug("%s: params '%s'", G_STRFUNC, platform_params);
+
+    if (!cog_platform_setup(platform, shell, platform_params ?: "", error)) {
+        g_object_unref(platform);
+        g_assert(!default_platform);
+        return NULL;
+    }
+    g_debug("%s: Configured %s @ %p", G_STRFUNC, G_OBJECT_TYPE_NAME(platform), platform);
+
+    g_assert(platform == default_platform);
+    return platform;
+}
+
+/**
+ * cog_platform_create: (constructor)
+ * @name: (nullable): Name of the platform implementation to use.
+ * @env_prefix: (nullable): Prefix for environment variables to check.
+ * @error: Location where to store errors, if any.
+ *
+ * Creates a platform implementation.
+ *
+ * Create a platform implementation with the given @name,
+ *
+ * If the @env_prefix is non-%NULL, then the environment variable
+ * `<env_prefix>_PLATFORM_NAME` can be used to set the platform name
+ * when @name is %NULL.
  * Environment variables will *not* be used if %NULL is passed as the
  * prefix.
  *
@@ -174,40 +228,28 @@ cog_platform_create_im_context(CogPlatform *platform)
  * Note that [id@cog_modules_add_directory] may be used beforehand to
  * configure where to search for available platform plug-ins.
  *
- * Returns: (transfer full): The configured platform.
+ * Returns: (transfer full): The created platform.
  *
- * Since: 0.18
+ * Since: 0.20
  */
 CogPlatform *
-cog_platform_configure(const char *name, const char *params, const char *env_prefix, CogShell *shell, GError **error)
+cog_platform_create(const char *name, const char *env_prefix, GError **error)
 {
-    g_return_val_if_fail(!default_platform, default_platform);
-
     g_autofree char *platform_name = g_strdup(name);
-    g_autofree char *platform_params = g_strdup(params);
 
     if (env_prefix) {
         if (!platform_name) {
             g_autofree char *name_var = g_strconcat(env_prefix, "_PLATFORM_NAME", NULL);
             platform_name = g_strdup(g_getenv(name_var));
         }
-        if (!params) {
-            g_autofree char *params_var = g_strconcat(env_prefix, "_PLATFORM_PARAMS", NULL);
-            platform_params = g_strdup(g_getenv(params_var));
-        }
     }
-    g_debug("%s: name '%s', params '%s'", G_STRFUNC, platform_name, platform_params);
+    g_debug("%s: name '%s'", G_STRFUNC, platform_name);
 
     CogPlatform *platform = cog_platform_new(platform_name, error);
-    if (!platform)
-        return NULL;
-
-    if (!cog_platform_setup(platform, shell, platform_params ?: "", error)) {
-        g_object_unref(platform);
-        g_assert(!default_platform);
+    if (!platform) {
+        g_set_error_literal(error, COG_PLATFORM_WPE_ERROR, COG_PLATFORM_WPE_ERROR_INIT, "Failed creating platform");
         return NULL;
     }
-    g_debug("%s: Configured %s @ %p", G_STRFUNC, G_OBJECT_TYPE_NAME(platform), platform);
 
     g_assert(platform == default_platform);
     return platform;

--- a/core/cog-platform.h
+++ b/core/cog-platform.h
@@ -71,7 +71,8 @@ COG_API
 WebKitInputMethodContext *cog_platform_create_im_context (CogPlatform   *platform);
 
 COG_API CogPlatform *
-cog_platform_configure(const char *name, const char *params, const char *env_prefix, CogShell *shell, GError **error);
+cog_platform_configure(const char *params, const char *env_prefix, CogShell *shell, GError **error);
+COG_API CogPlatform *cog_platform_create(const char *name, const char *env_prefix, GError **error);
 
 G_END_DECLS
 

--- a/examples/viewport.c
+++ b/examples/viewport.c
@@ -37,10 +37,11 @@ main(int argc, char *argv[])
     cog_modules_add_directory(g_getenv("COG_MODULEDIR") ?: COG_MODULEDIR);
 
     g_autoptr(GError)      error = NULL;
-    g_autoptr(CogShell)    shell = cog_shell_new(g_get_prgname(), FALSE);
-    g_autoptr(CogPlatform) platform = cog_platform_configure(NULL, NULL, "COG", shell, &error);
+    g_autoptr(CogPlatform) platform = cog_platform_create(NULL, "COG", &error);
     if (!platform)
         g_error("Cannot configure platform: %s", error->message);
+    g_autoptr(CogShell) shell = cog_shell_new(g_get_prgname(), FALSE);
+    cog_platform_configure(NULL, "COG", shell, &error);
 
     g_autoptr(GMainLoop) loop = g_main_loop_new(NULL, FALSE);
 

--- a/platform/wayland/cog-platform-wl.c
+++ b/platform/wayland/cog-platform-wl.c
@@ -1357,7 +1357,6 @@ init_wayland(CogWlPlatform *platform, GError **error)
 static void
 clear_wayland(CogWlPlatform *platform)
 {
-    CogWlDisplay *display = platform->display;
     cog_wl_display_destroy(platform->display);
 }
 


### PR DESCRIPTION
Disassociate the configuration respect of the creation of the platform.


This disassembles the creation of the platform and the initialization of the shell by splitting the creation and the configuration of the platform. This will makes the code cleaner and facilitates future implementations (for example: https://github.com/Igalia/cog/blob/079b778beac477fdfe07ad7c29306200c8f263db/launcher/cog-launcher.c#L321 in https://github.com/Igalia/cog/pull/648)