### PR TITLE
core: Make the CogView.viewport property only readable

### DIFF
--- a/core/cog-view.c
+++ b/core/cog-view.c
@@ -125,8 +125,8 @@ cog_view_class_init(CogViewClass *klass)
      *
      * Since: 0.20
      */
-    s_properties[PROP_VIEWPORT] = g_param_spec_object("viewport", NULL, NULL, G_TYPE_OBJECT,
-                                                      G_PARAM_READABLE | G_PARAM_CONSTRUCT | G_PARAM_STATIC_STRINGS);
+    s_properties[PROP_VIEWPORT] =
+        g_param_spec_object("viewport", NULL, NULL, G_TYPE_OBJECT, G_PARAM_READABLE | G_PARAM_STATIC_STRINGS);
 
     g_object_class_install_properties(object_class, N_PROPERTIES, s_properties);
 }


### PR DESCRIPTION
Remove the `G_PARAM_CONSTRUCT` flag from the `CogView.viewport` property, because it it supposed to be only readable and it the viewport is set in a separate step separate from view construction by using `cog_viewport_add()`. It would be technically possible to allow setting the viewport at construction time, but that would need some additional support code it would use `G_PARAM_CONSTRUCT_ONLY`. For now it is easier to remove the flag.