### PR TITLE
wl: Specify button modifier in listeners

### DIFF
--- a/platform/wayland/cog-platform-wl.c
+++ b/platform/wayland/cog-platform-wl.c
@@ -11,6 +11,7 @@
 
 #include <glib-object.h>
 #include <glib.h>
+#include <linux/input-event-codes.h>
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdio.h>
@@ -283,6 +284,27 @@ pointer_on_leave(void *data, struct wl_pointer *pointer, uint32_t serial, struct
     seat->pointer.surface = NULL;
 }
 
+static uint32_t
+button_modifier(CogWlSeat *seat)
+{
+    if (!seat->pointer.state) {
+        return 0;
+    }
+
+    switch (seat->pointer.button) {
+    case BTN_LEFT:
+        return wpe_input_pointer_modifier_button1;
+
+    case BTN_RIGHT:
+        return wpe_input_pointer_modifier_button2;
+
+    case BTN_MIDDLE:
+        return wpe_input_pointer_modifier_button3;
+    }
+
+    return 0;
+}
+
 static void
 pointer_on_motion(void *data, struct wl_pointer *pointer, uint32_t time, wl_fixed_t fixed_x, wl_fixed_t fixed_y)
 {
@@ -302,7 +324,8 @@ pointer_on_motion(void *data, struct wl_pointer *pointer, uint32_t time, wl_fixe
                                             seat->pointer.x * display->current_output->scale,
                                             seat->pointer.y * display->current_output->scale,
                                             seat->pointer.button,
-                                            seat->pointer.state};
+                                            seat->pointer.state,
+                                            button_modifier(seat)};
 
     g_assert(seat->pointer_target);
     CogWlViewport *viewport = COG_WL_VIEWPORT(seat->pointer_target);
@@ -342,14 +365,13 @@ pointer_on_button(void              *data,
     seat->pointer.button = !!state ? button : 0;
     seat->pointer.state = state;
 
-    struct wpe_input_pointer_event event = {
-        wpe_input_pointer_event_type_button,
-        time,
-        seat->pointer.x * display->current_output->scale,
-        seat->pointer.y * display->current_output->scale,
-        seat->pointer.button,
-        seat->pointer.state,
-    };
+    struct wpe_input_pointer_event event = {wpe_input_pointer_event_type_button,
+                                            time,
+                                            seat->pointer.x * display->current_output->scale,
+                                            seat->pointer.y * display->current_output->scale,
+                                            seat->pointer.button,
+                                            seat->pointer.state,
+                                            button_modifier(seat)};
 
     CogWlPopup *popup = platform->popup;
     if (popup && popup->wl_surface) {


### PR DESCRIPTION
TODO:
- [ ] Is it necessary to fix the button value passed through WPE? It doesn't seem to affect the result in my tests
- [X] ~Implement back and forward buttons (I don't have the hardware right now to test it).~ I can't test the extra buttons since they change the browser page (obviously...). So I'll just removed them. The behavior is the same as before for those buttons

Closes #688 