### PR TITLE
wl: Add safe-guards for touch and pointer events

### DIFF
--- a/platform/wayland/cog-platform-wl.c
+++ b/platform/wayland/cog-platform-wl.c
@@ -271,7 +271,13 @@ pointer_on_enter(void              *data,
 static void
 pointer_on_leave(void *data, struct wl_pointer *pointer, uint32_t serial, struct wl_surface *surface)
 {
+    if (data == NULL || pointer == NULL)
+        return;
+
     CogWlSeat *seat = data;
+
+    if (seat->pointer_target == NULL || seat->pointer.surface == NULL)
+        return;
 
     if (pointer != seat->pointer_obj) {
         g_critical("%s: Got pointer %p, expected %p.", G_STRFUNC, pointer, seat->pointer_obj);
@@ -286,7 +292,14 @@ pointer_on_leave(void *data, struct wl_pointer *pointer, uint32_t serial, struct
 static void
 pointer_on_motion(void *data, struct wl_pointer *pointer, uint32_t time, wl_fixed_t fixed_x, wl_fixed_t fixed_y)
 {
-    CogWlSeat    *seat = data;
+    if (data == NULL || pointer == NULL)
+        return;
+
+    CogWlSeat *seat = data;
+
+    if (seat->pointer_target == NULL || seat->pointer.surface == NULL)
+        return;
+
     CogWlDisplay *display = seat->display;
 
     if (pointer != seat->pointer_obj) {
@@ -783,7 +796,13 @@ touch_on_down(void              *data,
 static void
 touch_on_up(void *data, struct wl_touch *touch, uint32_t serial, uint32_t time, int32_t id)
 {
+    if (data == NULL || touch == NULL)
+        return;
+
     CogWlSeat *seat = data;
+
+    if (seat->touch_target == NULL || seat->touch.surface == NULL)
+        return;
 
     if (touch != seat->touch_obj) {
         g_critical("%s: Got touch %p, expected %p.", G_STRFUNC, touch, seat->touch_obj);
@@ -833,8 +852,14 @@ touch_on_up(void *data, struct wl_touch *touch, uint32_t serial, uint32_t time, 
 static void
 touch_on_motion(void *data, struct wl_touch *touch, uint32_t time, int32_t id, wl_fixed_t x, wl_fixed_t y)
 {
+    if (data == NULL || touch == NULL)
+        return;
+
     CogWlSeat    *seat = data;
     CogWlDisplay *display = seat->display;
+
+    if (seat->touch_target == NULL || seat->touch.surface == NULL)
+        return;
 
     if (touch != seat->touch_obj) {
         g_critical("%s: Got touch %p, expected %p.", G_STRFUNC, touch, seat->touch_obj);


### PR DESCRIPTION
In some compositors it could be possible these 2 cases:

* to receive touch up/motion events immediately after a touch up (touch deinit the touch target).
* to receive pointer motion/leave event immediately after a touch leave (deinit the touch target).

This patch adds safeguards in the touch events callbacks