### PR TITLE
wl: Fix popup menu item 6 & 7 not rendering

### DIFF
--- a/platform/wayland/cog-popup-menu-wl.c
+++ b/platform/wayland/cog-popup-menu-wl.c
@@ -91,7 +91,7 @@ cog_popup_menu_paint(CogPopupMenu *popup_menu)
         }
 
         guint i = popup_menu->menu_current_page * 5;
-        guint i_max = i + 5;
+        guint i_max = i + (popup_menu->menu_has_paging ? 5 : 7);
         guint i_end = MIN(i_max, webkit_option_menu_get_n_items(popup_menu->option_menu));
         for (; i < i_end; ++i) {
             WebKitOptionMenuItem *item = webkit_option_menu_get_item(popup_menu->option_menu, i);


### PR DESCRIPTION
When HTML select had 6 or 7 options those respective options were not rendered, they still functioned fine just not visible.

Before:

![before](https://github.com/Igalia/cog/assets/161829293/7d6f701c-672e-4254-a0d9-7bab85e42771)

After:

![after](https://github.com/Igalia/cog/assets/161829293/d775be1a-22a5-49c2-a1e3-2312b604da93)
