### PR TITLE
Add in CogView a reference to the CogViewport where it belongs

### DIFF
--- a/core/cog-view-private.h
+++ b/core/cog-view-private.h
@@ -1,0 +1,17 @@
+/*
+ * cog-view-private.h
+ * Copyright (C) 2023 Igalia S.L.
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#pragma once
+
+#include "cog-view.h"
+#include "cog-viewport.h"
+
+G_BEGIN_DECLS
+
+void cog_view_set_viewport(CogView *self, CogViewport *viewport);
+
+G_END_DECLS

--- a/core/cog-view.c
+++ b/core/cog-view.c
@@ -7,6 +7,7 @@
 
 #include "cog-view.h"
 #include "cog-platform.h"
+#include "cog-view-private.h"
 
 /**
  * CogView:
@@ -26,6 +27,8 @@
 
 typedef struct {
     gboolean use_key_bindings;
+
+    GWeakRef viewport; /* Weak reference to the associated CogViewport */
 } CogViewPrivate;
 
 G_DEFINE_ABSTRACT_TYPE_WITH_PRIVATE(CogView, cog_view, WEBKIT_TYPE_WEB_VIEW)
@@ -37,6 +40,7 @@ struct _CogCoreViewClass {
 enum {
     PROP_0,
     PROP_USE_KEY_BINDINGS,
+    PROP_VIEWPORT,
     N_PROPERTIES,
 };
 
@@ -87,6 +91,9 @@ cog_view_get_property(GObject *object, unsigned prop_id, GValue *value, GParamSp
     case PROP_USE_KEY_BINDINGS:
         g_value_set_boolean(value, cog_view_get_use_key_bindings(self));
         break;
+    case PROP_VIEWPORT:
+        g_value_take_object(value, cog_view_get_viewport(self));
+        break;
     default:
         G_OBJECT_WARN_INVALID_PROPERTY_ID(object, prop_id, pspec);
     }
@@ -111,12 +118,26 @@ cog_view_class_init(CogViewClass *klass)
         g_param_spec_boolean("use-key-bindings", NULL, NULL, TRUE,
                              G_PARAM_READWRITE | G_PARAM_CONSTRUCT | G_PARAM_EXPLICIT_NOTIFY | G_PARAM_STATIC_STRINGS);
 
+    /**
+     * CogView:viewport: (default-value null)
+     *
+     * Viewport where the CogView belongs.
+     *
+     * Since: 0.20
+     */
+    s_properties[PROP_VIEWPORT] = g_param_spec_object("viewport", NULL, NULL, G_TYPE_OBJECT,
+                                                      G_PARAM_READABLE | G_PARAM_CONSTRUCT | G_PARAM_STATIC_STRINGS);
+
     g_object_class_install_properties(object_class, N_PROPERTIES, s_properties);
 }
 
 static void
 cog_view_init(CogView *self)
 {
+    CogViewPrivate *priv = cog_view_get_instance_private(self);
+
+    // Init the weak reference to the CogViewport.
+    g_weak_ref_init(&priv->viewport, NULL);
 }
 
 static inline struct wpe_view_backend *
@@ -379,6 +400,26 @@ cog_view_set_use_key_bindings(CogView *self, gboolean enable)
 }
 
 /**
+ * cog_view_set_viewport
+ * @self: A view.
+ * @viewport: The viewport where the View belongs.
+ *
+ * Since: 0.20
+ */
+void
+cog_view_set_viewport(CogView *self, CogViewport *viewport)
+{
+    g_return_if_fail(COG_IS_VIEW(self));
+
+    CogViewPrivate *priv = cog_view_get_instance_private(self);
+
+    // Sets a reference to the viewport
+    g_weak_ref_set(&priv->viewport, viewport);
+
+    g_object_notify_by_pspec(G_OBJECT(self), s_properties[PROP_VIEWPORT]);
+}
+
+/**
  * cog_view_get_use_key_bindings: (get-property use-key-bindings)
  * @self: A view.
  *
@@ -395,4 +436,21 @@ cog_view_get_use_key_bindings(CogView *self)
 
     CogViewPrivate *priv = cog_view_get_instance_private(COG_VIEW(self));
     return priv->use_key_bindings;
+}
+
+/**
+ * cog_view_get_viewport: (get-property viewport)
+ * @self: A view.
+ *
+ * Gets viewport where the view is attached.
+ *
+ * Returns: (transfer full) (nullable): The viewport what the view belongs.
+ *
+ * Since: 0.20
+ */
+CogViewport *
+cog_view_get_viewport(CogView *self)
+{
+    g_return_val_if_fail(COG_IS_VIEW(self), NULL);
+    return g_weak_ref_get(&((CogViewPrivate *) cog_view_get_instance_private(self))->viewport);
 }

--- a/core/cog-view.h
+++ b/core/cog-view.h
@@ -11,6 +11,7 @@
 #    error "Do not include this header directly, use <cog.h> instead"
 #endif
 
+#include "cog-viewport.h"
 #include "cog-webkit-utils.h"
 
 G_BEGIN_DECLS
@@ -43,12 +44,15 @@ COG_API
 struct wpe_view_backend *cog_view_get_backend(CogView *view);
 
 COG_API
-void                     cog_view_handle_key_event(CogView *self, const struct wpe_input_keyboard_event *event);
+void cog_view_handle_key_event(CogView *self, const struct wpe_input_keyboard_event *event);
 
 COG_API
-void                     cog_view_set_use_key_bindings(CogView *self, gboolean enable);
+void cog_view_set_use_key_bindings(CogView *self, gboolean enable);
 
 COG_API
-gboolean                 cog_view_get_use_key_bindings(CogView *self);
+gboolean cog_view_get_use_key_bindings(CogView *self);
+
+COG_API
+CogViewport *cog_view_get_viewport(CogView *self);
 
 G_END_DECLS

--- a/core/cog-viewport.c
+++ b/core/cog-viewport.c
@@ -7,6 +7,7 @@
 #include "cog-viewport.h"
 
 #include "cog-platform.h"
+#include "cog-view-private.h"
 #include "cog-view.h"
 
 /**
@@ -258,6 +259,8 @@ cog_viewport_add(CogViewport *self, CogView *view)
     CogViewportPrivate *priv = PRIV(self);
     g_return_if_fail(!g_ptr_array_find(priv->views, view, NULL));
 
+    cog_view_set_viewport(view, self);
+
     g_ptr_array_add(priv->views, g_object_ref(view));
     g_signal_emit(self, s_signals[ADD], 0, view);
 
@@ -303,6 +306,8 @@ cog_viewport_remove(CogViewport *self, CogView *view)
         g_warning("Attempted to remove view %p, which was not in viewport %p.", view, self);
         return;
     }
+
+    cog_view_set_viewport(view, NULL);
 
     g_object_ref(view);
     g_ptr_array_remove_index(priv->views, index);

--- a/platform/wayland/cog-view-wl.c
+++ b/platform/wayland/cog-view-wl.c
@@ -302,7 +302,6 @@ cog_wl_view_resize(CogWlView *view)
 {
     CogWlPlatform *platform = (CogWlPlatform *) cog_platform_get();
     CogWlViewport *viewport = COG_WL_VIEWPORT(platform->viewport);
-
     view->should_update_opaque_region = true;
 
     int32_t pixel_width = viewport->window.width * platform->display->current_output->scale;

--- a/platform/wayland/cog-view-wl.c
+++ b/platform/wayland/cog-view-wl.c
@@ -178,7 +178,6 @@ static WebKitWebViewBackend *
 cog_wl_view_create_backend(CogView *view)
 {
     CogWlPlatform *platform = (CogWlPlatform *) cog_platform_get();
-    CogWlViewport *viewport = COG_WL_VIEWPORT(platform->viewport);
     CogWlView     *self = COG_WL_VIEW(view);
 
     static const struct wpe_view_backend_exportable_fdo_egl_client client = {
@@ -188,8 +187,7 @@ cog_wl_view_create_backend(CogView *view)
 #endif
     };
 
-    self->exportable =
-        wpe_view_backend_exportable_fdo_egl_create(&client, self, viewport->window.width, viewport->window.height);
+    self->exportable = wpe_view_backend_exportable_fdo_egl_create(&client, self, DEFAULT_WIDTH, DEFAULT_HEIGHT);
 
     /* init WPE view backend */
     struct wpe_view_backend *view_backend = wpe_view_backend_exportable_fdo_get_view_backend(self->exportable);
@@ -214,8 +212,10 @@ cog_wl_view_create_backend(CogView *view)
 bool
 cog_wl_view_does_image_match_win_size(CogWlView *view)
 {
-    CogWlPlatform *platform = (CogWlPlatform *) cog_platform_get();
-    CogWlViewport *viewport = COG_WL_VIEWPORT(platform->viewport);
+    g_autoptr(CogWlViewport) viewport = COG_WL_VIEWPORT(cog_view_get_viewport((CogView *) view));
+    if (!viewport)
+        return false;
+
     return view->image && wpe_fdo_egl_exported_image_get_width(view->image) == viewport->window.width &&
            wpe_fdo_egl_exported_image_get_height(view->image) == viewport->window.height;
 }
@@ -228,8 +228,8 @@ cog_wl_view_enter_fullscreen(CogWlView *view)
         return;
 
 #if HAVE_FULLSCREEN_HANDLING
-    CogWlPlatform *platform = (CogWlPlatform *) cog_platform_get();
-    CogWlViewport *viewport = COG_WL_VIEWPORT(platform->viewport);
+    g_autoptr(CogWlViewport) viewport = COG_WL_VIEWPORT(cog_view_get_viewport((CogView *) view));
+    g_assert(viewport != NULL);
     if (viewport->window.was_fullscreen_requested_from_dom)
         wpe_view_backend_dispatch_did_enter_fullscreen(cog_view_get_backend(COG_VIEW(view)));
 #endif
@@ -250,8 +250,10 @@ cog_wl_view_exit_fullscreen(CogWlView *view)
 static bool
 cog_wl_view_handle_dom_fullscreen_request(void *data, bool fullscreen)
 {
-    CogWlPlatform *platform = (CogWlPlatform *) cog_platform_get();
-    CogWlViewport *viewport = COG_WL_VIEWPORT(platform->viewport);
+    CogWlView               *view = data;
+    g_autoptr(CogWlViewport) viewport = COG_WL_VIEWPORT(cog_view_get_viewport((CogView *) view));
+    if (!viewport)
+        return false;
 
     viewport->window.was_fullscreen_requested_from_dom = true;
     if (fullscreen != viewport->window.is_fullscreen)
@@ -277,8 +279,10 @@ cog_wl_view_on_buffer_release(void *data G_GNUC_UNUSED, struct wl_buffer *buffer
 static void
 cog_wl_view_request_frame(CogWlView *view)
 {
-    CogWlPlatform *platform = (CogWlPlatform *) cog_platform_get();
-    CogWlViewport *viewport = COG_WL_VIEWPORT(platform->viewport);
+    CogWlPlatform           *platform = (CogWlPlatform *) cog_platform_get();
+    g_autoptr(CogWlViewport) viewport = COG_WL_VIEWPORT(cog_view_get_viewport((CogView *) view));
+    if (!viewport)
+        return;
 
     if (!view->frame_callback) {
         static const struct wl_callback_listener listener = {.done = on_wl_surface_frame};
@@ -301,7 +305,15 @@ void
 cog_wl_view_resize(CogWlView *view)
 {
     CogWlPlatform *platform = (CogWlPlatform *) cog_platform_get();
-    CogWlViewport *viewport = COG_WL_VIEWPORT(platform->viewport);
+    g_assert(platform);
+
+    if (!platform->display || !platform->display->current_output)
+        return;
+
+    g_autoptr(CogWlViewport) viewport = COG_WL_VIEWPORT(cog_view_get_viewport((CogView *) view));
+    if (!viewport)
+        return;
+
     view->should_update_opaque_region = true;
 
     int32_t pixel_width = viewport->window.width * platform->display->current_output->scale;
@@ -318,9 +330,12 @@ cog_wl_view_resize(CogWlView *view)
 void
 cog_wl_view_update_surface_contents(CogWlView *view)
 {
-    CogWlPlatform *platform = (CogWlPlatform *) cog_platform_get();
-    CogWlViewport *viewport = COG_WL_VIEWPORT(platform->viewport);
     g_assert(view);
+
+    CogWlPlatform           *platform = (CogWlPlatform *) cog_platform_get();
+    g_autoptr(CogWlViewport) viewport = COG_WL_VIEWPORT(cog_view_get_viewport((CogView *) view));
+    if (!viewport)
+        return;
 
     struct wl_surface *surface = viewport->window.wl_surface;
     g_assert(surface);
@@ -370,10 +385,9 @@ cog_wl_view_update_surface_contents(CogWlView *view)
 }
 
 static bool
-validate_exported_geometry(uint32_t width, uint32_t height)
+validate_exported_geometry(CogWlViewport *viewport, uint32_t width, uint32_t height)
 {
     CogWlPlatform *platform = (CogWlPlatform *) cog_platform_get();
-    CogWlViewport *viewport = COG_WL_VIEWPORT(platform->viewport);
 
     const uint32_t surface_pixel_width = platform->display->current_output->scale * viewport->window.width;
     const uint32_t surface_pixel_height = platform->display->current_output->scale * viewport->window.height;
@@ -392,16 +406,15 @@ validate_exported_geometry(uint32_t width, uint32_t height)
 static void
 on_export_shm_buffer(void *data, struct wpe_fdo_shm_exported_buffer *exported_buffer)
 {
-    CogWlPlatform *platform = (CogWlPlatform *) cog_platform_get();
-    CogWlViewport *viewport = COG_WL_VIEWPORT(platform->viewport);
-    CogWlView     *view = data;
+    CogWlView               *view = data;
+    g_autoptr(CogWlViewport) viewport = COG_WL_VIEWPORT(cog_view_get_viewport((CogView *) view));
 
     struct wl_resource   *exported_resource = wpe_fdo_shm_exported_buffer_get_resource(exported_buffer);
     struct wl_shm_buffer *exported_shm_buffer = wpe_fdo_shm_exported_buffer_get_shm_buffer(exported_buffer);
 
     uint32_t image_width = wl_shm_buffer_get_width(exported_shm_buffer);
     uint32_t image_height = wl_shm_buffer_get_height(exported_shm_buffer);
-    if (!validate_exported_geometry(image_width, image_height)) {
+    if (!viewport || !validate_exported_geometry(viewport, image_width, image_height)) {
         wpe_view_backend_exportable_fdo_dispatch_frame_complete(view->exportable);
         wpe_view_backend_exportable_fdo_egl_dispatch_release_shm_exported_buffer(view->exportable, exported_buffer);
         return;
@@ -451,11 +464,12 @@ on_export_shm_buffer(void *data, struct wpe_fdo_shm_exported_buffer *exported_bu
 static void
 on_export_wl_egl_image(void *data, struct wpe_fdo_egl_exported_image *image)
 {
-    CogWlView *self = data;
+    CogWlView               *self = data;
+    g_autoptr(CogWlViewport) viewport = COG_WL_VIEWPORT(cog_view_get_viewport((CogView *) self));
 
     uint32_t image_width = wpe_fdo_egl_exported_image_get_width(image);
     uint32_t image_height = wpe_fdo_egl_exported_image_get_height(image);
-    if (!validate_exported_geometry(image_width, image_height)) {
+    if (!viewport || !validate_exported_geometry(viewport, image_width, image_height)) {
         wpe_view_backend_exportable_fdo_dispatch_frame_complete(self->exportable);
         wpe_view_backend_exportable_fdo_egl_dispatch_release_exported_image(self->exportable, image);
         return;
@@ -492,8 +506,9 @@ on_mouse_target_changed(WebKitWebView *view, WebKitHitTestResult *hitTestResult,
 static void
 on_run_file_chooser(WebKitWebView *view, WebKitFileChooserRequest *request)
 {
-    CogWlPlatform *platform = (CogWlPlatform *) cog_platform_get();
-    CogWlViewport *viewport = COG_WL_VIEWPORT(platform->viewport);
+    g_autoptr(CogWlViewport) viewport = COG_WL_VIEWPORT(cog_view_get_viewport((CogView *) view));
+    if (!viewport)
+        return;
 
     g_autoptr(XdpParent) xdp_parent = NULL;
     if (viewport->window.xdp_parent_wl_data.zxdg_exporter && viewport->window.xdp_parent_wl_data.wl_surface) {

--- a/platform/wayland/cog-viewport-wl.c
+++ b/platform/wayland/cog-viewport-wl.c
@@ -19,6 +19,7 @@
 G_DEFINE_DYNAMIC_TYPE(CogWlViewport, cog_wl_viewport, COG_TYPE_VIEWPORT)
 
 static void cog_wl_viewport_dispose(GObject *);
+static void cog_wl_viewport_on_add(CogWlViewport *, CogView *);
 static void destroy_window(CogWlViewport *);
 static void noop();
 
@@ -201,6 +202,8 @@ cog_wl_viewport_init(CogWlViewport *viewport)
 
     viewport->window.width_before_fullscreen = viewport->window.width;
     viewport->window.height_before_fullscreen = viewport->window.height;
+
+    g_signal_connect(COG_VIEWPORT(viewport), "add", G_CALLBACK(cog_wl_viewport_on_add), NULL);
 }
 
 /*
@@ -380,6 +383,12 @@ cog_wl_viewport_exit_fullscreen(CogWlViewport *viewport)
     }
     window->was_fullscreen_requested_from_dom = false;
 #endif
+}
+
+static void
+cog_wl_viewport_on_add(CogWlViewport *viewport G_GNUC_UNUSED, CogView *view)
+{
+    cog_wl_view_resize((CogWlView *) view);
 }
 
 void


### PR DESCRIPTION
Added a convenient reference to make explicit an **bidirectional the relationship between the CogViewport and the CogView**. This makes explicit the relation of membership of the a View respect the Viewport and breaks up the assumption of 'just one viewport in use' in the Platform. 

Also the WL plugin start to use the `cog_view_get_viewport()` to get the View's Viewport. This allows to use the CogViewport assigned to the CogView instead of the global CogViewport assigned to the Platform. 