### PR TITLE
wl: Fix the COG_PLATFORM_WL_VIEW_FULLSCREEN not works

### DIFF
--- a/platform/wayland/cog-viewport-wl.c
+++ b/platform/wayland/cog-viewport-wl.c
@@ -328,11 +328,6 @@ cog_wl_viewport_create_window(CogWlViewport *viewport, GError **error)
 static void
 cog_wl_viewport_enter_fullscreen(CogWlViewport *viewport)
 {
-    if (!cog_viewport_get_n_views(COG_VIEWPORT(viewport))) {
-        g_debug("%s: No views in viewport, will not fullscreen.", G_STRFUNC);
-        return;
-    }
-
     CogWlPlatform *platform = (CogWlPlatform *) cog_platform_get();
     CogWlDisplay  *display = platform->display;
     CogWlWindow   *window = &viewport->window;
@@ -340,7 +335,6 @@ cog_wl_viewport_enter_fullscreen(CogWlViewport *viewport)
     // Resize window to the size of the screen.
     window->width_before_fullscreen = window->width;
     window->height_before_fullscreen = window->height;
-    cog_wl_viewport_resize_to_largest_output(viewport);
 
     if (display->xdg_shell) {
         xdg_toplevel_set_fullscreen(window->xdg_toplevel, NULL);
@@ -350,8 +344,15 @@ cog_wl_viewport_enter_fullscreen(CogWlViewport *viewport)
         g_assert_not_reached();
     }
 
+    cog_wl_viewport_resize_to_largest_output(viewport);
+
+    if (!cog_viewport_get_n_views(COG_VIEWPORT(viewport))) {
+        g_debug("%s: No views in viewport, will not fullscreen.", G_STRFUNC);
+        return;
+    }
+
     // XXX: Do we need to set all views as fullscreened?
-    // Wait until a new exported image is reveived. See cog_wl_view_enter_fullscreen().
+    // Wait until a new exported image is received. See cog_wl_view_enter_fullscreen().
     cog_wl_view_enter_fullscreen(COG_WL_VIEW(cog_viewport_get_visible_view(COG_VIEWPORT(viewport))));
 }
 


### PR DESCRIPTION
The `COG_PLATFORM_WL_VIEW_FULLSCREEN` is evaluated during inside of the `cog_wl_viewport_create_window()`. At that point there is not yet a view created in the viewport associated to the window.

Allow the shells to set the fullscreen mode even if there is not a view available in the viewport. This will make the new views being created in fullscreen mode. This applies also to the one created during the initialization.