### PR TITLE
docs: Use a versioned libsoup documentation URL

### DIFF
--- a/docs/cog.toml.in
+++ b/docs/cog.toml.in
@@ -7,7 +7,7 @@ logo_url = "cog.png"
 browse_url = "https://github.com/Igalia/cog"
 repository_url = "https://github.com/Igalia/cog"
 website_url = "https://wpewebkit.org"
-dependencies = ["GLib-2.0", "GObject-2.0", "Gio-2.0", "Soup-2.4"]
+dependencies = ["GLib-2.0", "GObject-2.0", "Gio-2.0", "Soup-@LIBSOUP_API@"]
 devhelp = true
 search_index = true
 
@@ -26,10 +26,10 @@ name = "Gio"
 description = "The GLib input/output library"
 docs_url = "https://developer.gnome.org/gio/stable"
 
-[dependencies."Soup-2.4"]
+[dependencies."Soup-@LIBSOUP_API@"]
 name = "Soup"
 description = "The Soup networking library"
-docs_url = "https://developer.gnome.org/libsoup/stable"
+docs_url = "https://libsoup.gnome.org/libsoup-@LIBSOUP_API@"
 
 [theme]
 name = "basic"

--- a/docs/meson.build
+++ b/docs/meson.build
@@ -12,9 +12,12 @@ docs_md = [
 ]
 
 docs_toml = configure_file(
+    configuration: {
+        'PROJECT_VERSION': meson.project_version(),
+        'LIBSOUP_API': soup_target_api,
+    },
     input: 'cog.toml.in',
     output: 'cog.toml',
-    configuration: cog_config,
 )
 
 gi_outputs = import('gnome').generate_gir(


### PR DESCRIPTION
Replace `@LIBSOUP_API@` in the `cog.toml.in` template with the libsoup API version being used, and update the URL to use `libsoup.gnome.org`