### PR TITLE
x11: Support xcb-keysyms as fallback when XKB support not available

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+/subprojects/packagecache/
+/subprojects/xcb-util-keysyms-0.4.1/

--- a/meson.build
+++ b/meson.build
@@ -1,5 +1,5 @@
 project('cog', 'c',
-    meson_version: '>=0.53.2',
+    meson_version: '>=0.55',
     default_options: [
         'buildtype=debugoptimized',
         'b_ndebug=if-release',

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -52,6 +52,15 @@ option(
     description: 'Build content-protection support in the Wayland platform plug-in'
 )
 
+# X11 platform-specifig features
+option(
+    'x11_keyboard',
+    type: 'array',
+    value: ['xkb'],
+    choices: ['xkb', 'xcb-keysyms'],
+    description: 'Keyboard handler (xkb recommended)',
+)
+
 # Additional cog/cogctl options
 option(
     'cog_appid',

--- a/platform/x11/cog-platform-x11.c
+++ b/platform/x11/cog-platform-x11.c
@@ -20,7 +20,11 @@
 #include <xcb/xcb_cursor.h>
 
 #ifdef COG_X11_USE_XCB_KEYSYMS
-#    include <xcb/xcb_keysyms.h>
+#    if __has_include(<xcb/xcb_keysyms.h>)
+#        include <xcb/xcb_keysyms.h>
+#    else
+#        include <xcb_keysyms.h>
+#    endif
 #endif /* COG_X11_USE_XCB_KEYSYMS */
 
 #ifdef COG_X11_USE_XKB

--- a/platform/x11/meson.build
+++ b/platform/x11/meson.build
@@ -3,19 +3,30 @@ if libportal_dep.found()
     x11_platform_sources += ['cog-xdp-parent-x11.c']
 endif
 
+x11_platform_c_args = platform_c_args + [
+    '-DG_LOG_DOMAIN="Cog-X11"',
+]
+x11_platform_dependencies = [
+    wpebackend_fdo_dep,
+    cogplatformcommon_dep,
+    dependency('egl'),
+    dependency('xcb'),
+    dependency('xkbcommon-x11'),
+    dependency('x11-xcb'),
+    dependency('xcb-cursor'),
+]
+
+xcb_keysyms_dep = dependency('xcb-keysyms', required: false)
+if xcb_keysyms_dep.found()
+    x11_platform_dependencies += [xcb_keysyms_dep]
+    x11_platform_c_args += ['-DCOG_X11_USE_XCB_KEYSYMS']
+endif
+
 x11_platform_plugin = shared_module('cogplatform-x11',
     'cog-platform-x11.c',
     x11_platform_sources,
-    c_args: platform_c_args + ['-DG_LOG_DOMAIN="Cog-X11"'],
-    dependencies: [
-        wpebackend_fdo_dep,
-        cogplatformcommon_dep,
-        dependency('egl'),
-        dependency('xcb'),
-        dependency('xkbcommon-x11'),
-        dependency('x11-xcb'),
-        dependency('xcb-cursor'),
-    ],
+    c_args: x11_platform_c_args,
+    dependencies: x11_platform_dependencies,
     gnu_symbol_visibility: 'hidden',
     install_dir: plugin_path,
     install: true,

--- a/platform/x11/meson.build
+++ b/platform/x11/meson.build
@@ -16,11 +16,20 @@ x11_platform_dependencies = [
     dependency('xcb-cursor'),
 ]
 
-xcb_keysyms_dep = dependency('xcb-keysyms', required: false)
-if xcb_keysyms_dep.found()
-    x11_platform_dependencies += [xcb_keysyms_dep]
-    x11_platform_c_args += ['-DCOG_X11_USE_XCB_KEYSYMS']
+x11_platform_keyboard = get_option('x11_keyboard')
+if x11_platform_keyboard.length() == 0
+    warning('No X11 keyboard support chosen, keyboard input will NOT work')
 endif
+
+x11_platform_keyboard_dep_names = {
+    'xkb': 'xkbcommon-x11',
+    'xcb-keysyms': 'xcb-keysyms',
+}
+
+foreach item : x11_platform_keyboard
+    x11_platform_dependencies += [dependency(x11_platform_keyboard_dep_names[item])]
+    x11_platform_c_args += ['-DCOG_X11_USE_@0@=1'.format(item.underscorify().to_upper())]
+endforeach
 
 x11_platform_plugin = shared_module('cogplatform-x11',
     'cog-platform-x11.c',

--- a/subprojects/packagefiles/xcb-util-keysyms-0.4.1/meson.build
+++ b/subprojects/packagefiles/xcb-util-keysyms-0.4.1/meson.build
@@ -1,0 +1,24 @@
+project('xcb-util-keysyms', 'c',
+  version: '0.4.1',
+  default_options: [
+  ],
+)
+
+xcb_dep = dependency('xcb', version: '>=1.4')
+xcb_util_keysyms_dependencies = [xcb_dep, dependency('xproto', version: '>=7.0.8')]
+
+xcb_proto_version = xcb_dep.get_variable('xcbproto_version')
+assert(xcb_proto_version.version_compare('>=1.6'),
+  'libxcb was compiled against xcb-proto @0@, it needs to be compiled against 1.6 or newer'.format(xcb_proto_version))
+
+xcb_util_keysyms_lib = static_library('xcb-util-keysyms',
+  'keysyms/keysyms.c',
+  dependencies: xcb_util_keysyms_dependencies,
+  pic: true,
+)
+
+xcb_util_keysyms_dep = declare_dependency(
+  link_with: xcb_util_keysyms_lib,
+  dependencies: xcb_util_keysyms_dependencies,
+  include_directories: include_directories('keysyms'),
+)

--- a/subprojects/xcb-keysyms.wrap
+++ b/subprojects/xcb-keysyms.wrap
@@ -1,0 +1,9 @@
+[wrap-file]
+directory = xcb-util-keysyms-0.4.1
+source_url = https://xcb.freedesktop.org/dist/xcb-util-keysyms-0.4.1.tar.xz
+source_filename = xcb-util-keysyms-0.4.1.tar.xz
+source_hash = 7c260a5294412aed429df1da2f8afd3bd07b7cba3fec772fba15a613a6d5c638
+patch_directory = xcb-util-keysyms-0.4.1
+
+[provide]
+xcb-keysyms = xcb_util_keysyms_dep


### PR DESCRIPTION
These patch set pulls the parts of the code from #303 which implement usage of `xcb-keysyms` to handle keyboard input event translation, adding a few niceties on top:

- Allow passing `-Dx11_keyboard=` to Meson to choose which methods are supported. It is possible to use `xkb`, `xcb-keysyms`, or both. Passing an empty list disables keyboard input to web views.
- If support for both XKB and `xcb-keysyms`, then XKB will be preferred, and if not available then `xcb-keysyms` is used as fallback.
- Lastly, add a Wrap subproject definition that teaches Meson how to download a tarball and build a static `xcb-keysyms` library when not available. The library is a single `.c` file so it does not add much weight to the X11 platform plug-in, and we make it less likely that people may end up without keyboard input support.

Finally, I want to thank @agordon who was the person that originally wrote the code 🙏🏼 