### PR TITLE
Fixed the 0 device scale factor issue in the drm platform.

### DIFF
--- a/platform/drm/cog-platform-drm.c
+++ b/platform/drm/cog-platform-drm.c
@@ -1319,6 +1319,12 @@ key_repeat_source_dispatch(CogDrmPlatform *platform)
 }
 
 static void
+cog_drm_platform_shell_device_factor_changed(CogShell *shell, GParamSpec *param_spec, gpointer data)
+{
+    drm_data.device_scale = cog_shell_get_device_scale_factor(shell);
+}
+
+static void
 clear_glib (void)
 {
     if (glib_data.drm_source)
@@ -1399,6 +1405,7 @@ cog_drm_platform_setup(CogPlatform *platform, CogShell *shell, const char *param
     CogDrmPlatform *self = COG_DRM_PLATFORM(platform);
 
     init_config(COG_DRM_PLATFORM(platform), shell, params);
+    g_signal_connect(shell, "notify::device-scale-factor", G_CALLBACK(cog_drm_platform_shell_device_factor_changed), NULL);
 
     if (!wpe_loader_init ("libWPEBackend-fdo-1.0.so")) {
         g_set_error_literal (error,


### PR DESCRIPTION
Copied the code for fetching the device scale factor from the gtk platform.

The problem was that a scale factor of 0.0 was read before which just results in a black screen.

I am not certain if the "g_signal_connect" call is where you want it.