### PR TITLE
wl: Change IM context functions signature

### DIFF
--- a/core/cog-platform.c
+++ b/core/cog-platform.c
@@ -193,13 +193,14 @@ cog_platform_init_web_view (CogPlatform   *platform,
 }
 
 WebKitInputMethodContext *
-cog_platform_create_im_context(CogPlatform *platform)
+cog_platform_create_im_context(CogViewport *viewport)
 {
+    CogPlatform *platform = cog_platform_get();
     g_return_val_if_fail(COG_IS_PLATFORM(platform), NULL);
 
     CogPlatformClass *klass = COG_PLATFORM_GET_CLASS(platform);
     if (klass->create_im_context)
-        return klass->create_im_context(platform);
+        return klass->create_im_context(viewport);
 
     return NULL;
 }

--- a/core/cog-platform.h
+++ b/core/cog-platform.h
@@ -20,6 +20,8 @@ G_BEGIN_DECLS
 
 #define COG_PLATFORM_ERROR (cog_platform_error_quark())
 
+typedef struct _CogViewport CogViewport;
+
 typedef enum {
     COG_PLATFORM_ERROR_NO_MODULE,
 } CogPlatformError;
@@ -47,7 +49,7 @@ struct _CogPlatformClass {
     gboolean (*setup)(CogPlatform *, CogShell *shell, const char *params, GError **);
     WebKitWebViewBackend *(*get_view_backend)(CogPlatform *, WebKitWebView *related_view, GError **);
     void (*init_web_view)(CogPlatform *, WebKitWebView *);
-    WebKitInputMethodContext *(*create_im_context)(CogPlatform *);
+    WebKitInputMethodContext *(*create_im_context)(CogViewport *);
 
     GType (*get_view_type)(void);
     GType (*get_viewport_type)(void);
@@ -64,11 +66,10 @@ WebKitWebViewBackend     *cog_platform_get_view_backend  (CogPlatform   *platfor
                                                           GError       **error);
 
 COG_API
-void                      cog_platform_init_web_view     (CogPlatform   *platform,
-                                                          WebKitWebView *view);
+void cog_platform_init_web_view(CogPlatform *platform, WebKitWebView *view);
 
 COG_API
-WebKitInputMethodContext *cog_platform_create_im_context (CogPlatform   *platform);
+WebKitInputMethodContext *cog_platform_create_im_context(CogViewport *viewport);
 
 G_END_DECLS
 

--- a/core/cog-viewport.c
+++ b/core/cog-viewport.c
@@ -267,6 +267,9 @@ cog_viewport_add(CogViewport *self, CogView *view)
     struct wpe_view_backend *backend = cog_view_get_backend(view);
     wpe_view_backend_add_activity_state(backend, wpe_view_activity_state_in_window);
 
+    g_autoptr(WebKitInputMethodContext) im_context = cog_platform_create_im_context(self);
+    webkit_web_view_set_input_method_context(WEBKIT_WEB_VIEW(view), im_context);
+
     if (!priv->visible_view) {
         g_debug("%s<%p>: adding view %p as visible", G_STRFUNC, self, view);
         cog_viewport_set_visible_view_internal(self, priv, view);
@@ -306,6 +309,8 @@ cog_viewport_remove(CogViewport *self, CogView *view)
         g_warning("Attempted to remove view %p, which was not in viewport %p.", view, self);
         return;
     }
+
+    webkit_web_view_set_input_method_context(WEBKIT_WEB_VIEW(view), NULL);
 
     cog_view_set_viewport(view, NULL);
 

--- a/launcher/cog-launcher.c
+++ b/launcher/cog-launcher.c
@@ -273,8 +273,6 @@ cog_launcher_create_view(CogLauncher *self, CogShell *shell)
     g_signal_connect(web_view, "create", G_CALLBACK(on_web_view_create), NULL);
 
     cog_platform_init_web_view(platform, web_view);
-    g_autoptr(WebKitInputMethodContext) im_context = cog_platform_create_im_context(platform);
-    webkit_web_view_set_input_method_context(web_view, im_context);
 
     if (s_options.background_color != NULL) {
         WebKitColor color;

--- a/platform/wayland/cog-platform-wl.c
+++ b/platform/wayland/cog-platform-wl.c
@@ -1349,7 +1349,7 @@ cog_wl_platform_finalize(GObject *object)
 {
     CogWlPlatform *platform = COG_WL_PLATFORM(object);
 
-    cog_wl_text_input_clear(platform);
+    cog_wl_text_input_clear();
     if (platform->popup)
         cog_wl_platform_popup_destroy();
     clear_egl(platform->display);
@@ -1359,12 +1359,14 @@ cog_wl_platform_finalize(GObject *object)
 }
 
 static WebKitInputMethodContext *
-cog_wl_platform_create_im_context(CogPlatform *platform)
+cog_wl_platform_create_im_context(CogViewport *viewport)
 {
+    CogWlPlatform *platform = (CogWlPlatform *) cog_platform_get();
     g_assert(COG_WL_PLATFORM(platform)->display->seat_default);
-    cog_wl_text_input_set(COG_WL_PLATFORM(platform), COG_WL_PLATFORM(platform)->display->seat_default);
-    CogWlDisplay *display = COG_WL_PLATFORM(platform)->display;
 
+    cog_wl_text_input_set(COG_WL_VIEWPORT(viewport), COG_WL_PLATFORM(platform)->display->seat_default);
+
+    CogWlDisplay *display = COG_WL_PLATFORM(platform)->display;
     if (display->text_input_manager)
         return cog_im_context_wl_new();
     if (display->text_input_manager_v1)

--- a/platform/wayland/cog-utils-wl.c
+++ b/platform/wayland/cog-utils-wl.c
@@ -481,8 +481,10 @@ cog_wl_seat_set_cursor(CogWlSeat *seat, enum cursor_type type)
 #endif /* COG_USE_WAYLAND_CURSOR */
 
 void
-cog_wl_text_input_clear(CogWlPlatform *platform)
+cog_wl_text_input_clear(void)
 {
+    CogWlPlatform *platform = (CogWlPlatform *) cog_platform_get();
+
     CogWlDisplay *display = platform->display;
     cog_im_context_wl_set_text_input(NULL);
     g_clear_pointer(&display->text_input_manager, zwp_text_input_manager_v3_destroy);
@@ -491,10 +493,11 @@ cog_wl_text_input_clear(CogWlPlatform *platform)
 }
 
 void
-cog_wl_text_input_set(CogWlPlatform *platform, CogWlSeat *seat)
+cog_wl_text_input_set(CogWlViewport *viewport, CogWlSeat *seat)
 {
+    CogWlPlatform *platform = (CogWlPlatform *) cog_platform_get();
     CogWlDisplay  *display = platform->display;
-    CogWlViewport *viewport = COG_WL_VIEWPORT(platform->viewport);
+
     if (display->text_input_manager != NULL) {
         struct zwp_text_input_v3 *text_input =
             zwp_text_input_manager_v3_get_text_input(display->text_input_manager, seat->seat);

--- a/platform/wayland/cog-utils-wl.h
+++ b/platform/wayland/cog-utils-wl.h
@@ -50,7 +50,6 @@ typedef struct _CogWlTouch    CogWlTouch;
 typedef struct _CogWlWindow   CogWlWindow;
 typedef struct _CogWlXkb      CogWlXkb;
 
-typedef struct _CogWlPlatform CogWlPlatform;
 typedef struct _CogWlViewport CogWlViewport;
 
 struct _CogWlAxis {
@@ -310,7 +309,7 @@ void       cog_wl_seat_destroy(CogWlSeat *);
 void       cog_wl_seat_set_cursor(CogWlSeat *, enum cursor_type);
 uint32_t   cog_wl_seat_get_serial(CogWlSeat *);
 
-void cog_wl_text_input_clear(CogWlPlatform *);
-void cog_wl_text_input_set(CogWlPlatform *, CogWlSeat *);
+void cog_wl_text_input_clear(void);
+void cog_wl_text_input_set(CogWlViewport *, CogWlSeat *);
 
 G_END_DECLS


### PR DESCRIPTION
The input method context is now defined and assigned to the View once this is added to a **Viewport**, in `cog_viewport_add()`. It is not possible before because we need to have access to the `wl_surface` associated to the Viewport->Window for configuring the IM context.