### PR TITLE
wl: guard wl_output_release with a version check

### DIFF
--- a/platform/wayland/cog-platform-wl.c
+++ b/platform/wayland/cog-platform-wl.c
@@ -974,7 +974,15 @@ registry_on_global_remove(void *data, struct wl_registry *registry, uint32_t nam
     wl_list_for_each_safe(output, tmp_output, &platform->display->outputs, link) {
         if (output->name == name) {
             g_debug("%s: output #%" PRIi32 " @ %p removed.", G_STRFUNC, output->name, output->output);
-            g_clear_pointer(&output->output, wl_output_release);
+            if (output->output) {
+                if (wl_proxy_get_version((struct wl_proxy *) output->output) >= WL_OUTPUT_RELEASE_SINCE_VERSION) {
+                    wl_output_release(output->output);
+                } else {
+                    wl_proxy_destroy((struct wl_proxy *) output->output);
+                }
+                output->output = NULL;
+            }
+
             wl_list_remove(&output->link);
             if (platform->display->current_output == output) {
                 platform->display->current_output =


### PR DESCRIPTION
When a compositor advertises wl_output below v3 calling wl_output_release sends a request
that the server cannot support resulting in fatal protocol error. This kills the entire wl_display connection

registry_on_global_remove() calls this unconditionally

Fix is to check wl_proxy_get_version() against WL_OUTPUT_RELEASE_SINCE_VERSION before calling wl_output_release, falling back to wl_proxy_destroy() when below v3

Setup experienced on is labwc with a wlr-output-power-management to toggle on/off display using an Alexa integration