### PR TITLE
examples: Fix program names and call cog_init()

### DIFF
--- a/examples/viewport.c
+++ b/examples/viewport.c
@@ -33,7 +33,8 @@ main(int argc, char *argv[])
         return EXIT_FAILURE;
     }
 
-    g_set_prgname("view-stack");
+    g_set_prgname("viewport");
+    cog_init(NULL, NULL);
 
     g_autoptr(CogShell) shell = cog_shell_new(g_get_prgname(), FALSE);
     g_autoptr(GError)   error = NULL;

--- a/examples/viewports.c
+++ b/examples/viewports.c
@@ -33,7 +33,8 @@ main(int argc, char *argv[])
         return EXIT_FAILURE;
     }
 
-    g_set_prgname("view-stacks");
+    g_set_prgname("viewports");
+    cog_init(NULL, NULL);
 
     g_autoptr(CogShell) shell = cog_shell_new(NULL, FALSE);
     g_autoptr(GError)   error = NULL;


### PR DESCRIPTION
Add calls to `cog_init()` to make the examples honor the `COG_PLATFORM_NAME`, `COG_PLATFORM_PARAMS`, and `COG_MODULEDIR` environment variables properly. While at it, fix their calls to `g_set_prgname()`.