### PR TITLE
core: Remove cog_platform_configure() function

### DIFF
--- a/core/cog-platform.c
+++ b/core/cog-platform.c
@@ -15,25 +15,7 @@ G_DEFINE_QUARK(COG_PLATFORM_WPE_ERROR, cog_platform_wpe_error)
 
 G_DEFINE_ABSTRACT_TYPE(CogPlatform, cog_platform, G_TYPE_OBJECT)
 
-static void
-cog_platform_constructed(GObject *object)
-{
-    CogPlatform *platform = COG_PLATFORM(object);
-
-    if (cog_platform_get_default() == NULL)
-        cog_platform_set_default(platform);
-}
-
-static void
-cog_platform_finalize(GObject *object)
-{
-    CogPlatform *platform = COG_PLATFORM(object);
-
-    if (cog_platform_get_default() == platform)
-        cog_platform_set_default(NULL);
-
-    G_OBJECT_CLASS(cog_platform_parent_class)->finalize(object);
-}
+static CogPlatform *platform_singleton = NULL; // (owned) (atomic)
 
 static gboolean
 cog_platform_is_supported(void)
@@ -44,10 +26,6 @@ cog_platform_is_supported(void)
 static void
 cog_platform_class_init(CogPlatformClass *klass)
 {
-    GObjectClass *object_class = G_OBJECT_CLASS(klass);
-    object_class->constructed = cog_platform_constructed;
-    object_class->finalize = cog_platform_finalize;
-
     klass->is_supported = cog_platform_is_supported;
 }
 
@@ -56,41 +34,87 @@ cog_platform_init(CogPlatform *platform)
 {
 }
 
-static CogPlatform *default_platform = NULL;
+static inline gboolean
+cog_platform_ensure_singleton(const char *name)
+{
+    if (g_once_init_enter(&platform_singleton)) {
+        cog_modules_add_directory(NULL);
 
+        GType platform_type =
+            cog_modules_get_preferred(COG_MODULES_PLATFORM, name, G_STRUCT_OFFSET(CogPlatformClass, is_supported));
+
+        if (platform_type == G_TYPE_INVALID) {
+            if (name)
+                g_error("Requested platform '%s' not usable.", name);
+            else
+                g_error("Could not find an usable platform.");
+        }
+
+        g_debug("%s: %s requested, %s chosen.", G_STRFUNC, name ?: "None", g_type_name(platform_type));
+        g_once_init_leave(&platform_singleton, g_object_new(platform_type, NULL));
+        return FALSE;
+    }
+
+    return TRUE;
+}
+
+/**
+ * cog_init:
+ * @platform_name: (nullable): The name of the platform module to use.
+ * @module_path: (nullable): The directory to scan for modules.
+ *
+ * Initialize the library, optionally indicating options.
+ *
+ * This function ensures the creation of the single [class@CogPlatform]
+ * instance, and optionally allows indicating which platform module to use
+ * and from which directory to load modules.
+ *
+ * If the @platform_name passed is %NULL, the value of the
+ * `COG_PLATFORM_NAME` environment variable will be used. If the environment
+ * variable is undefined, the most suitable platform module will be determined
+ * automatically.
+ *
+ * If the @module_path passed is %NULL, the value of the `COG_MODULEDIR`
+ * environment variable will be used. If the environment variable is
+ * undefined, the default module path chosen at build time will be used.
+ *
+ * Note that it is **not required** to use this function. It is possible
+ * to use [id@cog_platform_get] if the default behaviour of using the
+ * environment variables (if defined) and automatic detection as fallback
+ * with the default module path is acceptable.
+ *
+ * This function is thread-safe.
+ *
+ * Since: 0.20
+ */
 void
-cog_platform_set_default(CogPlatform *platform)
+cog_init(const char *platform_name, const char *module_path)
 {
-    default_platform = platform;
+    cog_modules_add_directory(module_path ?: g_getenv("COG_MODULEDIR"));
+    gboolean already_initialized = cog_platform_ensure_singleton(platform_name ?: g_getenv("COG_PLATFORM_NAME"));
+    g_return_if_fail(!already_initialized);
 }
 
+/**
+ * cog_platform_get:
+ *
+ * Gets the platform instance.
+ *
+ * The platform module instance is a singleton. The instance will be created
+ * if needed, but [id@cog_init] can be used to control at which point it shall
+ * be created and which particular module to use.
+ *
+ * This function is thread-safe.
+ *
+ * Returns: (transfer none): The platform instance.
+ *
+ * Since: 0.20
+ */
 CogPlatform *
-cog_platform_get_default(void)
+cog_platform_get(void)
 {
-    return default_platform;
-}
-
-CogPlatform *
-cog_platform_new(const char *name, GError **error)
-{
-    GType platform_type =
-        cog_modules_get_preferred(COG_MODULES_PLATFORM, name, G_STRUCT_OFFSET(CogPlatformClass, is_supported));
-
-    if (platform_type == G_TYPE_INVALID) {
-        g_set_error_literal(error, COG_PLATFORM_ERROR, COG_PLATFORM_ERROR_NO_MODULE,
-                            "Could not find a usable platform module");
-        return NULL;
-    }
-
-    g_autoptr(CogPlatform) self = g_object_new(platform_type, NULL);
-    if (G_IS_INITABLE(self)) {
-        if (!g_initable_init(G_INITABLE(self),
-                             NULL, /* cancellable */
-                             error))
-            return NULL;
-    }
-
-    return g_steal_pointer(&self);
+    cog_platform_ensure_singleton(NULL);
+    return platform_singleton;
 }
 
 gboolean
@@ -100,7 +124,10 @@ cog_platform_setup (CogPlatform *platform,
                     GError     **error)
 {
     g_return_val_if_fail(COG_IS_PLATFORM(platform), FALSE);
-    g_return_val_if_fail (COG_IS_SHELL (shell), FALSE);
+    g_return_val_if_fail(COG_IS_SHELL(shell), FALSE);
+
+    if (G_IS_INITABLE(platform) && !g_initable_init(G_INITABLE(platform), NULL /* cancellable */, error))
+        return FALSE;
 
     return COG_PLATFORM_GET_CLASS(platform)->setup(platform, shell, params, error);
 }
@@ -155,70 +182,4 @@ cog_platform_create_im_context(CogPlatform *platform)
         return klass->create_im_context(platform);
 
     return NULL;
-}
-
-/**
- * cog_platform_configure: (constructor)
- * @name: (nullable): Name of the platform implementation to use.
- * @params: (nullable): Parameters passed to the platform implementation.
- * @env_prefix: (nullable): Prefix for environment variables to check.
- * @shell: The shell that the platform will be configured for.
- * @error: Location where to store errors, if any.
- *
- * Creates and configures a platform implementation.
- *
- * Search and create a platform implementation with the given @name,
- * configuring it with the passed @params for use with a @shell.
- *
- * If the @env_prefix is non-%NULL, then the environment variable
- * `<env_prefix>_PLATFORM_NAME` can be used to set the platform name
- * when @name is %NULL, and the variable `<env_prefix>_PLATFORM_PARAMS`
- * can be used to set the configuration parameters when @params is %NULL.
- * Environment variables will *not* be used if %NULL is passed as the
- * prefix.
- *
- * If both @name is %NULL and the `<env_prefix>_PLATFORM_NAME` variable
- * not defined, then the platform implementation will be chosen automatically
- * among the available ones.
- *
- * Note that [id@cog_modules_add_directory] may be used beforehand to
- * configure where to search for available platform plug-ins.
- *
- * Returns: (transfer full): The configured platform.
- *
- * Since: 0.18
- */
-CogPlatform *
-cog_platform_configure(const char *name, const char *params, const char *env_prefix, CogShell *shell, GError **error)
-{
-    g_return_val_if_fail(!default_platform, default_platform);
-
-    g_autofree char *platform_name = g_strdup(name);
-    g_autofree char *platform_params = g_strdup(params);
-
-    if (env_prefix) {
-        if (!platform_name) {
-            g_autofree char *name_var = g_strconcat(env_prefix, "_PLATFORM_NAME", NULL);
-            platform_name = g_strdup(g_getenv(name_var));
-        }
-        if (!params) {
-            g_autofree char *params_var = g_strconcat(env_prefix, "_PLATFORM_PARAMS", NULL);
-            platform_params = g_strdup(g_getenv(params_var));
-        }
-    }
-    g_debug("%s: name '%s', params '%s'", G_STRFUNC, platform_name, platform_params);
-
-    CogPlatform *platform = cog_platform_new(platform_name, error);
-    if (!platform)
-        return NULL;
-
-    if (!cog_platform_setup(platform, shell, platform_params ?: "", error)) {
-        g_object_unref(platform);
-        g_assert(!default_platform);
-        return NULL;
-    }
-    g_debug("%s: Configured %s @ %p", G_STRFUNC, G_OBJECT_TYPE_NAME(platform), platform);
-
-    g_assert(platform == default_platform);
-    return platform;
 }

--- a/core/cog-platform.h
+++ b/core/cog-platform.h
@@ -52,9 +52,8 @@ struct _CogPlatformClass {
     GType (*get_view_type)(void);
 };
 
-COG_API void         cog_platform_set_default(CogPlatform *);
-COG_API CogPlatform *cog_platform_get_default(void);
-COG_API CogPlatform *cog_platform_new(const char *name, GError **);
+COG_API void         cog_init(const char *platform_name, const char *module_path);
+COG_API CogPlatform *cog_platform_get(void);
 
 COG_API gboolean cog_platform_setup(CogPlatform *platform, CogShell *shell, const char *params, GError **error);
 
@@ -69,9 +68,6 @@ void                      cog_platform_init_web_view     (CogPlatform   *platfor
 
 COG_API
 WebKitInputMethodContext *cog_platform_create_im_context (CogPlatform   *platform);
-
-COG_API CogPlatform *
-cog_platform_configure(const char *name, const char *params, const char *env_prefix, CogShell *shell, GError **error);
 
 G_END_DECLS
 

--- a/core/cog-view.c
+++ b/core/cog-view.c
@@ -146,7 +146,7 @@ _cog_view_get_impl_type_init(GType *type)
 {
     *type = cog_core_view_get_type();
 
-    CogPlatform *platform = cog_platform_get_default();
+    CogPlatform *platform = cog_platform_get();
     if (platform) {
         CogPlatformClass *platform_class = COG_PLATFORM_GET_CLASS(platform);
         if (platform_class->get_view_type) {
@@ -216,7 +216,7 @@ cog_core_view_create_backend(CogView *view G_GNUC_UNUSED)
 {
     g_autoptr(GError) error = NULL;
 
-    WebKitWebViewBackend *backend = cog_platform_get_view_backend(cog_platform_get_default(), NULL, &error);
+    WebKitWebViewBackend *backend = cog_platform_get_view_backend(cog_platform_get(), NULL, &error);
     if (!backend)
         g_error("%s: Could not create view backend, %s", G_STRFUNC, error->message);
 

--- a/docs/cog.toml.in
+++ b/docs/cog.toml.in
@@ -42,6 +42,7 @@ base_url = "https://github.com/Igalia/cog/blob/master/"
 [extra]
 content_files = [
     "overview.md",
+    "running.md",
     "contributing.md",
     "platform-wl.md",
     "platform-drm.md",

--- a/docs/running.md
+++ b/docs/running.md
@@ -1,0 +1,22 @@
+Title: Running Cog Applications
+
+Running Cog Applications
+========================
+
+Environment Variables
+---------------------
+
+The runtime behaviour of the Cog core library can be influenced by a number of
+environment variables.
+
+`COG_MODULEDIR`
+:  Allows to specify a non-default location where to search for platform
+   plug-in modules. The default location is under `<libdir>/cog/modules`
+   unless a custom location was specified during configuration when
+   building. See [id@cog_modules_add_directory] and [id@cog_init] for
+   more information.
+
+`COG_PLATFORM_NAME`
+:  This variable can be set to the name of the platform plug-in module to
+   use and prevent automatically determining which one to use.
+   See [id@cog_init] for more information.

--- a/examples/viewport.c
+++ b/examples/viewport.c
@@ -34,12 +34,12 @@ main(int argc, char *argv[])
     }
 
     g_set_prgname("view-stack");
-    cog_modules_add_directory(g_getenv("COG_MODULEDIR"));
 
-    g_autoptr(GError)      error = NULL;
-    g_autoptr(CogShell)    shell = cog_shell_new(g_get_prgname(), FALSE);
-    g_autoptr(CogPlatform) platform = cog_platform_configure(NULL, NULL, "COG", shell, &error);
-    if (!platform)
+    g_autoptr(CogShell) shell = cog_shell_new(g_get_prgname(), FALSE);
+    g_autoptr(GError)   error = NULL;
+
+    CogPlatform *platform = cog_platform_get();
+    if (!cog_platform_setup(platform, shell, g_getenv("COG_PLATFORM_PARAMS") ?: "", &error))
         g_error("Cannot configure platform: %s", error->message);
 
     g_autoptr(GMainLoop) loop = g_main_loop_new(NULL, FALSE);

--- a/launcher/cog.c
+++ b/launcher/cog.c
@@ -22,7 +22,6 @@ int
 main(int argc, char *argv[])
 {
     g_set_application_name("Cog");
-    cog_modules_add_directory(g_getenv("COG_MODULEDIR"));
 
     g_info("%s:", COG_MODULES_PLATFORM_EXTENSION_POINT);
     cog_modules_foreach(COG_MODULES_PLATFORM, print_module_info, NULL);

--- a/platform/wayland/cog-platform-wl.c
+++ b/platform/wayland/cog-platform-wl.c
@@ -530,7 +530,7 @@ pointer_on_motion(void *data, struct wl_pointer *pointer, uint32_t time, wl_fixe
                                             seat->pointer.button,
                                             seat->pointer.state};
 
-    CogView *view = cog_viewport_get_visible_view(((CogWlPlatform *) cog_platform_get_default())->viewport);
+    CogView *view = cog_viewport_get_visible_view(((CogWlPlatform *) cog_platform_get())->viewport);
     if (view)
         wpe_view_backend_dispatch_pointer_event(cog_view_get_backend(view), &event);
 }
@@ -551,7 +551,7 @@ pointer_on_button(void              *data,
         return;
     }
 
-    CogWlPlatform *platform = (CogWlPlatform *) cog_platform_get_default();
+    CogWlPlatform *platform = (CogWlPlatform *) cog_platform_get();
 
     seat->pointer.serial = serial;
 
@@ -588,7 +588,7 @@ pointer_on_button(void              *data,
         }
     }
 
-    CogView *view = cog_viewport_get_visible_view(((CogWlPlatform *) cog_platform_get_default())->viewport);
+    CogView *view = cog_viewport_get_visible_view(((CogWlPlatform *) cog_platform_get())->viewport);
     if (view)
         wpe_view_backend_dispatch_pointer_event(cog_view_get_backend(view), &event);
 }
@@ -612,7 +612,7 @@ dispatch_axis_event(CogWlSeat *seat)
     event.x_axis = wl_fixed_to_double(seat->axis.x_delta) * display->current_output->scale;
     event.y_axis = -wl_fixed_to_double(seat->axis.y_delta) * display->current_output->scale;
 
-    CogView *view = cog_viewport_get_visible_view(((CogWlPlatform *) cog_platform_get_default())->viewport);
+    CogView *view = cog_viewport_get_visible_view(((CogWlPlatform *) cog_platform_get())->viewport);
     if (view)
         wpe_view_backend_dispatch_axis_event(cog_view_get_backend(view), &event.base);
 
@@ -760,7 +760,7 @@ keyboard_on_leave(void *data, struct wl_keyboard *wl_keyboard, uint32_t serial, 
 static void
 handle_key_event(CogWlSeat *seat, uint32_t key, uint32_t state, uint32_t time)
 {
-    CogWlPlatform *platform = (CogWlPlatform *) cog_platform_get_default();
+    CogWlPlatform *platform = (CogWlPlatform *) cog_platform_get();
     CogView       *view = cog_viewport_get_visible_view(platform->viewport);
 
     if (!view || seat->xkb.state == NULL)
@@ -959,7 +959,7 @@ touch_on_down(void              *data,
 
     memcpy(&seat->touch.points[id], &raw_event, sizeof(struct wpe_input_touch_event_raw));
 
-    CogWlPlatform *platform = (CogWlPlatform *) cog_platform_get_default();
+    CogWlPlatform *platform = (CogWlPlatform *) cog_platform_get();
     CogWlPopup    *popup = platform->popup;
     if (popup && popup->wl_surface) {
         if (seat->touch.surface == popup->wl_surface) {
@@ -999,7 +999,7 @@ touch_on_up(void *data, struct wl_touch *touch, uint32_t serial, uint32_t time, 
         wpe_input_touch_event_type_up, time, id, seat->touch.points[id].x, seat->touch.points[id].y,
     };
 
-    CogWlPlatform *platform = (CogWlPlatform *) cog_platform_get_default();
+    CogWlPlatform *platform = (CogWlPlatform *) cog_platform_get();
     CogWlPopup    *popup = platform->popup;
 
     if (popup && popup->wl_surface) {
@@ -1050,7 +1050,7 @@ touch_on_motion(void *data, struct wl_touch *touch, uint32_t time, int32_t id, w
 
     struct wpe_input_touch_event event = {seat->touch.points, 10, raw_event.type, raw_event.id, raw_event.time};
 
-    CogView *view = cog_viewport_get_visible_view(((CogWlPlatform *) cog_platform_get_default())->viewport);
+    CogView *view = cog_viewport_get_visible_view(((CogWlPlatform *) cog_platform_get())->viewport);
     if (view)
         wpe_view_backend_dispatch_touch_event(cog_view_get_backend(view), &event);
 }
@@ -1578,7 +1578,7 @@ destroy_window(CogWlPlatform *platform)
 static struct wpe_view_backend *
 gamepad_provider_get_view_backend_for_gamepad(void *provider G_GNUC_UNUSED, void *gamepad G_GNUC_UNUSED)
 {
-    CogWlPlatform *platform = COG_WL_PLATFORM(cog_platform_get_default());
+    CogWlPlatform *platform = COG_WL_PLATFORM(cog_platform_get());
 
     CogWlView *view = (CogWlView *) cog_viewport_get_visible_view(platform->viewport);
     g_assert(view);

--- a/platform/wayland/cog-utils-wl.c
+++ b/platform/wayland/cog-utils-wl.c
@@ -196,7 +196,7 @@ static void
 xdg_popup_on_popup_done(void *data, struct xdg_popup *xdg_popup)
 {
     CogWlPopup    *popup = data;
-    CogWlPlatform *platform = (CogWlPlatform *) cog_platform_get_default();
+    CogWlPlatform *platform = (CogWlPlatform *) cog_platform_get();
 
     // Reset the reference in the Platform if the destroyed popup is the same
     if (platform->popup == popup)

--- a/platform/wayland/cog-view-wl.c
+++ b/platform/wayland/cog-view-wl.c
@@ -176,7 +176,7 @@ cog_wl_view_clear_buffers(CogWlView *view)
 static WebKitWebViewBackend *
 cog_wl_view_create_backend(CogView *view)
 {
-    CogWlPlatform *platform = (CogWlPlatform *) cog_platform_get_default();
+    CogWlPlatform *platform = (CogWlPlatform *) cog_platform_get();
     CogWlView *self = COG_WL_VIEW(view);
 
     static const struct wpe_view_backend_exportable_fdo_egl_client client = {
@@ -212,7 +212,7 @@ cog_wl_view_create_backend(CogView *view)
 bool
 cog_wl_view_does_image_match_win_size(CogWlView *view)
 {
-    CogWlPlatform *platform = (CogWlPlatform *) cog_platform_get_default();
+    CogWlPlatform *platform = (CogWlPlatform *) cog_platform_get();
     return view->image && wpe_fdo_egl_exported_image_get_width(view->image) == platform->window.width &&
            wpe_fdo_egl_exported_image_get_height(view->image) == platform->window.height;
 }
@@ -225,7 +225,7 @@ cog_wl_view_enter_fullscreen(CogWlView *view)
         return;
 
 #if HAVE_FULLSCREEN_HANDLING
-    CogWlPlatform *platform = (CogWlPlatform *) cog_platform_get_default();
+    CogWlPlatform *platform = (CogWlPlatform *) cog_platform_get();
     if (platform->window.was_fullscreen_requested_from_dom)
         wpe_view_backend_dispatch_did_enter_fullscreen(cog_view_get_backend(COG_VIEW(view)));
 #endif
@@ -246,7 +246,7 @@ cog_wl_view_exit_fullscreen(CogWlView *view)
 static bool
 cog_wl_view_handle_dom_fullscreen_request(void *data, bool fullscreen)
 {
-    CogWlPlatform *platform = (CogWlPlatform *) cog_platform_get_default();
+    CogWlPlatform *platform = (CogWlPlatform *) cog_platform_get();
 
     platform->window.was_fullscreen_requested_from_dom = true;
     if (fullscreen != platform->window.is_fullscreen)
@@ -272,7 +272,7 @@ cog_wl_view_on_buffer_release(void *data G_GNUC_UNUSED, struct wl_buffer *buffer
 static void
 cog_wl_view_request_frame(CogWlView *view)
 {
-    CogWlPlatform *platform = (CogWlPlatform *) cog_platform_get_default();
+    CogWlPlatform *platform = (CogWlPlatform *) cog_platform_get();
 
     if (!view->frame_callback) {
         static const struct wl_callback_listener listener = {.done = on_wl_surface_frame};
@@ -294,7 +294,7 @@ cog_wl_view_request_frame(CogWlView *view)
 void
 cog_wl_view_resize(CogWlView *view)
 {
-    CogWlPlatform *platform = (CogWlPlatform *) cog_platform_get_default();
+    CogWlPlatform *platform = (CogWlPlatform *) cog_platform_get();
 
     view->should_update_opaque_region = true;
 
@@ -312,7 +312,7 @@ cog_wl_view_resize(CogWlView *view)
 void
 cog_wl_view_update_surface_contents(CogWlView *view)
 {
-    CogWlPlatform *platform = (CogWlPlatform *) cog_platform_get_default();
+    CogWlPlatform *platform = (CogWlPlatform *) cog_platform_get();
     g_assert(view);
 
     struct wl_surface *surface = platform->window.wl_surface;
@@ -365,7 +365,7 @@ cog_wl_view_update_surface_contents(CogWlView *view)
 static bool
 validate_exported_geometry(uint32_t width, uint32_t height)
 {
-    CogWlPlatform *platform = (CogWlPlatform *) cog_platform_get_default();
+    CogWlPlatform *platform = (CogWlPlatform *) cog_platform_get();
 
     const uint32_t surface_pixel_width = platform->display->current_output->scale * platform->window.width;
     const uint32_t surface_pixel_height = platform->display->current_output->scale * platform->window.height;
@@ -384,7 +384,7 @@ validate_exported_geometry(uint32_t width, uint32_t height)
 static void
 on_export_shm_buffer(void *data, struct wpe_fdo_shm_exported_buffer *exported_buffer)
 {
-    CogWlPlatform *platform = (CogWlPlatform *) cog_platform_get_default();
+    CogWlPlatform *platform = (CogWlPlatform *) cog_platform_get();
     CogWlView     *view = data;
 
     struct wl_resource   *exported_resource = wpe_fdo_shm_exported_buffer_get_resource(exported_buffer);
@@ -466,7 +466,7 @@ static void
 on_mouse_target_changed(WebKitWebView *view, WebKitHitTestResult *hitTestResult, guint mouseModifiers)
 {
 #ifdef COG_USE_WAYLAND_CURSOR
-    CogWlPlatform *platform = (CogWlPlatform *) cog_platform_get_default();
+    CogWlPlatform *platform = (CogWlPlatform *) cog_platform_get();
     if (webkit_hit_test_result_context_is_link(hitTestResult)) {
         cog_wl_seat_set_cursor(platform->display->seat_default, CURSOR_HAND);
     } else if (webkit_hit_test_result_context_is_editable(hitTestResult)) {
@@ -483,7 +483,7 @@ on_mouse_target_changed(WebKitWebView *view, WebKitHitTestResult *hitTestResult,
 static void
 on_run_file_chooser(WebKitWebView *view, WebKitFileChooserRequest *request)
 {
-    CogWlPlatform *platform = (CogWlPlatform *) cog_platform_get_default();
+    CogWlPlatform *platform = (CogWlPlatform *) cog_platform_get();
 
     g_autoptr(XdpParent) xdp_parent = NULL;
     if (platform->window.xdp_parent_wl_data.zxdg_exporter && platform->window.xdp_parent_wl_data.wl_surface) {
@@ -497,7 +497,7 @@ on_run_file_chooser(WebKitWebView *view, WebKitFileChooserRequest *request)
 static void
 on_show_option_menu(WebKitWebView *view, WebKitOptionMenu *menu, WebKitRectangle *rectangle, gpointer *data)
 {
-    CogWlPlatform *platform = (CogWlPlatform *) cog_platform_get_default();
+    CogWlPlatform *platform = (CogWlPlatform *) cog_platform_get();
     cog_wl_platform_popup_create(platform, g_object_ref(menu));
 }
 
@@ -577,7 +577,7 @@ shm_buffer_create(CogWlView *view, struct wl_resource *buffer_resource, size_t s
     buffer->buffer_resource = buffer_resource;
     wl_resource_add_destroy_listener(buffer_resource, &buffer->destroy_listener);
 
-    CogWlPlatform *platform = (CogWlPlatform *) cog_platform_get_default();
+    CogWlPlatform *platform = (CogWlPlatform *) cog_platform_get();
     buffer->shm_pool = wl_shm_create_pool(platform->display->shm, fd, size);
     buffer->data = data;
     buffer->size = size;


### PR DESCRIPTION
Remove the `cog_platform_configure()` utility function, because at this point it does not do much else than calling `cog_platform_new()` and `cog_platform_setup()`. Instead, make sure that the platform instance is a global singleton and that it is created on-demand on the first call of a the `cog_platform_get()` accessor.

In order to allow manually indicating which platform plug-in to use, a new `cog_init()` function is added. While at it, make it unnecessary for programs to always call `cog_modules_add_directory()` if they only need to use the default module path.

The upside of these changes is that the API gets much more convenient to use, and in the simplest of cases, it is enough to let the library initialize the platform instance. The one-time configuration using `cog_platform_setup()` is still needed, but now the following is enough to properly use the library:

```c
CogShell *shell = cog_shell_new("my-program", FALSE);
if (!cog_platform_setup(cog_platform_get(), shell, "", NULL))
    g_error("Cannot initialize Cog.");
```

Note that the `COG_MODULEDIR` and `COG_PLATFORM_NAME` environment variables are still used when `NULL`s are passed to `cog_init()` or during implicit initialization.

----

- This is an alternative take on #647
- If possible, it would be better to merge #656 first (see [comment below](https://github.com/Igalia/cog/pull/655#issuecomment-1809805319))