### PR TITLE
wl: Change cog_wl_platform_popup_* API

### DIFF
--- a/platform/wayland/cog-platform-wl.c
+++ b/platform/wayland/cog-platform-wl.c
@@ -350,11 +350,11 @@ pointer_on_button(void              *data,
             cog_popup_menu_handle_event(
                 popup->popup_menu, !!state ? COG_POPUP_MENU_EVENT_STATE_PRESSED : COG_POPUP_MENU_EVENT_STATE_RELEASED,
                 event.x, event.y);
-            cog_wl_platform_popup_update(platform);
+            cog_wl_platform_popup_update();
             return;
         } else {
             if (!!state)
-                cog_wl_platform_popup_destroy(platform);
+                cog_wl_platform_popup_destroy();
         }
     }
 
@@ -752,10 +752,10 @@ touch_on_down(void              *data,
         if (seat->touch.surface == popup->wl_surface) {
             cog_popup_menu_handle_event(popup->popup_menu, COG_POPUP_MENU_EVENT_STATE_PRESSED, raw_event.x,
                                         raw_event.y);
-            cog_wl_platform_popup_update(platform);
+            cog_wl_platform_popup_update();
             return;
         } else
-            cog_wl_platform_popup_destroy(platform);
+            cog_wl_platform_popup_destroy();
     }
 
     struct wpe_input_touch_event event = {seat->touch.points, 10, raw_event.type, raw_event.id, raw_event.time};
@@ -797,7 +797,7 @@ touch_on_up(void *data, struct wl_touch *touch, uint32_t serial, uint32_t time, 
         if (target_surface == popup->wl_surface) {
             cog_popup_menu_handle_event(popup->popup_menu, COG_POPUP_MENU_EVENT_STATE_RELEASED, raw_event.x,
                                         raw_event.y);
-            cog_wl_platform_popup_update(platform);
+            cog_wl_platform_popup_update();
 
             memset(&seat->touch.points[id], 0x00, sizeof(struct wpe_input_touch_event_raw));
             return;
@@ -1351,7 +1351,7 @@ cog_wl_platform_finalize(GObject *object)
 
     cog_wl_text_input_clear(platform);
     if (platform->popup)
-        cog_wl_platform_popup_destroy(platform);
+        cog_wl_platform_popup_destroy();
     clear_egl(platform->display);
     clear_wayland(platform);
 
@@ -1373,24 +1373,29 @@ cog_wl_platform_create_im_context(CogPlatform *platform)
 }
 
 void
-cog_wl_platform_popup_create(CogWlPlatform *platform, WebKitOptionMenu *option_menu)
+cog_wl_platform_popup_create(CogWlViewport *viewport, WebKitOptionMenu *option_menu)
 {
+    CogWlPlatform *platform = (CogWlPlatform *) cog_platform_get();
     g_assert(!platform->popup);
 
-    CogWlPopup *popup = cog_wl_popup_create(platform, option_menu);
+    CogWlPopup *popup = cog_wl_popup_create(viewport, option_menu);
     platform->popup = popup;
 }
 
 void
-cog_wl_platform_popup_destroy(CogWlPlatform *platform)
+cog_wl_platform_popup_destroy(void)
 {
+    CogWlPlatform *platform = (CogWlPlatform *) cog_platform_get();
+
     g_assert(platform->popup);
     g_clear_pointer(&platform->popup, cog_wl_popup_destroy);
 }
 
 void
-cog_wl_platform_popup_update(CogWlPlatform *platform)
+cog_wl_platform_popup_update(void)
 {
+    CogWlPlatform *platform = (CogWlPlatform *) cog_platform_get();
+
     g_assert(platform->popup);
     cog_wl_popup_update(platform->popup);
 }

--- a/platform/wayland/cog-platform-wl.h
+++ b/platform/wayland/cog-platform-wl.h
@@ -46,8 +46,8 @@ struct _CogWlPlatform {
  *
  * Returns: (void)
  */
-void cog_wl_platform_popup_create(CogWlPlatform *, WebKitOptionMenu *);
-void cog_wl_platform_popup_destroy(CogWlPlatform *);
-void cog_wl_platform_popup_update(CogWlPlatform *);
+void cog_wl_platform_popup_create(CogWlViewport *, WebKitOptionMenu *);
+void cog_wl_platform_popup_destroy(void);
+void cog_wl_platform_popup_update(void);
 
 G_END_DECLS

--- a/platform/wayland/cog-utils-wl.c
+++ b/platform/wayland/cog-utils-wl.c
@@ -274,10 +274,10 @@ xdg_surface_on_configure(void *data, struct xdg_surface *surface, uint32_t seria
 }
 
 CogWlPopup *
-cog_wl_popup_create(CogWlPlatform *platform, WebKitOptionMenu *option_menu)
+cog_wl_popup_create(CogWlViewport *viewport, WebKitOptionMenu *option_menu)
 {
+    CogWlPlatform *platform = (CogWlPlatform *) cog_platform_get();
     CogWlDisplay  *display = platform->display;
-    CogWlViewport *viewport = COG_WL_VIEWPORT(platform->viewport);
 
     CogWlPopup *popup = g_slice_new0(CogWlPopup);
     g_debug("%s: Create @ %p", G_STRFUNC, popup);

--- a/platform/wayland/cog-utils-wl.h
+++ b/platform/wayland/cog-utils-wl.h
@@ -51,6 +51,7 @@ typedef struct _CogWlWindow   CogWlWindow;
 typedef struct _CogWlXkb      CogWlXkb;
 
 typedef struct _CogWlPlatform CogWlPlatform;
+typedef struct _CogWlViewport CogWlViewport;
 
 struct _CogWlAxis {
     bool       has_delta;
@@ -299,7 +300,7 @@ CogWlDisplay *cog_wl_display_create(const char *name, GError **error);
 void          cog_wl_display_destroy(CogWlDisplay *self);
 CogWlOutput  *cog_wl_display_find_output(CogWlDisplay *, struct wl_output *);
 
-CogWlPopup *cog_wl_popup_create(CogWlPlatform *, WebKitOptionMenu *);
+CogWlPopup *cog_wl_popup_create(CogWlViewport *, WebKitOptionMenu *);
 void        cog_wl_popup_destroy(CogWlPopup *);
 void        cog_wl_popup_display(CogWlPopup *);
 void        cog_wl_popup_update(CogWlPopup *);

--- a/platform/wayland/cog-view-wl.c
+++ b/platform/wayland/cog-view-wl.c
@@ -522,8 +522,11 @@ on_run_file_chooser(WebKitWebView *view, WebKitFileChooserRequest *request)
 static void
 on_show_option_menu(WebKitWebView *view, WebKitOptionMenu *menu, WebKitRectangle *rectangle, gpointer *data)
 {
-    CogWlPlatform *platform = (CogWlPlatform *) cog_platform_get();
-    cog_wl_platform_popup_create(platform, g_object_ref(menu));
+    g_autoptr(CogWlViewport) viewport = COG_WL_VIEWPORT(cog_view_get_viewport((CogView *) view));
+    if (!viewport)
+        return;
+
+    cog_wl_platform_popup_create(viewport, g_object_ref(menu));
 }
 
 static void


### PR DESCRIPTION
Change the `cog_wl_platform_popup_create()` signature. It receives the viewport as it needs the information from the active viewport to get the wl_surface.

The viewport used by ` on_show_option_menu()` will be the one associated to the View.