### PR TITLE
wl: Check wl_surface before use it

### DIFF
--- a/platform/wayland/cog-platform-wl.c
+++ b/platform/wayland/cog-platform-wl.c
@@ -240,6 +240,10 @@ pointer_on_enter(void              *data,
                  wl_fixed_t         fixed_x,
                  wl_fixed_t         fixed_y)
 {
+    // We might be reading pending events after destroying the surface.
+    if (!surface)
+        return;
+
     CogWlSeat *seat = data;
 
     if (pointer != seat->pointer_obj) {
@@ -509,6 +513,10 @@ keyboard_on_enter(void               *data,
                   struct wl_surface  *surface,
                   struct wl_array    *keys)
 {
+    // We might be reading pending events after destroying the surface.
+    if (!surface)
+        return;
+
     CogWlSeat *seat = data;
 
     if (wl_keyboard != seat->keyboard_obj) {
@@ -717,6 +725,10 @@ touch_on_down(void              *data,
               wl_fixed_t         x,
               wl_fixed_t         y)
 {
+    // We might be reading pending events after destroying the surface.
+    if (!surface)
+        return;
+
     CogWlSeat    *seat = data;
     CogWlDisplay *display = seat->display;
 


### PR DESCRIPTION
... on pointer_on_enter, touch_on_down and keyboard_on_enter.

It can be possible a situation during the destruction of a CogView where the UI-process were receiving and trying to process an input event for a non existant wl_surface.

Under this scenario, the wl_surface associated could be not longer accesible so the input handler will receive a null-pointer (0x0).

Backtrace:

```
0  0xb9999999 in wl_proxy_get_user_data (proxy=proxy@entry=0x0)
    at ../wayland/src/wayland-client.c:2135

    at /usr/include/wayland-client-protocol.h:3393
    fixed_x=0, fixed_y=5, surface=0x0 <<<< , data=0xa9999999)
```