### PR TITLE
drm: select a CRTC from possible_crtcs when none is bound yet

### DIFF
--- a/platform/drm/cog-platform-drm.c
+++ b/platform/drm/cog-platform-drm.c
@@ -394,12 +394,40 @@ find_crtc_for_encoder(const drmModeRes *resources, const drmModeEncoder *encoder
     for (int i = 0; i < resources->count_crtcs; i++) {
         const uint32_t crtc_mask = 1 << i;
         const uint32_t crtc_id = resources->crtcs[i];
-        if (encoder->possible_crtcs & crtc_mask && encoder->crtc_id == crtc_id) {
+        /*
+         * Match on the static possible_crtcs capability only. Do NOT also
+         * require encoder->crtc_id == crtc_id: that is the *currently bound*
+         * CRTC, which is 0 until some client performs the first modeset, and
+         * gating on it would make startup depend on another DRM client having
+         * run first. find_crtc_for_connector() handles preferring an active
+         * CRTC when one exists.
+         */
+        if (encoder->possible_crtcs & crtc_mask) {
             return crtc_id;
         }
     }
 
     /* no match found */
+    return -1;
+}
+
+/*
+ * Pick a CRTC able to drive @connector. Iterates the connector's own encoders
+ * and returns the first CRTC permitted by their possible_crtcs bitmask. This
+ * works even before any modeset has been performed on the device.
+ */
+static int32_t
+find_crtc_for_connector(int fd, const drmModeRes *resources, const drmModeConnector *connector)
+{
+    for (int i = 0; i < connector->count_encoders; i++) {
+        drmModeEncoder *encoder = drmModeGetEncoder(fd, connector->encoders[i]);
+        if (!encoder)
+            continue;
+        const int32_t crtc_id = find_crtc_for_encoder(resources, encoder);
+        drmModeFreeEncoder(encoder);
+        if (crtc_id != -1)
+            return crtc_id;
+    }
     return -1;
 }
 
@@ -545,27 +573,34 @@ init_drm(void)
             (long)((drm_data.mode - drm_data.connector.obj->modes) / sizeof(drmModeModeInfo *)), drm_data.mode->name,
             drm_data.mode->vrefresh);
 
-    /* Try the currently connected encoder+crtc */
-    for (int i = 0; i < drm_data.base_resources->count_encoders; ++i) {
-        drm_data.encoder = drmModeGetEncoder(drm_data.fd, drm_data.base_resources->encoders[i]);
-        if (!drm_data.encoder) {
-            /* cannot retrieve encoder, ignoring... */
-            continue;
-        }
+    /*
+     * Choose a CRTC for the connector. Prefer the CRTC bound to its currently
+     * active encoder (if a modeset already happened), otherwise fall back to
+     * any CRTC allowed by the connector's encoders' possible_crtcs. The latter
+     * is what lets cog start on a freshly booted device, before any other DRM
+     * client has driven the pipeline.
+     */
+    int32_t crtc_id = -1;
 
-        const int32_t crtc_id = find_crtc_for_encoder(drm_data.base_resources, drm_data.encoder);
-        if (crtc_id != -1) {
-            drm_data.crtc.obj_id = crtc_id;
-            break;
+    /* 1. Currently active encoder + CRTC, if present. */
+    if (drm_data.connector.obj->encoder_id) {
+        drmModeEncoder *enc = drmModeGetEncoder(drm_data.fd, drm_data.connector.obj->encoder_id);
+        if (enc) {
+            if (enc->crtc_id)
+                crtc_id = enc->crtc_id;
+            drmModeFreeEncoder(enc);
         }
-
-        g_clear_pointer (&drm_data.encoder, drmModeFreeEncoder);
     }
 
-    if (!drm_data.encoder) {
+    /* 2. Fall back to possible_crtcs of the connector's encoders. */
+    if (crtc_id == -1)
+        crtc_id = find_crtc_for_connector(drm_data.fd, drm_data.base_resources, drm_data.connector.obj);
+
+    if (crtc_id == -1) {
         fprintf(stderr, "no crtc for encoder found!\n");
         return FALSE;
     }
+    drm_data.crtc.obj_id = crtc_id;
 
     drm_data.connector.obj_id = drm_data.connector.obj->connector_id;
 


### PR DESCRIPTION
init_drm() located the CRTC for the chosen connector by looking for an encoder whose crtc_id already pointed at a CRTC, i.e. it required that a modeset had already been performed by some other DRM client or fbdev. On a freshly booted device where nothing has driven the pipeline yet, every encoder reports crtc_id == 0, so the search failed with

    no crtc for encoder found!

and cog aborted ("Failed to initialize DRM"). cog could only start once an unrelated client (e.g. a display manager) had performed the first modeset and populated encoder->crtc_id.

Prefer the CRTC bound to the connector's currently active encoder, when there is one (avoids re-routing a CRTC another client drives). Otherwise pick the first CRTC allowed by the possible_crtcs bitmask of any of the connector's encoders (which should work even before the first modeset).

While at that, iterate the connector's own encoder list instead of every encoder in the device.