### PR TITLE
wl: release previous keymap/state in keyboard_on_keymap

### DIFF
--- a/platform/wayland/cog-platform-wl.c
+++ b/platform/wayland/cog-platform-wl.c
@@ -527,15 +527,20 @@ keyboard_on_keymap(void *data, struct wl_keyboard *wl_keyboard, uint32_t format,
         return;
     }
 
-    seat->xkb.keymap = xkb_keymap_new_from_string(seat->xkb.context,
-                                                  (char *) mapping,
-                                                  XKB_KEYMAP_FORMAT_TEXT_V1,
-                                                  XKB_KEYMAP_COMPILE_NO_FLAGS);
+    struct xkb_keymap *new_keymap = xkb_keymap_new_from_string(seat->xkb.context,
+                                                               (char *) mapping,
+                                                               XKB_KEYMAP_FORMAT_TEXT_V1,
+                                                               XKB_KEYMAP_COMPILE_NO_FLAGS);
     munmap(mapping, size);
     close(fd);
 
-    if (seat->xkb.keymap == NULL)
+    if (new_keymap == NULL)
         return;
+
+    g_clear_pointer(&seat->xkb.state, xkb_state_unref);
+    g_clear_pointer(&seat->xkb.keymap, xkb_keymap_unref);
+
+    seat->xkb.keymap = new_keymap;
 
     seat->xkb.state = xkb_state_new(seat->xkb.keymap);
     if (seat->xkb.state == NULL)


### PR DESCRIPTION
## Summary

Fixes the long-standing memory leak reported in #65.

The Wayland compositor may send `wl_keyboard.keymap` more than once during a session (observed repeatedly in practice on some compositors). Each time it did, `keyboard_on_keymap` built a new `xkb_keymap`/`xkb_state` pair and overwrote the previous `seat->xkb.keymap`/`seat->xkb.state` pointers without releasing them first, leaking both objects permanently on every re-send.

## Root cause investigation

Root-caused via `heaptrack` against a real production kiosk session (Raspberry Pi 3B, ~113 keymap re-sends/s from the compositor): 76% of all leaked bytes traced to this call site's `xkb_keymap_new_from_string` allocation and the associated `xkb_state`. Two other theories (a `wl_buffer` caching issue, and `wp_presentation_feedback` protocol objects) were investigated and ruled out with direct instrumentation before landing on this.

## Fix

Release the previous `seat->xkb.state`/`seat->xkb.keymap` via `g_clear_pointer` before installing the newly-received keymap — the same cleanup pattern already used elsewhere in the codebase at teardown, just missing here.

## Validation

- 10-minute `smaps`-based before/after RSS comparison: steady-state growth ≈ 0 after the fix, vs. ~161-170MB/hr unpatched on this device.
- Confirmed via two independent methods: `heaptrack`'s own leak accounting, and direct `/proc/PID/smaps` RSS tracking.
- Deployed to a production kiosk (24/7 Raspberry Pi 3B dashboard) and soak-tested across multiple runs; cumulative clean runtime is now past 100 hours with no recurrence of the leak pattern.

Opened as a draft for initial review — happy to iterate on approach/style before marking ready.

🤖 Generated with [Claude Code](https://claude.com/claude-code), disclosed per the pattern discussed on #65.

https://claude.ai/code/session_015BuSGK8nc5fhP2swoujz3w