### PR TITLE
core, wl, headless: New virtual functions in CogPlatform to track live viewport instances

### DIFF
--- a/core/cog-platform-private.h
+++ b/core/cog-platform-private.h
@@ -1,0 +1,19 @@
+/*
+ * cog-platform-private.h
+ * Copyright (C) 2023 Igalia S.L.
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#pragma once
+
+#include "cog-platform.h"
+
+G_BEGIN_DECLS
+
+typedef struct _CogViewport CogViewport;
+
+void cog_platform_notify_viewport_created(CogViewport *viewport);
+void cog_platform_notify_viewport_disposed(CogViewport *viewport);
+
+G_END_DECLS

--- a/core/cog-platform.h
+++ b/core/cog-platform.h
@@ -1,5 +1,6 @@
 /*
  * cog-platform.h
+ * Copyright (C) 2019-2023 Igalia S.L.
  * Copyright (C) 2018 Adrian Perez <aperez@igalia.com>
  * Copyright (C) 2018 Eduardo Lima <elima@igalia.com>
  *
@@ -53,6 +54,9 @@ struct _CogPlatformClass {
 
     GType (*get_view_type)(void);
     GType (*get_viewport_type)(void);
+
+    void (*viewport_created)(CogPlatform *self, CogViewport *viewport);
+    void (*viewport_disposed)(CogPlatform *self, CogViewport *viewport);
 };
 
 COG_API void         cog_init(const char *platform_name, const char *module_path);

--- a/core/cog-viewport.c
+++ b/core/cog-viewport.c
@@ -6,9 +6,8 @@
 
 #include "cog-viewport.h"
 
-#include "cog-platform.h"
+#include "cog-platform-private.h"
 #include "cog-view-private.h"
-#include "cog-view.h"
 
 /**
  * CogViewport:
@@ -161,6 +160,8 @@ cog_viewport_dispose(GObject *object)
     g_ptr_array_set_size(PRIV(object)->views, 0);
 
     G_OBJECT_CLASS(cog_viewport_parent_class)->dispose(object);
+
+    cog_platform_notify_viewport_disposed((CogViewport *) object);
 }
 
 static void
@@ -172,6 +173,14 @@ cog_viewport_finalize(GObject *object)
 }
 
 static void
+cog_viewport_constructed(GObject *object)
+{
+    G_OBJECT_CLASS(cog_viewport_parent_class)->constructed(object);
+
+    cog_platform_notify_viewport_created((CogViewport *) object);
+}
+
+static void
 cog_viewport_class_init(CogViewportClass *klass)
 {
     GObjectClass *object_class = G_OBJECT_CLASS(klass);
@@ -179,6 +188,7 @@ cog_viewport_class_init(CogViewportClass *klass)
     object_class->get_property = cog_viewport_get_property;
     object_class->dispose = cog_viewport_dispose;
     object_class->finalize = cog_viewport_finalize;
+    object_class->constructed = cog_viewport_constructed;
 
     /**
      * CogViewport::visible-view: (attributes org.gtk.Property.get=cog_viewport_get_visible_view org.gtk.Property.set=cog_viewport_set_visible_view) (setter set_visible_view) (getter get_visible_view):

--- a/platform/headless/cog-platform-headless.c
+++ b/platform/headless/cog-platform-headless.c
@@ -1,6 +1,6 @@
 /*
  * cog-platform-headless.c
- * Copyright (C) 2021 Igalia S.L
+ * Copyright (C) 2021, 2023 Igalia S.L
  *
  * SPDX-License-Identifier: MIT
  */
@@ -11,10 +11,15 @@
 #include <wpe/fdo.h>
 #include <wpe/unstable/fdo-shm.h>
 
-typedef struct {
+struct _CogHeadlessView {
+    CogView parent;
+
     bool                                    frame_ack_pending;
     struct wpe_view_backend_exportable_fdo *exportable;
-} CogHeadlessView;
+};
+
+G_DECLARE_FINAL_TYPE(CogHeadlessView, cog_headless_view, COG, HEADLESS_VIEW, CogView)
+G_DEFINE_DYNAMIC_TYPE(CogHeadlessView, cog_headless_view, COG_TYPE_VIEW)
 
 struct _CogHeadlessPlatformClass {
     CogPlatformClass parent_class;
@@ -26,8 +31,7 @@ struct _CogHeadlessPlatform {
     unsigned max_fps;
     unsigned tick_source;
 
-    /* TODO: Move elsewhere once multiple views are supported */
-    CogHeadlessView view;
+    GPtrArray *viewports; /* CogViewport */
 };
 
 G_DECLARE_FINAL_TYPE(CogHeadlessPlatform, cog_headless_platform, COG, HEADLESS_PLATFORM, CogPlatform)
@@ -46,25 +50,66 @@ static void on_export_shm_buffer(void* data, struct wpe_fdo_shm_exported_buffer*
     view->frame_ack_pending = true;
 }
 
-static gboolean
-on_cog_headless_platform_tick(CogHeadlessPlatform *self)
+static void
+on_cog_headless_view_backend_destroy(CogHeadlessView *self)
 {
-    CogHeadlessView *view = &self->view;
-    if (view->frame_ack_pending) {
-        view->frame_ack_pending = false;
-        wpe_view_backend_exportable_fdo_dispatch_frame_complete(view->exportable);
-    }
-    return G_SOURCE_CONTINUE;
+    g_debug("%s: view %p, exportable %p", G_STRFUNC, self, self->exportable);
+    g_assert(self->exportable);
+    g_clear_pointer(&self->exportable, wpe_view_backend_exportable_fdo_destroy);
 }
 
-static void
-cog_headless_view_initialize(CogHeadlessView *self, CogHeadlessPlatform *platform)
+static WebKitWebViewBackend *
+cog_headless_view_create_backend(CogView *view)
 {
+    CogHeadlessView *self = COG_HEADLESS_VIEW(view);
+
     static const struct wpe_view_backend_exportable_fdo_client client = {
         .export_shm_buffer = on_export_shm_buffer,
     };
 
     self->exportable = wpe_view_backend_exportable_fdo_create(&client, self, 800, 600);
+
+    struct wpe_view_backend *view_backend = wpe_view_backend_exportable_fdo_get_view_backend(self->exportable);
+    return webkit_web_view_backend_new(view_backend, (GDestroyNotify) on_cog_headless_view_backend_destroy, self);
+}
+
+static void
+cog_headless_view_class_init(CogHeadlessViewClass *klass)
+{
+    CogViewClass *view_class = COG_VIEW_CLASS(klass);
+    view_class->create_backend = cog_headless_view_create_backend;
+}
+
+static void
+cog_headless_view_class_finalize(CogHeadlessViewClass *klass G_GNUC_UNUSED)
+{
+}
+
+static void
+cog_headless_view_init(CogHeadlessView *self G_GNUC_UNUSED)
+{
+}
+
+static void
+cog_headless_view_tick(CogHeadlessView *view)
+{
+    if (view->frame_ack_pending) {
+        view->frame_ack_pending = false;
+        wpe_view_backend_exportable_fdo_dispatch_frame_complete(view->exportable);
+    }
+}
+
+static void
+cog_headless_viewport_tick(CogViewport *viewport)
+{
+    cog_viewport_foreach(viewport, (GFunc) cog_headless_view_tick, NULL);
+}
+
+static gboolean
+on_cog_headless_platform_tick(CogHeadlessPlatform *self)
+{
+    g_ptr_array_foreach(self->viewports, (GFunc) cog_headless_viewport_tick, NULL);
+    return G_SOURCE_CONTINUE;
 }
 
 static gboolean
@@ -84,7 +129,6 @@ cog_headless_platform_setup(CogPlatform* platform, CogShell* shell G_GNUC_UNUSED
     }
     g_debug("Maximum refresh rate: %u FPS", self->max_fps);
 
-    cog_headless_view_initialize(&self->view, self);
     self->tick_source = g_timeout_add(1000.0 / self->max_fps, G_SOURCE_FUNC(on_cog_headless_platform_tick), self);
     return TRUE;
 }
@@ -95,28 +139,31 @@ cog_headless_platform_finalize(GObject* object)
     CogHeadlessPlatform *self = COG_HEADLESS_PLATFORM(object);
 
     g_clear_handle_id(&self->tick_source, g_source_remove);
+    g_clear_pointer(&self->viewports, g_ptr_array_unref);
 
     G_OBJECT_CLASS(cog_headless_platform_parent_class)->finalize(object);
 }
 
 static void
-on_cog_headless_view_backend_destroy(CogHeadlessView *self)
-{
-    g_assert(self->exportable);
-    g_clear_pointer(&self->exportable, wpe_view_backend_exportable_fdo_destroy);
-}
-
-static WebKitWebViewBackend*
-cog_headless_platform_get_view_backend(CogPlatform* platform, WebKitWebView* related_view, GError** error)
+cog_headless_viewport_created(CogPlatform *platform, CogViewport *viewport)
 {
     CogHeadlessPlatform *self = COG_HEADLESS_PLATFORM(platform);
 
-    struct wpe_view_backend *view_backend = wpe_view_backend_exportable_fdo_get_view_backend(self->view.exportable);
-    WebKitWebViewBackend    *wk_view_backend =
-        webkit_web_view_backend_new(view_backend, (GDestroyNotify) on_cog_headless_view_backend_destroy, &self->view);
+    g_assert(!g_ptr_array_find(self->viewports, viewport, NULL));
+    g_ptr_array_add(self->viewports, viewport);
 
-    g_assert(wk_view_backend);
-    return wk_view_backend;
+    g_debug("%s: new viewport %p", G_STRFUNC, viewport);
+}
+
+static void
+cog_headless_viewport_disposed(CogPlatform *platform, CogViewport *viewport)
+{
+    CogHeadlessPlatform *self = COG_HEADLESS_PLATFORM(platform);
+
+    gboolean removed G_GNUC_UNUSED = g_ptr_array_remove_fast(self->viewports, viewport);
+    g_assert(removed);
+
+    g_debug("%s: removed viewport %p", G_STRFUNC, viewport);
 }
 
 static void
@@ -127,7 +174,9 @@ cog_headless_platform_class_init(CogHeadlessPlatformClass* klass)
 
     CogPlatformClass* platform_class = COG_PLATFORM_CLASS(klass);
     platform_class->setup = cog_headless_platform_setup;
-    platform_class->get_view_backend = cog_headless_platform_get_view_backend;
+    platform_class->get_view_type = cog_headless_view_get_type;
+    platform_class->viewport_created = cog_headless_viewport_created;
+    platform_class->viewport_disposed = cog_headless_viewport_disposed;
 }
 
 static void
@@ -138,6 +187,7 @@ cog_headless_platform_class_finalize(CogHeadlessPlatformClass* klass G_GNUC_UNUS
 static void
 cog_headless_platform_init(CogHeadlessPlatform* self)
 {
+    self->viewports = g_ptr_array_sized_new(3);
     self->max_fps = 30; /* Default value */
 }
 
@@ -146,6 +196,7 @@ g_io_cogplatform_headless_load(GIOModule* module)
 {
     GTypeModule* type_module = G_TYPE_MODULE(module);
     cog_headless_platform_register_type(type_module);
+    cog_headless_view_register_type(type_module);
 }
 
 G_MODULE_EXPORT void


### PR DESCRIPTION
Platform implementations may need (or want) to track all the `CogViewport` instances in use. Until now this was done by fetching the list of viewports from `CogShell`, but that assumed that a.) there is always a shell instantiated, and b.) there will ever be only one viewport. It is already possible _today_ to use multiple viewports (see `examples/viewports.c`) so the latter does not hold true. We want to also avoid using the shell from platform implementations so what this PR does is:

- Add two vfuncs `CogPlatform.viewport_created` and `CogPlatform.viewport_disposed`, and corresponding signals `CogPlatform::viewport-created` and `CogPlatform::viewport-disposed`. These are triggered from `CogViewport` during creation and disposal using private functions.
- Add multiple view support to the headless platform plug-in, using the above to track all views in all viewports.
- Change the Wayland platform plug-in to use the above to track viewports, instead of picking the viewport list from `CogShell`.

After this, the uses that remain of the shell in platform implementations are related to their configuration. Those uses will be addressed in a separa patch set. 

This is part of the work towards decoupling `CogShell` from `CogPlatform`, as per #634.
