### PR TITLE
CI: Use actions/upload-artifact v4

### DIFF
--- a/.github/workflows/ci-native.yml
+++ b/.github/workflows/ci-native.yml
@@ -95,7 +95,7 @@ jobs:
         run:
           ninja -C ~/build/
       - name: Archive Documentation
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: docs
           path: ~/build/docs/html

--- a/.github/workflows/codestyle.yml
+++ b/.github/workflows/codestyle.yml
@@ -28,7 +28,7 @@ jobs:
         run: |
           data/check-style -ocode-style.diff origin/master
       - name: Archive Diff
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: failure()
         with:
           name: diff


### PR DESCRIPTION
Use version 4 of `actions/upload-artifact`, as v3 has been deprecated and removed.