### PR TITLE
automation: Save automated view and avoid dangling ref when closing window

### DIFF
--- a/launcher/cog-launcher.c
+++ b/launcher/cog-launcher.c
@@ -240,7 +240,7 @@ on_automation_session_create_web_view(WebKitAutomationSession *session, CogLaunc
         webkit_website_policies_new_with_policies("autoplay", s_options.autoplay_policy, NULL);
 #endif /* HAVE_WEBKIT_AUTOPLAY */
 
-    WebKitWebView *new_view =
+    g_autoptr(WebKitWebView) new_view =
         (WebKitWebView *) cog_view_new("settings", cog_shell_get_web_settings(launcher->shell), "web-context",
                                        cog_shell_get_web_context(launcher->shell), "is-controlled-by-automation", TRUE,
                                        "zoom-level", s_options.scale_factor, "use-key-bindings", FALSE,
@@ -253,8 +253,6 @@ on_automation_session_create_web_view(WebKitAutomationSession *session, CogLaunc
                                        NULL);
     // FIXME New window should be new viewport
     cog_viewport_add(launcher->viewport, (CogView *) new_view);
-    // Let viewport own the view
-    g_object_unref(new_view);
 
     return new_view;
 }

--- a/launcher/cog-launcher.c
+++ b/launcher/cog-launcher.c
@@ -230,6 +230,11 @@ on_web_view_create(WebKitWebView *web_view, WebKitNavigationAction *action)
 static WebKitWebView *
 on_automation_session_create_web_view(WebKitAutomationSession *session, CogLauncher *launcher)
 {
+    static bool first_time = true;
+    if (first_time) {
+        first_time = false;
+        return (WebKitWebView *) cog_viewport_get_visible_view(launcher->viewport);
+    }
 #if HAVE_WEBKIT_AUTOPLAY
     g_autoptr(WebKitWebsitePolicies) website_policies =
         webkit_website_policies_new_with_policies("autoplay", s_options.autoplay_policy, NULL);
@@ -346,8 +351,10 @@ cog_launcher_startup(GApplication *application)
         webkit_website_policies_new_with_policies("autoplay", s_options.autoplay_policy, NULL);
 #endif
 
-    g_autoptr(CogView) view = cog_view_new("settings", cog_shell_get_web_settings(self->shell), "web-context",
-                                           cog_shell_get_web_context(self->shell), "zoom-level", s_options.scale_factor,
+    g_autoptr(CogView) view = cog_view_new("settings", cog_shell_get_web_settings(self->shell),
+                                           "web-context", cog_shell_get_web_context(self->shell),
+                                           "is-controlled-by-automation", self->automated,
+                                           "zoom-level", s_options.scale_factor,
                                            "use-key-bindings", !s_options.disable_key_bindings,
 #if COG_USE_WPE2
                                            "network-session", self->network_session,

--- a/launcher/cog-launcher.c
+++ b/launcher/cog-launcher.c
@@ -240,18 +240,19 @@ on_automation_session_create_web_view(WebKitAutomationSession *session, CogLaunc
         webkit_website_policies_new_with_policies("autoplay", s_options.autoplay_policy, NULL);
 #endif /* HAVE_WEBKIT_AUTOPLAY */
 
-    WebKitWebView *new_view = (WebKitWebView *) cog_view_new("settings", cog_shell_get_web_settings(launcher->shell), "web-context",
-                                          cog_shell_get_web_context(launcher->shell), "is-controlled-by-automation",
-                                          TRUE, "zoom-level", s_options.scale_factor, "use-key-bindings", FALSE,
+    WebKitWebView *new_view =
+        (WebKitWebView *) cog_view_new("settings", cog_shell_get_web_settings(launcher->shell), "web-context",
+                                       cog_shell_get_web_context(launcher->shell), "is-controlled-by-automation", TRUE,
+                                       "zoom-level", s_options.scale_factor, "use-key-bindings", FALSE,
 #if COG_USE_WPE2
-                                          "network-session", launcher->network_session,
+                                       "network-session", launcher->network_session,
 #endif /* COG_USE_WPE2 */
 #if HAVE_WEBKIT_AUTOPLAY
-                                          "website-policies", website_policies,
+                                       "website-policies", website_policies,
 #endif /* HAVE_WEBKIT_AUTOPLAY */
-                                          NULL);
+                                       NULL);
     // FIXME New window should be new viewport
-    cog_viewport_add(launcher->viewport, (CogView*)new_view);
+    cog_viewport_add(launcher->viewport, (CogView *) new_view);
     // Let viewport own the view
     g_object_unref(new_view);
 
@@ -351,18 +352,17 @@ cog_launcher_startup(GApplication *application)
         webkit_website_policies_new_with_policies("autoplay", s_options.autoplay_policy, NULL);
 #endif
 
-    g_autoptr(CogView) view = cog_view_new("settings", cog_shell_get_web_settings(self->shell),
-                                           "web-context", cog_shell_get_web_context(self->shell),
-                                           "is-controlled-by-automation", self->automated,
-                                           "zoom-level", s_options.scale_factor,
-                                           "use-key-bindings", !s_options.disable_key_bindings,
+    g_autoptr(CogView) view =
+        cog_view_new("settings", cog_shell_get_web_settings(self->shell), "web-context",
+                     cog_shell_get_web_context(self->shell), "is-controlled-by-automation", self->automated,
+                     "zoom-level", s_options.scale_factor, "use-key-bindings", !s_options.disable_key_bindings,
 #if COG_USE_WPE2
-                                           "network-session", self->network_session,
+                     "network-session", self->network_session,
 #endif
 #if HAVE_WEBKIT_AUTOPLAY
-                                           "website-policies", website_policies,
+                     "website-policies", website_policies,
 #endif
-                                           NULL);
+                     NULL);
 
     cog_platform_init_web_view(cog_platform_get(), WEBKIT_WEB_VIEW(view));
 

--- a/launcher/cog-launcher.c
+++ b/launcher/cog-launcher.c
@@ -235,7 +235,7 @@ on_automation_session_create_web_view(WebKitAutomationSession *session, CogLaunc
         webkit_website_policies_new_with_policies("autoplay", s_options.autoplay_policy, NULL);
 #endif /* HAVE_WEBKIT_AUTOPLAY */
 
-    return (WebKitWebView *) cog_view_new("settings", cog_shell_get_web_settings(launcher->shell), "web-context",
+    WebKitWebView *new_view = (WebKitWebView *) cog_view_new("settings", cog_shell_get_web_settings(launcher->shell), "web-context",
                                           cog_shell_get_web_context(launcher->shell), "is-controlled-by-automation",
                                           TRUE, "zoom-level", s_options.scale_factor, "use-key-bindings", FALSE,
 #if COG_USE_WPE2
@@ -245,6 +245,12 @@ on_automation_session_create_web_view(WebKitAutomationSession *session, CogLaunc
                                           "website-policies", website_policies,
 #endif /* HAVE_WEBKIT_AUTOPLAY */
                                           NULL);
+    // FIXME New window should be new viewport
+    cog_viewport_add(launcher->viewport, (CogView*)new_view);
+    // Let viewport own the view
+    g_object_unref(new_view);
+
+    return new_view;
 }
 
 static void


### PR DESCRIPTION
The view created for automation was not being saved in the viewport, leaving some required signals unhandled, like "close". This causes the view to never be destroyed when called from WebKit's WebPageProxy::close(), leading to infinite loop in the close window WebDriver algorithm, as the list of open windows would never change.

After hooking the close signal, there was the issue with cog_viewport_add ref'ing the view when storing the view with g_ptr_array_add but not releasing this reference when removing, doing just a ref/unref pair to preserve during the removal.

This commit removes the extra g_object_ref during the cleanup, effectively relying on the previously saved ref before unref'ing it

This should fix the WPT webdriver fixtures that rely on creating and destroying views for testing.

Note: This commit makes creating new windows for automation behave like creating new tabs, regardless of the "create-web-view::window" detail, which maybe could be implemented creating a new viewport in a future commit.