### PR TITLE
core: Allow passing NULL as platform setup params

### DIFF
--- a/core/cog-platform.c
+++ b/core/cog-platform.c
@@ -117,17 +117,37 @@ cog_platform_get(void)
     return platform_singleton;
 }
 
+/**
+ * cog_platform_setup:
+ * @platform: Platform instance.
+ * @shell: The shell being configured.
+ * @params: (nullable): String with parameters for the platform plug-in.
+ * @error: (nullable): Location where to store an error on failure.
+ *
+ * Configure the platform plug-in module.
+ *
+ * If the @params string is %NULL or empty, the value of the
+ * `COG_PLATFORM_PARAMS` environment variable will be used, if defined.
+ * Each platform module may have its own syntax for the parameters string,
+ * but typically they accept a list of comma-separated `variable=value`
+ * assignments.
+ *
+ * The documentation for each platform plug-in details the available
+ * parameters and deviations of the parameter string syntax, if applicable.
+ *
+ * Returns: Whether the platform was configured successfully.
+ */
 gboolean
-cog_platform_setup (CogPlatform *platform,
-                    CogShell    *shell,
-                    const char  *params,
-                    GError     **error)
+cog_platform_setup(CogPlatform *platform, CogShell *shell, const char *params, GError **error)
 {
     g_return_val_if_fail(COG_IS_PLATFORM(platform), FALSE);
     g_return_val_if_fail(COG_IS_SHELL(shell), FALSE);
 
     if (G_IS_INITABLE(platform) && !g_initable_init(G_INITABLE(platform), NULL /* cancellable */, error))
         return FALSE;
+
+    if (!params || params[0] == '\0')
+        params = g_getenv("COG_PLATFORM_PARAMS") ?: "";
 
     return COG_PLATFORM_GET_CLASS(platform)->setup(platform, shell, params, error);
 }

--- a/docs/running.md
+++ b/docs/running.md
@@ -20,3 +20,10 @@ environment variables.
 :  This variable can be set to the name of the platform plug-in module to
    use and prevent automatically determining which one to use.
    See [id@cog_init] for more information.
+
+`COG_PLATFORM_PARAMS`
+:  This variable may contain setup parameters for the chosen platform plug-in
+   module. The parameters supported by each platform may be found in their
+   respective documentation pages. The format of the parameters string is
+   typically (but not always) a comma-separated list of `variable=value`
+   assignments. See [id@cog_platform_setup] for more information.

--- a/examples/viewport.c
+++ b/examples/viewport.c
@@ -39,7 +39,7 @@ main(int argc, char *argv[])
     g_autoptr(GError)   error = NULL;
 
     CogPlatform *platform = cog_platform_get();
-    if (!cog_platform_setup(platform, shell, g_getenv("COG_PLATFORM_PARAMS") ?: "", &error))
+    if (!cog_platform_setup(platform, shell, NULL, &error))
         g_error("Cannot configure platform: %s", error->message);
 
     g_autoptr(GMainLoop) loop = g_main_loop_new(NULL, FALSE);

--- a/launcher/cog-launcher.c
+++ b/launcher/cog-launcher.c
@@ -240,8 +240,7 @@ cog_launcher_create_view(CogLauncher *self, CogShell *shell)
     CogPlatform *platform = cog_platform_get();
 
     g_autoptr(GError) error = NULL;
-    if (!cog_platform_setup(platform, shell, s_options.platform_params ?: (g_getenv("COG_PLATFORM_PARAMS") ?: ""),
-                            &error))
+    if (!cog_platform_setup(platform, shell, s_options.platform_params, &error))
         g_error("Cannot configure platform: %s", error->message);
 
 #if HAVE_WEBKIT_AUTOPLAY


### PR DESCRIPTION
Change `cog_platform_setup()` to allow passing `NULL` as the parameters string, and fall back to using the value of the `COG_PLATFORM_PARAMS` environment variable in that case. In order to keep the same ABI with existing platform plug-ins, the function ensures that an empty string is always passed when needed.

This change simplifies call sites for the function, which no longer need to handle reading the environment variable themselves, nor taking care of always passing a valid string, even if empty.

While at it, write the missing documentation for `cog_platform_setup()`.

----

This depends on https://github.com/Igalia/cog/pull/655