### PR TITLE
wl: fix pointer modifiers

### DIFF
--- a/platform/wayland/cog-utils-wl.h
+++ b/platform/wayland/cog-utils-wl.h
@@ -82,6 +82,7 @@ struct _CogWlPointer {
     int32_t            y;
     uint32_t           button;
     uint32_t           state;
+    uint32_t           modifiers;
     uint32_t           serial;
 };
 


### PR DESCRIPTION
After #760, the 'buttons' field for Pointer & Mouse events stopped working.