### PR TITLE
REGRESSION(47dee03): Broke DRM plugin on RPi4 (#614)

### DIFF
--- a/platform/drm/cog-platform-drm.c
+++ b/platform/drm/cog-platform-drm.c
@@ -358,7 +358,7 @@ find_crtc_for_encoder(const drmModeRes *resources, const drmModeEncoder *encoder
     for (int i = 0; i < resources->count_crtcs; i++) {
         const uint32_t crtc_mask = 1 << i;
         const uint32_t crtc_id = resources->crtcs[i];
-        if (encoder->possible_crtcs & crtc_mask) {
+        if (encoder->possible_crtcs & crtc_mask && encoder->crtc_id == crtc_id) {
             return crtc_id;
         }
     }


### PR DESCRIPTION
`find_crtc_for_encoder()` should not only check the bitmask but also the ID of the CRTC.

See #614 for a detailed description of the issue that this PR fixes.