### PR TITLE
Add CogView::cog_view_[set|is]_visible() accessors

### DIFF
--- a/core/cog-view.c
+++ b/core/cog-view.c
@@ -454,3 +454,23 @@ cog_view_get_viewport(CogView *self)
     g_return_val_if_fail(COG_IS_VIEW(self), NULL);
     return g_weak_ref_get(&((CogViewPrivate *) cog_view_get_instance_private(self))->viewport);
 }
+
+/**
+ * cog_view_is_visible:
+ * @self: A view.
+ *
+ * Gets whether the view is visible in a viewport.
+ *
+ * Returns: True if the view is visible in its viewport and false in any
+ * other case.
+ *
+ * Since: 0.20
+ */
+gboolean
+cog_view_is_visible(CogView *self)
+{
+    g_return_val_if_fail(COG_IS_VIEW(self), false);
+
+    g_autoptr(CogViewport) viewport = cog_view_get_viewport(self);
+    return viewport && self == cog_viewport_get_visible_view(viewport);
+}

--- a/core/cog-view.c
+++ b/core/cog-view.c
@@ -474,3 +474,28 @@ cog_view_is_visible(CogView *self)
     g_autoptr(CogViewport) viewport = cog_view_get_viewport(self);
     return viewport && self == cog_viewport_get_visible_view(viewport);
 }
+
+/**
+ * cog_view_set_visible:
+ * @self: A view.
+ *
+ * Set the view as visible in its viewport.
+ *
+ * Returns: %TRUE if the view was set as visible, or %FALSE if the view
+ *    does is not attached to a viewport.
+ *
+ * Since: 0.20
+ */
+gboolean
+cog_view_set_visible(CogView *self)
+{
+    g_assert(COG_IS_VIEW(self));
+
+    g_autoptr(CogViewport) viewport = cog_view_get_viewport(self);
+    if (!viewport)
+        return FALSE;
+
+    cog_viewport_set_visible_view(viewport, self);
+
+    return TRUE;
+}

--- a/core/cog-view.h
+++ b/core/cog-view.h
@@ -58,4 +58,7 @@ CogViewport *cog_view_get_viewport(CogView *self);
 COG_API
 gboolean cog_view_is_visible(CogView *self);
 
+COG_API
+gboolean cog_view_set_visible(CogView *self);
+
 G_END_DECLS

--- a/core/cog-view.h
+++ b/core/cog-view.h
@@ -55,4 +55,7 @@ gboolean cog_view_get_use_key_bindings(CogView *self);
 COG_API
 CogViewport *cog_view_get_viewport(CogView *self);
 
+COG_API
+gboolean cog_view_is_visible(CogView *self);
+
 G_END_DECLS


### PR DESCRIPTION
Add convenient accessors to the "visible" property the to the **CogView** external API:

* `CogView::cog_view_set_visible()` sets the view as the one visible inside of the viewport where the view is attached.
* `CogView::cog_view_is_visible()` gets if the view is visible inside of the viewport where the view is attached.