### PR TITLE
core, wl: Factor out view fullscreening

### DIFF
--- a/core/cog-view.c
+++ b/core/cog-view.c
@@ -327,6 +327,10 @@ cog_view_try_handle_key_binding(CogView *self, const struct wpe_input_keyboard_e
         return TRUE;
     }
 
+    /* F11, toggle fullscreen */
+    if (!event->modifiers && event->key_code == WPE_KEY_F11)
+        return cog_view_set_fullscreen(self, !cog_view_is_fullscreen(self));
+
     return FALSE;
 }
 
@@ -498,4 +502,52 @@ cog_view_set_visible(CogView *self)
     cog_viewport_set_visible_view(viewport, self);
 
     return TRUE;
+}
+
+/**
+ * cog_view_set_fullscreen:
+ * @self: A view.
+ * @enable: Whether to enable fullscreening.
+ *
+ * Change the fullscreening status of the view.
+ *
+ * Note that not all platform plug-ins may implement view fullscreening,
+ * and in that case %FALSE is always returned.
+ *
+ * Returns: Whether the view fullscreening state was set to the requested one.
+ *
+ * Since: 0.20
+ */
+gboolean
+cog_view_set_fullscreen(CogView *self, gboolean enable)
+{
+    g_return_val_if_fail(COG_IS_VIEW(self), FALSE);
+
+    CogViewClass *klass = COG_VIEW_GET_CLASS(self);
+    if (klass->set_fullscreen)
+        return (*klass->set_fullscreen)(self, enable);
+
+    return FALSE;
+}
+
+/**
+ * cog_view_is_fullscreen:
+ * @self: A view.
+ *
+ * Gets whether the view is fullscreened.
+ *
+ * Returns: Whether the view is fullscreened.
+ *
+ * Since: 0.20
+ */
+gboolean
+cog_view_is_fullscreen(CogView *self)
+{
+    g_return_val_if_fail(COG_IS_VIEW(self), FALSE);
+
+    CogViewClass *klass = COG_VIEW_GET_CLASS(self);
+    if (klass->is_fullscreen)
+        return (*klass->is_fullscreen)(self);
+
+    return FALSE;
 }

--- a/core/cog-view.h
+++ b/core/cog-view.h
@@ -29,7 +29,10 @@ struct _CogViewClass {
     /*< private >*/
     WebKitWebViewClass parent_class;
 
-    WebKitWebViewBackend *(*create_backend)(CogView *);
+    /*< public >*/
+    WebKitWebViewBackend *(*create_backend)(CogView *self);
+    gboolean (*set_fullscreen)(CogView *self, gboolean enable);
+    gboolean (*is_fullscreen)(CogView *self);
 };
 
 #define COG_TYPE_VIEW_IMPL (cog_view_get_impl_type())
@@ -60,5 +63,8 @@ gboolean cog_view_is_visible(CogView *self);
 
 COG_API
 gboolean cog_view_set_visible(CogView *self);
+
+COG_API gboolean cog_view_set_fullscreen(CogView *self, gboolean enable);
+COG_API gboolean cog_view_is_fullscreen(CogView *self);
 
 G_END_DECLS

--- a/platform/wayland/cog-platform-wl.c
+++ b/platform/wayland/cog-platform-wl.c
@@ -579,19 +579,6 @@ handle_key_event(CogWlSeat *seat, uint32_t key, uint32_t state, uint32_t time)
         return;
 
     uint32_t keysym = xkb_state_key_get_one_sym(seat->xkb.state, key);
-    uint32_t unicode = xkb_state_key_get_utf32(seat->xkb.state, key);
-
-    /* TODO: Move as much as possible from fullscreen handling to common code. */
-    if (cog_view_get_use_key_bindings(view) && state == WL_KEYBOARD_KEY_STATE_PRESSED && seat->xkb.modifiers == 0 &&
-        unicode == 0 && keysym == XKB_KEY_F11) {
-        if (viewport->window.is_fullscreen && viewport->window.was_fullscreen_requested_from_dom) {
-            struct wpe_view_backend *backend = cog_view_get_backend(view);
-            wpe_view_backend_dispatch_request_exit_fullscreen(backend);
-            return;
-        }
-        cog_wl_viewport_set_fullscreen(viewport, !viewport->window.is_fullscreen);
-        return;
-    }
 
     if (seat->xkb.compose_state != NULL && state == WL_KEYBOARD_KEY_STATE_PRESSED &&
         xkb_compose_state_feed(seat->xkb.compose_state, keysym) == XKB_COMPOSE_FEED_ACCEPTED &&


### PR DESCRIPTION
Move view fullscreening to a new vfunc in the `CogView` class, which gets in turn implemented by `CogWlView`. This moves the entry point to common code, which would allow other platform plug-ins to implement the functionality if desired. Also, handling its key binding can be moved along to common code.