### PR TITLE
Set entry->registered to TRUE when custom URI scheme handler is regis…

### DIFF
--- a/core/cog-shell.c
+++ b/core/cog-shell.c
@@ -117,6 +117,7 @@ request_handler_map_entry_register (const char             *scheme,
                                                 handle_uri_scheme_request,
                                                 entry,
                                                 NULL);
+        entry->registered = TRUE;
     }
 }
 


### PR DESCRIPTION
…tered

Sets the `entry->registered` flag to `TRUE` after registering the custom URI handler with WebKit.

Fixes #727 