### PR TITLE
core: Make cog_modules_add_directory() honor COG_MODULEDIR

### DIFF
--- a/core/cog-platform.c
+++ b/core/cog-platform.c
@@ -90,7 +90,7 @@ cog_platform_ensure_singleton(const char *name)
 void
 cog_init(const char *platform_name, const char *module_path)
 {
-    cog_modules_add_directory(module_path ?: g_getenv("COG_MODULEDIR"));
+    cog_modules_add_directory(module_path);
     gboolean already_initialized = cog_platform_ensure_singleton(platform_name ?: g_getenv("COG_PLATFORM_NAME"));
     g_return_if_fail(!already_initialized);
 }


### PR DESCRIPTION
Move handling of the `COG_MODULEDIR` environment variable into the `cog_modules_add_directory()` function, fix the bug that skipped using the environment variable when `cog_init()` is *not* used, and improve robustness:
    
- The path passed is checked to be a valid directory location.
- The environment variable is checked only once for the whole execution of the process, the first time the function is called with a `NULL` argument.
- The path in the environment variable is checked for validity as well. A warning is produced for invalid locations.
- If either the environment variable or the compiled-in default path are used, it is considered that the “default” path was set, and will not be set again to avoid re-scanning directories unnecessarily.

While at it, sprinkle comments on the code to explain the logic.

----

This depends on changes from https://github.com/Igalia/cog/pull/655