### PR TITLE
wl: Attach Viewport to the surface

### DIFF
--- a/platform/wayland/cog-utils-wl.c
+++ b/platform/wayland/cog-utils-wl.c
@@ -111,6 +111,14 @@ setup_wayland_event_source(GMainContext *main_context, struct wl_display *displa
     return &wl_source->source;
 }
 
+struct wl_surface *
+cog_wl_compositor_create_surface(struct wl_compositor *compositor, void *container)
+{
+    struct wl_surface *surface = wl_compositor_create_surface(compositor);
+    wl_surface_set_user_data(surface, container);
+    return surface;
+}
+
 void
 cog_wl_display_add_seat(CogWlDisplay *display, CogWlSeat *seat)
 {
@@ -282,7 +290,7 @@ cog_wl_popup_create(CogWlPlatform *platform, WebKitOptionMenu *option_menu)
     popup->popup_menu =
         cog_popup_menu_create(option_menu, display->shm, popup->width, popup->height, display->current_output->scale);
 
-    popup->wl_surface = wl_compositor_create_surface(display->compositor);
+    popup->wl_surface = cog_wl_compositor_create_surface(display->compositor, platform);
     g_assert(popup->wl_surface);
 
 #ifdef WL_SURFACE_SET_BUFFER_SCALE_SINCE_VERSION

--- a/platform/wayland/cog-utils-wl.c
+++ b/platform/wayland/cog-utils-wl.c
@@ -290,7 +290,7 @@ cog_wl_popup_create(CogWlPlatform *platform, WebKitOptionMenu *option_menu)
     popup->popup_menu =
         cog_popup_menu_create(option_menu, display->shm, popup->width, popup->height, display->current_output->scale);
 
-    popup->wl_surface = cog_wl_compositor_create_surface(display->compositor, platform);
+    popup->wl_surface = cog_wl_compositor_create_surface(display->compositor, viewport);
     g_assert(popup->wl_surface);
 
 #ifdef WL_SURFACE_SET_BUFFER_SCALE_SINCE_VERSION

--- a/platform/wayland/cog-utils-wl.h
+++ b/platform/wayland/cog-utils-wl.h
@@ -274,6 +274,23 @@ struct _CogWlDisplay {
     GSource *event_src;
 };
 
+/**
+ * CogWlPlatform::cog_wl_compositor_create_surface:
+ * @compositor: The Wayland compositor.
+ * @container: User data.
+ *
+ * Commonly used for adding reference to the container that has this surface.
+ * For example, for a surface on a CogWlWindow, the reference will point to
+ * the CogWlPlatform. The rationale behind this is to articulate an easy way
+ * for passing the container as contextual information associated to a
+ * wl_surface. This is interesting for avoiding the use of global
+ * references and, in a near future, will make easier the access to the
+ * object that groups the CogWlViews.
+ *
+ * returns: static struct wl_surface *
+ */
+struct wl_surface *cog_wl_compositor_create_surface(struct wl_compositor *compositor, void *container);
+
 void          cog_wl_display_add_seat(CogWlDisplay *, CogWlSeat *);
 CogWlDisplay *cog_wl_display_create(const char *name, GError **error);
 void          cog_wl_display_destroy(CogWlDisplay *self);

--- a/platform/wayland/cog-utils-wl.h
+++ b/platform/wayland/cog-utils-wl.h
@@ -173,12 +173,15 @@ struct _CogWlSeat {
 
     CogWlKeyboard       keyboard;
     struct wl_keyboard *keyboard_obj;
+    void               *keyboard_target; /* Current target of keyboard events. */
 
     CogWlPointer       pointer;
     struct wl_pointer *pointer_obj;
+    void              *pointer_target; /* Current target of pointer events. */
 
     CogWlTouch       touch;
     struct wl_touch *touch_obj;
+    void            *touch_target; /* Current target of touch events. */
 
     CogWlXkb xkb;
 

--- a/platform/wayland/cog-viewport-wl.c
+++ b/platform/wayland/cog-viewport-wl.c
@@ -247,7 +247,7 @@ cog_wl_viewport_create_window(CogWlViewport *viewport, GError **error)
     CogWlPlatform *platform = COG_WL_PLATFORM(cog_platform_get());
     CogWlDisplay  *display = platform->display;
 
-    viewport->window.wl_surface = wl_compositor_create_surface(display->compositor);
+    viewport->window.wl_surface = cog_wl_compositor_create_surface(display->compositor, viewport);
 
 #if COG_ENABLE_WESTON_DIRECT_DISPLAY
     viewport->window.video_surfaces = g_hash_table_new_full(g_direct_hash, g_direct_equal, NULL, destroy_video_surface);


### PR DESCRIPTION
**motivation:** Every single wl_surface in the Cog apps belongs to a specific Viewport but there is not a way, right now, in the code to know where     is the Viewport associated to the wl_surface.
    
**excerpt:** This change allows a direct way for accessing to the Viewport associated from a given wl_surface. Also opens the possibility of     to handle the input events methods avoiding this assumption: There is     just one single and unique CogView associated to the platform. This change is much more logical than the previous assumption.
