### PR TITLE
core: Remove view and viewport handling from CogShell

### DIFF
--- a/core/cog-shell.c
+++ b/core/cog-shell.c
@@ -121,25 +121,6 @@ request_handler_map_entry_register (const char             *scheme,
 }
 
 static void
-cog_shell_startup_base(CogShell *shell)
-{
-    CogShellPrivate *priv = PRIV(shell);
-
-    if (priv->request_handlers) {
-        g_hash_table_foreach (priv->request_handlers,
-                              (GHFunc) request_handler_map_entry_register,
-                              priv->web_context);
-    }
-
-    webkit_web_context_set_automation_allowed(priv->web_context, priv->automated);
-}
-
-static void
-cog_shell_shutdown_base(CogShell *shell G_GNUC_UNUSED)
-{
-}
-
-static void
 cog_shell_get_property (GObject    *object,
                         unsigned    prop_id,
                         GValue     *value,
@@ -255,6 +236,8 @@ cog_shell_constructed(GObject *object)
                                      "memory-pressure-settings", priv->web_mem_settings,
 #endif
                                      NULL);
+
+    webkit_web_context_set_automation_allowed(priv->web_context, priv->automated);
 }
 
 static void
@@ -283,9 +266,6 @@ cog_shell_class_init(CogShellClass *klass)
     object_class->constructed = cog_shell_constructed;
     object_class->get_property = cog_shell_get_property;
     object_class->set_property = cog_shell_set_property;
-
-    klass->startup = cog_shell_startup_base;
-    klass->shutdown = cog_shell_shutdown_base;
 
     /**
      * CogShell:name: (attributes org.gtk.Property.get=cog_shell_get_name):
@@ -537,35 +517,4 @@ cog_shell_set_request_handler(CogShell *shell, const char *scheme, CogRequestHan
     }
 
     request_handler_map_entry_register (scheme, entry, priv->web_context);
-}
-
-/**
- * cog_shell_startup: (virtual startup)
- *
- * Finish initializing the shell.
- *
- * This takes care of registering custom URI scheme handlers.
- *
- * Subclasses which override this method **must** invoke the base
- * implementation.
- */
-void
-cog_shell_startup  (CogShell *shell)
-{
-    g_return_if_fail (COG_IS_SHELL (shell));
-    CogShellClass *klass = COG_SHELL_GET_CLASS (shell);
-    (*klass->startup) (shell);
-}
-
-/**
- * cog_shell_shutdown: (virtual shutdown)
- *
- * Deinitialize the shell.
- */
-void
-cog_shell_shutdown (CogShell *shell)
-{
-    g_return_if_fail (COG_IS_SHELL (shell));
-    CogShellClass *klass = COG_SHELL_GET_CLASS (shell);
-    (*klass->shutdown) (shell);
 }

--- a/core/cog-shell.h
+++ b/core/cog-shell.h
@@ -1,5 +1,6 @@
 /*
  * cog-shell.h
+ * Copyright (C) 2019-2023 Igalia S.L.
  * Copyright (C) 2018 Adrian Perez <aperez@igalia.com>
  *
  * SPDX-License-Identifier: MIT
@@ -27,10 +28,6 @@ G_DECLARE_DERIVABLE_TYPE(CogShell, cog_shell, COG, SHELL, GObject)
 
 struct _CogShellClass {
     GObjectClass parent_class;
-
-    /*< public >*/
-    void (*startup)(CogShell *self);
-    void (*shutdown)(CogShell *self);
 };
 
 COG_API CogShell         *cog_shell_new(const char *name, gboolean automated);
@@ -41,8 +38,5 @@ COG_API GKeyFile         *cog_shell_get_config_file(CogShell *shell);
 COG_API gdouble           cog_shell_get_device_scale_factor(CogShell *shell);
 COG_API gboolean          cog_shell_is_automated(CogShell *shell);
 COG_API void cog_shell_set_request_handler(CogShell *shell, const char *scheme, CogRequestHandler *handler);
-
-COG_API void cog_shell_startup(CogShell *shell);
-COG_API void cog_shell_shutdown(CogShell *shell);
 
 G_END_DECLS

--- a/core/cog-shell.h
+++ b/core/cog-shell.h
@@ -18,8 +18,7 @@ G_BEGIN_DECLS
 
 #define COG_SHELL_DEFAULT_VIEWPORT_INDEX 0
 
-typedef struct _CogViewport   CogViewport;
-typedef struct _WebKitWebView WebKitWebView;
+typedef struct _CogView CogView;
 
 #define COG_TYPE_SHELL (cog_shell_get_type())
 
@@ -30,16 +29,14 @@ struct _CogShellClass {
     GObjectClass parent_class;
 
     /*< public >*/
-    WebKitWebView* (*create_view) (CogShell*);
-    void           (*startup)     (CogShell*);
-    void           (*shutdown)    (CogShell*);
+    void (*startup)(CogShell *self);
+    void (*shutdown)(CogShell *self);
 };
 
 COG_API CogShell         *cog_shell_new(const char *name, gboolean automated);
 COG_API const char       *cog_shell_get_name(CogShell *shell);
 COG_API WebKitWebContext *cog_shell_get_web_context(CogShell *shell);
 COG_API WebKitSettings   *cog_shell_get_web_settings(CogShell *shell);
-COG_API WebKitWebView    *cog_shell_get_web_view(CogShell *shell);
 COG_API GKeyFile         *cog_shell_get_config_file(CogShell *shell);
 COG_API gdouble           cog_shell_get_device_scale_factor(CogShell *shell);
 COG_API gboolean          cog_shell_is_automated(CogShell *shell);
@@ -47,13 +44,5 @@ COG_API void cog_shell_set_request_handler(CogShell *shell, const char *scheme, 
 
 COG_API void cog_shell_startup(CogShell *shell);
 COG_API void cog_shell_shutdown(CogShell *shell);
-
-COG_API CogViewport *cog_shell_get_viewport(CogShell *shell);
-COG_API GPtrArray   *cog_shell_get_viewports(CogShell *shell);
-
-COG_API void         cog_shell_add_viewport(CogShell *shell, CogViewport *viewport);
-COG_API void         cog_shell_remove_viewport(CogShell *shell, CogViewport *viewport);
-COG_API gsize        cog_shell_get_n_viewports(CogShell *shell);
-COG_API CogViewport *cog_shell_get_nth_viewport(CogShell *shell, gsize index);
 
 G_END_DECLS

--- a/examples/viewport.c
+++ b/examples/viewport.c
@@ -43,9 +43,8 @@ main(int argc, char *argv[])
     if (!cog_platform_setup(platform, shell, NULL, &error))
         g_error("Cannot configure platform: %s", error->message);
 
+    g_autoptr(CogViewport) viewport = cog_viewport_new();
     g_autoptr(GMainLoop) loop = g_main_loop_new(NULL, FALSE);
-
-    CogViewport *viewport = cog_shell_get_viewport(shell);
 
     for (int i = 1; i < argc; i++) {
         g_autoptr(CogView) view = cog_view_new(NULL);

--- a/examples/viewports.c
+++ b/examples/viewports.c
@@ -46,7 +46,6 @@ main(int argc, char *argv[])
     g_autoptr(GMainLoop) loop = g_main_loop_new(NULL, FALSE);
 
     CogViewport *viewport0 = cog_viewport_new();
-    cog_shell_add_viewport(shell, viewport0);
 
     for (int i = 1; i < argc; i++) {
         g_autoptr(CogView) view = cog_view_new(NULL);
@@ -64,7 +63,6 @@ main(int argc, char *argv[])
     on_timeout_tick(&data0);
 
     CogViewport *viewport1 = cog_viewport_new();
-    cog_shell_add_viewport(shell, viewport1);
 
     for (int i = 1; i < argc; i++) {
         g_autoptr(CogView) view = cog_view_new(NULL);

--- a/launcher/cog-launcher.c
+++ b/launcher/cog-launcher.c
@@ -303,8 +303,6 @@ cog_launcher_startup(GApplication *application)
 
     g_object_set(self->shell, "device-scale-factor", s_options.device_scale_factor, NULL);
 
-    cog_shell_startup(self->shell);
-
     if (s_options.handler_map) {
         GHashTableIter i;
         void          *key, *value;
@@ -414,14 +412,6 @@ cog_launcher_activate(GApplication *application)
     /* GApplication warns if activate is not handled. Usually this signal will focus a
        window but this doesn't apply to many of our platforms so this is a noop. */
     G_APPLICATION_CLASS(cog_launcher_parent_class)->activate(application);
-}
-
-static void
-cog_launcher_shutdown(GApplication *application)
-{
-    cog_shell_shutdown(cog_launcher_get_shell(COG_LAUNCHER(application)));
-
-    G_APPLICATION_CLASS(cog_launcher_parent_class)->shutdown(application);
 }
 
 static void
@@ -1498,7 +1488,6 @@ cog_launcher_class_init(CogLauncherClass *klass)
     GApplicationClass *application_class = G_APPLICATION_CLASS(klass);
     application_class->open = cog_launcher_open;
     application_class->startup = cog_launcher_startup;
-    application_class->shutdown = cog_launcher_shutdown;
     application_class->handle_local_options = cog_launcher_handle_local_options;
     application_class->activate = cog_launcher_activate;
 


### PR DESCRIPTION
Remove handling of viewports and views from `CogShell`. Tracking live viewports can be done using `CogPlatform` since #683 and platform plug-ins no longer depend on `CogShell` for that. The following are no longer needed in `CogShell`:

- The `:web-view` and `:viewport` properties, and their accessors.
- The `::create-view` and `::create-viewport` signals.
- The `.create_view()` virtual function and its default implementation.
- The `cog_shell_add_viewport()`, `cog_shell_remove_viewport()`, `cog_shell_get_n_viewports()`, and `cog_shell_get_nth_viewport()` methods.

As a side effect of the above removals, the examples have been changed to have them create their views using `cog_view_new()` instead of relying on the default implementation of the `CogShell.create_view()` virtual function.

The launcher also needed a number of changes, which now manages itself a viewport as it cannot rely on the shell for that. Some code was moved around to accommodate creation of the view in `cog_launcher_startup()` without relying on the `CogShell::create-view` signal, and similarly for web view creation when running in automation mode.

There are more opportunities for further simplifications that would be better done in separate patches: this one focuses on the minimum amount of changes needed to get view and viewport handling out of `CogShell`.