### PR TITLE
core: Add some convenience to the module loader

### DIFF
--- a/examples/viewport.c
+++ b/examples/viewport.c
@@ -34,7 +34,7 @@ main(int argc, char *argv[])
     }
 
     g_set_prgname("view-stack");
-    cog_modules_add_directory(g_getenv("COG_MODULEDIR") ?: COG_MODULEDIR);
+    cog_modules_add_directory(g_getenv("COG_MODULEDIR"));
 
     g_autoptr(GError)      error = NULL;
     g_autoptr(CogShell)    shell = cog_shell_new(g_get_prgname(), FALSE);

--- a/launcher/cog.c
+++ b/launcher/cog.c
@@ -22,7 +22,7 @@ int
 main(int argc, char *argv[])
 {
     g_set_application_name("Cog");
-    cog_modules_add_directory(g_getenv("COG_MODULEDIR") ?: COG_MODULEDIR);
+    cog_modules_add_directory(g_getenv("COG_MODULEDIR"));
 
     g_info("%s:", COG_MODULES_PLATFORM_EXTENSION_POINT);
     cog_modules_foreach(COG_MODULES_PLATFORM, print_module_info, NULL);


### PR DESCRIPTION
This brings in two related commits which make it a bit simpler to use the module loading API. Namely:

- Allow passing the same directory more than once to `cog_modules_add_directory()`, or directories with plugins which have the same name. Duplicates will be skipped, and that prevents potential issues with multiple installations of the same module, and avoids programs needing to track which directories have been already scanned to avoid passing the same path more than once.
- Remove the need to do an initial call to `cog_modules_add_directory(COG_MODULEDIR)` to scan the default module path. This is now done implicitly. 