### PR TITLE
core: show default values in the generated option help

### DIFF
--- a/core/cog-utils.c
+++ b/core/cog-utils.c
@@ -319,6 +319,70 @@ option_entry_parse_to_property (const char *option,
     return TRUE;
 }
 
+/*
+ * Formats "<blurb> (default: <value>)" for an option's help text.
+ *
+ * GOptionEntry.description is a borrowed const char*, and the entry array is
+ * freed right after being handed to the option group, so the string has to
+ * outlive it. Interning avoids having to track the allocation: the set of
+ * options is fixed and built once at startup.
+ *
+ * Properties whose default carries no information (an unset or empty string)
+ * are left with their plain blurb.
+ */
+static const char *
+option_description_with_default(GParamSpec *prop, GType prop_type)
+{
+    const char   *blurb = g_param_spec_get_blurb(prop);
+    const GValue *def = g_param_spec_get_default_value(prop);
+    if (!def)
+        return blurb;
+
+    g_autofree char *value = NULL;
+    switch (prop_type) {
+    case G_TYPE_BOOLEAN:
+        value = g_strdup(g_value_get_boolean(def) ? "true" : "false");
+        break;
+    case G_TYPE_STRING: {
+        const char *s = g_value_get_string(def);
+        if (!s || !*s)
+            return blurb;
+        value = g_strdup(s);
+        break;
+    }
+    case G_TYPE_DOUBLE:
+        value = g_strdup_printf("%g", g_value_get_double(def));
+        break;
+    case G_TYPE_FLOAT:
+        value = g_strdup_printf("%g", (double) g_value_get_float(def));
+        break;
+    case G_TYPE_INT:
+        value = g_strdup_printf("%d", g_value_get_int(def));
+        break;
+    case G_TYPE_INT64:
+        value = g_strdup_printf("%" G_GINT64_FORMAT, g_value_get_int64(def));
+        break;
+    case G_TYPE_LONG:
+        value = g_strdup_printf("%ld", g_value_get_long(def));
+        break;
+    case G_TYPE_UINT:
+        value = g_strdup_printf("%u", g_value_get_uint(def));
+        break;
+    case G_TYPE_UINT64:
+        value = g_strdup_printf("%" G_GUINT64_FORMAT, g_value_get_uint64(def));
+        break;
+    case G_TYPE_ULONG:
+        value = g_strdup_printf("%lu", g_value_get_ulong(def));
+        break;
+    default:
+        return blurb;
+    }
+
+    g_autofree char *text =
+        blurb ? g_strdup_printf("%s (default: %s)", blurb, value) : g_strdup_printf("(default: %s)", value);
+    return g_intern_string(text);
+}
+
 int
 entry_comparator (const void *p1, const void *p2)
 {
@@ -372,7 +436,7 @@ cog_option_entries_from_class (GObjectClass *klass)
         entry->long_name = g_param_spec_get_name (prop);
         entry->arg = G_OPTION_ARG_CALLBACK;
         entry->arg_data = option_entry_parse_to_property;
-        entry->description = g_param_spec_get_blurb (prop);
+        entry->description = option_description_with_default(prop, prop_type);
         entry->arg_description = type_name;
         if (prop_type == G_TYPE_BOOLEAN && g_str_has_prefix (entry->long_name, "enable-"))
             entry->flags |= G_OPTION_FLAG_OPTIONAL_ARG;


### PR DESCRIPTION
Closes #132.

The options generated from `WebKitSettings` properties only carried the property blurb, so `cog --help` gave no hint about what a setting does when left alone.

Before:

```
  --allow-modal-dialogs=BOOL      Whether it is possible to create modal dialogs
  --auto-load-images=BOOL         Load images automatically.
  --default-charset=STRING        The default text charset used when interpreting content with unspecified charset.
  --default-font-size=UNSIGNED    The default font size used to display text.
  --user-agent=STRING             The user agent string
```

After:

```
  --allow-modal-dialogs=BOOL      Whether it is possible to create modal dialogs (default: false)
  --auto-load-images=BOOL         Load images automatically. (default: true)
  --default-charset=STRING        The default text charset used when interpreting content with unspecified charset. (default: iso-8859-1)
  --default-font-size=UNSIGNED    The default font size used to display text. (default: 16)
  --user-agent=STRING             The user agent string
```

`--user-agent` is deliberately unchanged: its default is unset (WebKit composes it at runtime), and an option whose default carries no information keeps its plain blurb rather than gaining an empty `(default: )`.

### On the ownership question raised in the issue

The issue notes that GLib has no API returning a default value as a `const char*`, and suggests a new `CogOption` type would be needed to own the composed strings.

`g_intern_string()` avoids that. `GOptionEntry.description` is borrowed, and the entry array is freed right after `g_option_group_add_entries()`, so the string only has to outlive the array — which an interned string does, without anything having to track it. The set of options is fixed and built once at startup, so the interning table does not grow over time.

### Details

Each type is formatted explicitly rather than going through `g_strdup_value_contents()`, which renders doubles as `1.000000` and unset strings as `NULL` — neither reads well in `--help`.

### Testing

Built on Debian testing against wpewebkit 2.52.6, before and after the patch: both build clean, with the same warning count (0).

`cog --help-websettings` on the resulting binaries:

- 57 options before, 57 after — nothing gained or lost.
- 52 gained a `(default: ...)` suffix.
- 5 were deliberately left alone: `math-font-family`, `media-content-types-requiring-hardware-support`, `user-agent` and `webrtc-udp-ports-range` have unset or empty string defaults, and `--features` is not generated from a `GParamSpec`.
- No `(default: )`, `(default: NULL)`, `(null)` or doubled suffix anywhere in the output.

`data/check-style` against `origin/master` with clang-format 18.1.8 reports no differences.
