### PR TITLE
drm: Detect if drivers support buffer modifiers

### DIFF
--- a/platform/drm/cog-platform-drm.c
+++ b/platform/drm/cog-platform-drm.c
@@ -131,6 +131,7 @@ static struct {
     double   device_scale;
 
     bool atomic_modesetting;
+    bool addfb2_modifiers;
     bool mode_set;
 } drm_data = {
     .fd = -1,


### PR DESCRIPTION
Use `drmGetCap()` in the DRM modesetting renderer to detect whether framebuffers can be created with modifiers, instead of always trying to use them and falling back to avoid them.