### PR TITLE
clang-tidy: Add option to silence GLib macro warnings

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,3 @@
+---
+CheckOptions:
+    bugprone-sizeof-expression.WarnOnSizeOfPointerToAggregate: false


### PR DESCRIPTION
Add a (for now) very simple configuration for `clang-tidy` that silences warnings about `sizeof()` expressions from `g_clear_{object,pointer}` macros. The `clang-tidy` configuration file is also used by `clangd`, so this also avoids these false positive diagnostics when using it in an editor with LSP support.