### PR TITLE
platform-wl: Reuse wl_display between being checked and being used

### DIFF
--- a/platform/wayland/cog-platform-wl.c
+++ b/platform/wayland/cog-platform-wl.c
@@ -1155,12 +1155,15 @@ static const struct wpe_video_plane_display_dmabuf_receiver video_plane_display_
 };
 #endif
 
+/* Saved by check_supported(), consumed once by init_wayland(). */
+static struct wl_display *checked_wl_display = NULL;
+
 static gboolean
 init_wayland(CogWlPlatform *platform, GError **error)
 {
     g_debug("Initializing Wayland...");
 
-    CogWlDisplay *display = cog_wl_display_create(NULL, error);
+    CogWlDisplay *display = cog_wl_display_create(g_steal_pointer(&checked_wl_display), error);
     platform->display = display;
     display->registry = wl_display_get_registry(display->display);
     g_assert(display->registry);
@@ -1258,7 +1261,13 @@ check_supported(void *data G_GNUC_UNUSED)
 #undef CHECK_SHELL_PROTOCOL
 
         wl_registry_destroy(registry);
-        wl_display_disconnect(display);
+
+        /* Keep the connection open for init_wayland() to reuse, required when WAYLAND_SOCKET is set. */
+        if (ok)
+            checked_wl_display = display;
+        else
+            wl_display_disconnect(display);
+
         return GINT_TO_POINTER(ok);
     } else {
         return GINT_TO_POINTER(FALSE);

--- a/platform/wayland/cog-utils-wl.c
+++ b/platform/wayland/cog-utils-wl.c
@@ -131,12 +131,14 @@ cog_wl_display_add_seat(CogWlDisplay *display, CogWlSeat *seat)
 }
 
 CogWlDisplay *
-cog_wl_display_create(const char *name, GError **error)
+cog_wl_display_create(struct wl_display *wl_display, GError **error)
 {
-    struct wl_display *wl_display = wl_display_connect(name);
     if (!wl_display) {
-        g_set_error(error, G_FILE_ERROR, g_file_error_from_errno(errno), "Could not open Wayland display");
-        return FALSE;
+        wl_display = wl_display_connect(NULL);
+        if (!wl_display) {
+            g_set_error(error, G_FILE_ERROR, g_file_error_from_errno(errno), "Could not open Wayland display");
+            return FALSE;
+        }
     }
 
     CogWlDisplay *display = g_slice_new0(CogWlDisplay);

--- a/platform/wayland/cog-utils-wl.h
+++ b/platform/wayland/cog-utils-wl.h
@@ -290,7 +290,7 @@ struct _CogWlDisplay {
 struct wl_surface *cog_wl_compositor_create_surface(struct wl_compositor *compositor, void *container);
 
 void          cog_wl_display_add_seat(CogWlDisplay *, CogWlSeat *);
-CogWlDisplay *cog_wl_display_create(const char *name, GError **error);
+CogWlDisplay *cog_wl_display_create(struct wl_display *wl_display, GError **error);
 void          cog_wl_display_destroy(CogWlDisplay *self);
 CogWlOutput  *cog_wl_display_find_output(CogWlDisplay *, struct wl_output *);
 


### PR DESCRIPTION
In normal cases this shouldn't meaningfully change behavior.

However if WAYLAND_SOCKET is set to an fd then wl_display_disconnect() closes that fd leaving it in a state where it cannot be reused.