### PR TITLE
build: make libmanette support explicit

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -144,7 +144,7 @@ if cog_launcher_system_bus
 endif
 
 wpe_dep = dependency('wpe-1.0', version: '>=1.14.0')
-manette_dep = dependency('manette-0.2', version: '>=0.2.4', required: false)
+manette_dep = dependency('manette-0.2', version: '>=0.2.4', required: get_option('libmanette'))
 
 subdir('core')
 subdir('platform')

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -38,6 +38,13 @@ option(
     description: 'Use libportal to provide file picker dialogs'
 )
 
+option(
+    'libmanette',
+    type: 'feature',
+    value: 'auto',
+    description: 'Use libmanette to support gamepads'
+)
+
 # Wayland platform-specific features
 option(
     'wayland_weston_direct_display',


### PR DESCRIPTION
This allows disabling libmanette support when libmanette is installed.